### PR TITLE
Reject local-interface addresses as trusted-proxy sources (fail-closed on interface-enum failure)

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import {
   assertGatewayAuthConfigured,
@@ -567,6 +569,26 @@ describe("gateway auth", () => {
 });
 
 describe("trusted-proxy auth", () => {
+  function mockLocalInterfaces(nonLoopbackAddress = "10.0.0.2", family: "IPv4" | "IPv6" = "IPv4") {
+    const spy = vi.isMockFunction(os.networkInterfaces)
+      ? vi.mocked(os.networkInterfaces)
+      : vi.spyOn(os, "networkInterfaces");
+    spy.mockReturnValue(
+      makeNetworkInterfacesSnapshot({
+        lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+        eth0: [{ address: nonLoopbackAddress, family }],
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    mockLocalInterfaces();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   type GatewayConnectInput = Parameters<typeof authorizeGatewayConnect>[0];
   const trustedProxyConfig = {
     userHeader: "x-forwarded-user",
@@ -609,6 +631,75 @@ describe("trusted-proxy auth", () => {
     expect(res.ok).toBe(true);
     expect(res.method).toBe("trusted-proxy");
     expect(res.user).toBe("nick@example.com");
+  });
+
+  it("rejects trusted-proxy headers from the host non-loopback interface address", async () => {
+    mockLocalInterfaces("10.0.0.1");
+
+    const res = await authorizeTrustedProxy({
+      trustedProxies: ["10.0.0.1"],
+      remoteAddress: "10.0.0.1",
+      headers: {
+        "x-forwarded-user": "nick@example.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_local_interface_source");
+  });
+
+  it("fails closed (before header validation) when host interface discovery fails", async () => {
+    vi.mocked(os.networkInterfaces).mockImplementation(() => {
+      throw new Error("interface discovery failed");
+    });
+
+    const res = await authorizeTrustedProxy({
+      trustedProxies: ["10.0.0.1"],
+      remoteAddress: "10.0.0.1",
+      // The required "x-forwarded-proto" header is intentionally omitted: if the
+      // flow reached header validation it would report a missing-header reason,
+      // so asserting the fail-closed reason proves the header path was not reached.
+      headers: {
+        "x-forwarded-user": "nick@example.com",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_local_interface_check_failed");
+  });
+
+  it("accepts a genuine non-local trusted proxy that is not a host interface", async () => {
+    mockLocalInterfaces("10.0.0.2");
+
+    const res = await authorizeTrustedProxy({
+      trustedProxies: ["10.0.0.1"],
+      remoteAddress: "10.0.0.1",
+      headers: {
+        "x-forwarded-user": "nick@example.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("trusted-proxy");
+    expect(res.user).toBe("nick@example.com");
+  });
+
+  it("rejects trusted-proxy headers from a host IPv6 interface address", async () => {
+    mockLocalInterfaces("fd7a:115c:a1e0::1234", "IPv6");
+
+    const res = await authorizeTrustedProxy({
+      trustedProxies: ["fd7a:115c:a1e0::1234"],
+      remoteAddress: "fd7a:115c:a1e0::1234",
+      headers: {
+        "x-forwarded-user": "nick@example.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_local_interface_source");
   });
 
   it("rejects trusted-proxy HTTP requests from origins outside the allowlist", async () => {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -14,6 +14,7 @@ import {
 import { type ResolvedGatewayAuth } from "./auth-resolve.js";
 import {
   isLoopbackAddress,
+  resolveLocalInterfaceAddressMatch,
   resolveRequestClientIp,
   isTrustedProxyAddress,
   resolveClientIp,
@@ -277,6 +278,17 @@ function authorizeTrustedProxy(params: {
   }
   if (isLoopbackAddress(remoteAddr)) {
     return { reason: "trusted_proxy_loopback_source" };
+  }
+  // Loopback sources are already rejected above, so the remote address is
+  // non-loopback here. Reject other host-interface addresses too, and fail
+  // closed when the host interfaces cannot be enumerated, so the host itself
+  // cannot impersonate an upstream proxy.
+  const localInterfaceMatch = resolveLocalInterfaceAddressMatch(remoteAddr);
+  if (localInterfaceMatch === undefined) {
+    return { reason: "trusted_proxy_local_interface_check_failed" };
+  }
+  if (localInterfaceMatch) {
+    return { reason: "trusted_proxy_local_interface_source" };
   }
 
   const requiredHeaders = trustedProxyConfig.requiredHeaders ?? [];

--- a/src/test-helpers/network-interfaces.ts
+++ b/src/test-helpers/network-interfaces.ts
@@ -1,0 +1,45 @@
+import os from "node:os";
+import type { NetworkInterfacesSnapshot } from "../infra/network-interfaces.js";
+
+type NetworkInterfaceEntry = NonNullable<ReturnType<typeof os.networkInterfaces>[string]>[number];
+
+type NetworkInterfaceEntryInput = {
+  address: string;
+  family: "IPv4" | "IPv6";
+  internal?: boolean;
+  netmask?: string;
+};
+
+function makeNetworkInterfaceEntry(input: NetworkInterfaceEntryInput): NetworkInterfaceEntry {
+  if (input.family === "IPv6") {
+    return {
+      address: input.address,
+      family: "IPv6",
+      internal: input.internal ?? false,
+      netmask: input.netmask ?? "",
+      cidr: null,
+      mac: "",
+      scopeid: 0,
+    };
+  }
+
+  return {
+    address: input.address,
+    family: "IPv4",
+    internal: input.internal ?? false,
+    netmask: input.netmask ?? "",
+    cidr: null,
+    mac: "",
+  };
+}
+
+export function makeNetworkInterfacesSnapshot(
+  snapshot: Record<string, NetworkInterfaceEntryInput[]>,
+): NetworkInterfacesSnapshot {
+  return Object.fromEntries(
+    Object.entries(snapshot).map(([name, entries]) => [
+      name,
+      entries.map((entry) => makeNetworkInterfaceEntry(entry)),
+    ]),
+  );
+}


### PR DESCRIPTION
## What

`authorizeTrustedProxy()` in `src/gateway/auth.ts` validates that a request's remote address is an allow-listed trusted proxy and rejects loopback sources, but it did **not** reject other **local-interface** addresses, and it did not fail closed when the host's network interfaces could not be enumerated.

As a result, a request whose source IP is one of the host's own non-loopback interface addresses could pass trusted-proxy authorization when that address was present in the configured `trustedProxies` allow-list — i.e., the host itself could impersonate an upstream proxy and supply proxy-trusted headers. This is a defense-in-depth hardening (it requires a local-interface address to be configured as a trusted proxy), not a remote unauthenticated bypass.

## Change

After the existing (unconditional) loopback rejection — the source is guaranteed non-loopback at that point — resolve the local-interface match via the existing `resolveLocalInterfaceAddressMatch()` helper in `src/gateway/net.ts`:

- `undefined` (interface enumeration failed) → reject, **fail closed** (`trusted_proxy_local_interface_check_failed`)
- `true` (address is a host interface) → reject (`trusted_proxy_local_interface_source`)
- `false` → continue to the existing required-header validation

The fork's unconditional loopback rejection is preserved (no `allowLoopback` option is introduced). Because loopback returns early, the local-interface branch runs only for non-loopback sources — so upstream's `if (!remoteIsLoopback)` guard is intentionally omitted here as it would be dead code.

This mirrors upstream OpenClaw commit `26c7da2d02e` ("Harden trusted-proxy source validation", openclaw/openclaw#81290). The `net.ts` helper already existed; only the `auth.ts` consumer wiring and tests were missing.

## Tests

`src/gateway/auth.test.ts` gains cases for the new branch, using a new `src/test-helpers/network-interfaces.ts` helper to mock host-interface enumeration deterministically (so the suite does not depend on the CI host's real interfaces):

- a non-loopback host-interface source is rejected with `trusted_proxy_local_interface_source`
- interface-enumeration failure fails closed with `trusted_proxy_local_interface_check_failed` and does **not** reach the required-header path
- a genuine non-local, non-loopback trusted proxy still passes
- an IPv6 host-interface source is rejected

Gateway test lane: `68 passed (68)`.

Closes #2842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
