### PR TITLE
fix(plugins): realpath + containment-check onboarding local-path install

### DIFF
--- a/src/commands/onboarding/plugin-install.test.ts
+++ b/src/commands/onboarding/plugin-install.test.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
+import {
+  hasTrustedGitWorkspace,
+  isWithinBaseDirectory,
+  resolveLocalPath,
+} from "./plugin-install.js";
+
+// resolveLocalPath / hasTrustedGitWorkspace hardening (issue #2838): realpath +
+// containment + directory-only gate before an unscanned addPluginLoadPath, and a
+// realpath + `.git` walk-up workspace-trust check (vs the prior bare existsSync).
+
+function entryWithLocalPath(localPath: string | undefined): ChannelPluginCatalogEntry {
+  // resolveLocalPath only reads entry.install.localPath — a minimal shape suffices.
+  return { install: { localPath } } as unknown as ChannelPluginCatalogEntry;
+}
+
+let workspace: string;
+let outside: string;
+
+beforeEach(() => {
+  workspace = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "rc-plugin-ws-")));
+  outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "rc-plugin-out-")));
+});
+
+afterEach(() => {
+  fs.rmSync(workspace, { recursive: true, force: true });
+  fs.rmSync(outside, { recursive: true, force: true });
+});
+
+describe("isWithinBaseDirectory", () => {
+  it("accepts the base itself and descendants", () => {
+    expect(isWithinBaseDirectory("/base", "/base")).toBe(true);
+    expect(isWithinBaseDirectory("/base", "/base/child")).toBe(true);
+    expect(isWithinBaseDirectory("/base", "/base/a/b/c")).toBe(true);
+  });
+
+  it("rejects parents, siblings, and absolute escapes", () => {
+    expect(isWithinBaseDirectory("/base", "/base/..")).toBe(false);
+    expect(isWithinBaseDirectory("/base", "/base/../sibling")).toBe(false);
+    expect(isWithinBaseDirectory("/base", "/elsewhere")).toBe(false);
+    // A base whose name is a prefix of the target must not count as containing it.
+    expect(isWithinBaseDirectory("/base", "/base-evil")).toBe(false);
+  });
+});
+
+describe("resolveLocalPath", () => {
+  it("returns null when local install is not allowed or no localPath is set", () => {
+    fs.mkdirSync(path.join(workspace, "plugin"));
+    expect(resolveLocalPath(entryWithLocalPath("plugin"), workspace, false)).toBeNull();
+    expect(resolveLocalPath(entryWithLocalPath(undefined), workspace, true)).toBeNull();
+    expect(resolveLocalPath(entryWithLocalPath("   "), workspace, true)).toBeNull();
+  });
+
+  it("resolves an in-workspace directory to its realpath", () => {
+    const pluginDir = path.join(workspace, "plugin");
+    fs.mkdirSync(pluginDir);
+    expect(resolveLocalPath(entryWithLocalPath("plugin"), workspace, true)).toBe(
+      fs.realpathSync(pluginDir),
+    );
+  });
+
+  it("rejects a symlink whose target escapes the workspace", () => {
+    // workspace/escape -> outside (a directory outside both workspace and cwd)
+    fs.symlinkSync(outside, path.join(workspace, "escape"), "dir");
+    expect(resolveLocalPath(entryWithLocalPath("escape"), workspace, true)).toBeNull();
+  });
+
+  it("rejects a `..` traversal that escapes the workspace base", () => {
+    // Nest the workspace one level down so `../secret` escapes it but stays on disk.
+    const nested = path.join(workspace, "ws");
+    fs.mkdirSync(nested);
+    fs.mkdirSync(path.join(workspace, "secret"));
+    expect(resolveLocalPath(entryWithLocalPath("../secret"), nested, true)).toBeNull();
+  });
+
+  it("rejects an absolute path outside the trusted bases", () => {
+    expect(resolveLocalPath(entryWithLocalPath(outside), workspace, true)).toBeNull();
+  });
+
+  it("rejects a file-valued localPath (directories only)", () => {
+    fs.writeFileSync(path.join(workspace, "afile"), "x");
+    expect(resolveLocalPath(entryWithLocalPath("afile"), workspace, true)).toBeNull();
+  });
+
+  it("returns null for a non-existent path (drives the npm fallback)", () => {
+    expect(resolveLocalPath(entryWithLocalPath("does-not-exist"), workspace, true)).toBeNull();
+  });
+});
+
+describe("hasTrustedGitWorkspace", () => {
+  it("trusts a directory containing a .git directory", () => {
+    fs.mkdirSync(path.join(workspace, ".git"));
+    expect(hasTrustedGitWorkspace(workspace)).toBe(true);
+  });
+
+  it("trusts a descendant of a git workspace (walk-up)", () => {
+    fs.mkdirSync(path.join(workspace, ".git"));
+    const child = path.join(workspace, "a", "b");
+    fs.mkdirSync(child, { recursive: true });
+    expect(hasTrustedGitWorkspace(child)).toBe(true);
+  });
+
+  it("trusts a worktree/submodule .git gitdir-pointer file", () => {
+    const gitDir = path.join(workspace, "realgit");
+    fs.mkdirSync(gitDir);
+    const wt = path.join(workspace, "wt");
+    fs.mkdirSync(wt);
+    fs.writeFileSync(path.join(wt, ".git"), `gitdir: ${gitDir}\n`);
+    expect(hasTrustedGitWorkspace(wt)).toBe(true);
+  });
+
+  it("does not trust a directory with no .git in its ancestry", () => {
+    // A fresh tmp dir under os.tmpdir() has no .git up to the filesystem root.
+    expect(hasTrustedGitWorkspace(workspace)).toBe(false);
+  });
+
+  it("does not trust a non-existent path", () => {
+    expect(hasTrustedGitWorkspace(path.join(workspace, "nope"))).toBe(false);
+  });
+});

--- a/src/commands/onboarding/plugin-install.ts
+++ b/src/commands/onboarding/plugin-install.ts
@@ -25,21 +25,71 @@ type InstallResult = {
   installed: boolean;
 };
 
-function hasGitWorkspace(workspaceDir?: string): boolean {
-  const candidates = new Set<string>();
-  candidates.add(path.join(process.cwd(), ".git"));
-  if (workspaceDir && workspaceDir !== process.cwd()) {
-    candidates.add(path.join(workspaceDir, ".git"));
+function resolveRealDirectory(dir: string): string | null {
+  try {
+    const resolved = fs.realpathSync(dir);
+    return fs.statSync(resolved).isDirectory() ? resolved : null;
+  } catch {
+    return null;
   }
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return true;
-    }
-  }
-  return false;
 }
 
-function resolveLocalPath(
+function resolveGitDirectoryMarker(dir: string): string | null {
+  const marker = path.join(dir, ".git");
+  try {
+    const stat = fs.statSync(marker);
+    if (stat.isDirectory()) {
+      return resolveRealDirectory(marker);
+    }
+    if (!stat.isFile()) {
+      return null;
+    }
+    // A `.git` FILE is a gitdir pointer (worktrees, submodules): `gitdir: <path>`.
+    const content = fs.readFileSync(marker, "utf8").trim();
+    const gitDir = /^gitdir:\s*(.+)$/i.exec(content)?.[1]?.trim();
+    if (!gitDir) {
+      return null;
+    }
+    return resolveRealDirectory(path.isAbsolute(gitDir) ? gitDir : path.resolve(dir, gitDir));
+  } catch {
+    return null;
+  }
+}
+
+// Exported for unit testing of the load-path containment hardening (issue #2838).
+export function isWithinBaseDirectory(baseDir: string, targetPath: string): boolean {
+  const relative = path.relative(baseDir, targetPath);
+  return (
+    relative === "" ||
+    (!path.isAbsolute(relative) && !relative.startsWith(`..${path.sep}`) && relative !== "..")
+  );
+}
+
+export function hasTrustedGitWorkspace(root: string): boolean {
+  const realRoot = resolveRealDirectory(root);
+  if (!realRoot) {
+    return false;
+  }
+  for (let dir = realRoot; ; dir = path.dirname(dir)) {
+    if (resolveGitDirectoryMarker(dir)) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return false;
+    }
+  }
+}
+
+function hasGitWorkspace(workspaceDir?: string): boolean {
+  const roots = [process.cwd()];
+  if (workspaceDir && workspaceDir !== process.cwd()) {
+    roots.push(workspaceDir);
+  }
+  return roots.some((root) => hasTrustedGitWorkspace(root));
+}
+
+export function resolveLocalPath(
   entry: ChannelPluginCatalogEntry,
   workspaceDir: string | undefined,
   allowLocal: boolean,
@@ -51,14 +101,37 @@ function resolveLocalPath(
   if (!raw) {
     return null;
   }
-  const candidates = new Set<string>();
-  candidates.add(path.resolve(process.cwd(), raw));
+  const bases = [process.cwd()];
   if (workspaceDir && workspaceDir !== process.cwd()) {
-    candidates.add(path.resolve(workspaceDir, raw));
+    bases.push(workspaceDir);
+  }
+  const candidates = new Set<string>();
+  for (const base of bases) {
+    const realBase = resolveRealDirectory(base);
+    if (realBase) {
+      candidates.add(path.resolve(realBase, raw));
+    }
   }
   for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
+    try {
+      // Realpath BEFORE the containment check so a symlink cannot point the
+      // resolved target outside a trusted base. Reject anything that escapes
+      // (symlink / `..` / absolute) or is not a directory.
+      const resolved = fs.realpathSync(candidate);
+      const withinTrustedBase = bases.some((base) => {
+        const realBase = resolveRealDirectory(base);
+        return realBase ? isWithinBaseDirectory(realBase, resolved) : false;
+      });
+      if (!withinTrustedBase) {
+        continue;
+      }
+      if (fs.statSync(resolved).isDirectory()) {
+        return resolved;
+      }
+    } catch {
+      // Missing / unreadable / broken-symlink candidate — fall through to the
+      // next candidate, then to null (which drives the npm-install fallback).
+      continue;
     }
   }
   return null;
@@ -85,16 +158,23 @@ function resolveLocalPath(
  *     (that override is CLI-only), so there would be no supported way to
  *     proceed.
  *
- * Known residual: a catalog `localPath` is relative and resolved against the
- * process CWD (`resolveLocalPath`), so a checkout whose CWD holds an
- * attacker-controlled file at the catalog-relative location could be
- * registered unscanned. Accepted for now given the git-workspace + existence
- * gating above.
+ * Residual after hardening: `resolveLocalPath` now realpaths each candidate,
+ * requires the resolved target to stay within a trusted base directory
+ * (realpath'd CWD or agent workspace, via `isWithinBaseDirectory`), and gates
+ * to directories only — closing the symlink / `..` / absolute-path escape and
+ * the file-vs-directory sub-vectors. `hasGitWorkspace` likewise realpaths and
+ * walks up for a `.git` marker (directory or gitdir-pointer file) rather than a
+ * bare existence check. What remains is narrow: an attacker who can already
+ * write a directory at the exact catalog-relative location INSIDE the trusted
+ * workspace could still have it registered unscanned — but that presupposes
+ * write access to the victim's checkout, itself a serious local compromise and
+ * the same already-compromised precondition under which this first-party
+ * local-source exception is accepted.
  *
  * REVISIT this exception if either changes: (a) the wizard gains a UI to set
  * the force-unsafe override, or (b) `trustedSourceLinkedOfficialInstall`
  * (already plumbed in cli/plugin-install-plan.ts) is consumed to scan-and-warn
- * for catalog-verified sources. See issue #2834.
+ * for catalog-verified sources.
  */
 function addPluginLoadPath(cfg: RemoteClawConfig, pluginPath: string): RemoteClawConfig {
   const existing = cfg.plugins?.load?.paths ?? [];


### PR DESCRIPTION
## Summary

The onboarding wizard's local-path plugin install registers a catalog-relative directory as a plugin load path via `addPluginLoadPath` **without running the dangerous-code scanner** that the npm / archive install flows enforce. Previously `resolveLocalPath` resolved the path with bare `path.resolve` + `fs.existsSync` — no symlink / `..` / absolute-escape defense and no file-vs-directory gate — and `hasGitWorkspace` used a bare `fs.existsSync(cwd/.git)` check.

This hardens both:

- **`resolveLocalPath`** — realpath each candidate, require the resolved target to stay within a trusted base directory (realpath'd CWD or agent workspace, via `isWithinBaseDirectory`), and gate to directories only. Closes the symlink / `..` / absolute-path escape and the file-vs-directory sub-vectors.
- **`hasGitWorkspace`** — realpath + walk up for a `.git` marker (directory, or a gitdir-pointer file for worktrees/submodules) rather than a bare existence check.

## Why

Plugins load in-process with full host capability, so an unscanned load-path install is a sensitive surface. The local source is first-party (channel catalog / bundled) and the install is operator-driven, so this is defense-in-depth hardening of an already-reviewed unscanned exception — not a live install-gate bypass.

## Preserved behavior

- The bundled-source short-circuit (`bundledLocalPath ?? resolveLocalPath(...)`) is intact — bundled paths bypass containment by design.
- An unresolvable / out-of-base path returns `null`, driving the existing npm-install fallback, so the normal first-party in-workspace install is unaffected.

## Tests

Adds `src/commands/onboarding/plugin-install.test.ts` (14 cases): the containment predicate, the symlink / `..` / absolute escape rejections, the directory-only gate, and the git-workspace trust check (`.git` directory, gitdir-pointer file, walk-up, none).

Closes #2838

🤖 Generated with [Claude Code](https://claude.com/claude-code)
