### PR TITLE
Redact credential-bearing URLs in gateway client error logs

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -539,6 +539,7 @@ describe("GatewayClient connect auth payload", () => {
     ws: MockWebSocket,
     connectId: string | undefined,
     details: Record<string, unknown>,
+    message = "unauthorized",
   ) {
     ws.emitMessage(
       JSON.stringify({
@@ -547,7 +548,7 @@ describe("GatewayClient connect auth payload", () => {
         ok: false,
         error: {
           code: "INVALID_REQUEST",
-          message: "unauthorized",
+          message,
           details,
         },
       }),
@@ -583,6 +584,56 @@ describe("GatewayClient connect auth payload", () => {
       vi.useRealTimers();
     }
   }
+
+  it("redacts credential-bearing URLs in connect failure logs", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitConnectFailure(
+      ws,
+      connect.id,
+      { code: "AUTH_UNAUTHORIZED" },
+      "wss://user:pass@gateway.example/ws?token=secret-token failed", // pragma: allowlist secret
+    );
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+    });
+    const logged = String(logErrorMock.mock.calls.at(-1)?.[0] ?? "");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("secret-token");
+    expect(logged).toContain("//***:***@");
+    expect(logged).toContain("token=***");
+    expect(logged).toContain("failed");
+    client.stop();
+  });
+
+  it("preserves trailing diagnostics after redacted connect failure URL query params", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitConnectFailure(
+      ws,
+      connect.id,
+      { code: "AUTH_UNAUTHORIZED" },
+      "wss://gateway.example/ws?token=secret-token failed with 401 from remote gateway", // pragma: allowlist secret
+    );
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+    });
+    const logged = String(logErrorMock.mock.calls.at(-1)?.[0] ?? "");
+    expect(logged).toContain("wss://gateway.example/ws?token=*** failed with 401");
+    expect(logged).toContain("from remote gateway");
+    expect(logged).not.toContain("secret-token");
+    client.stop();
+  });
 
   it("uses explicit shared token and does not inject stored device token", () => {
     loadDeviceAuthTokenMock.mockReturnValue({ token: "stored-device-token" });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -144,6 +144,46 @@ export function describeGatewayCloseCode(code: number): string | undefined {
   return GATEWAY_CLOSE_CODE_HINTS[code];
 }
 
+// Query-parameter names whose values may carry credentials in a gateway URL.
+// Mirrors the sensitive-parameter set upstream redacts via
+// `isSensitiveUrlQueryParamName` (src/shared/net/redact-sensitive-url.ts), which
+// this fork does not vendor; the set is inlined here to keep the client
+// self-contained.
+const SENSITIVE_URL_QUERY_PARAMS = new Set([
+  "token",
+  "apikey",
+  "api_key",
+  "password",
+  "passwd",
+  "secret",
+  "auth",
+  "authorization",
+  "access_token",
+  "refresh_token",
+  "key",
+  "sig",
+  "signature",
+  "session",
+  "sessionid",
+  // Upstream (50508b1d0c8) also redacts these two; kept for parity.
+  "pass",
+  "client_secret",
+]);
+
+// Redacts credential-bearing gateway URLs from a diagnostic string before it is
+// logged: strips `//user:pass@` userinfo and masks the values of sensitive query
+// parameters, while leaving the surrounding diagnostic text intact. Mirrors
+// upstream's `formatGatewayClientErrorForLog` (commit 50508b1d0c8); this fork
+// vendors neither `redactToolPayloadText` nor `isSensitiveUrlQueryParamName`, so
+// the URL redaction is inlined and the general log-redaction layer is omitted.
+function formatGatewayClientErrorForLog(err: unknown): string {
+  return String(err)
+    .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
+    .replace(/([?&])([^=&\s]+)=([^&#\s"'<>)]*)/g, (match, prefix: string, key: string) =>
+      SENSITIVE_URL_QUERY_PARAMS.has(key.toLowerCase()) ? `${prefix}${key}=***` : match,
+    );
+}
+
 const FORCE_STOP_TERMINATE_GRACE_MS = 250;
 const STOP_AND_WAIT_TIMEOUT_MS = 1_000;
 
@@ -306,7 +346,7 @@ export class GatewayClient {
       this.opts.onClose?.(code, reasonText);
     });
     ws.on("error", (err) => {
-      logDebug(`gateway client error: ${String(err)}`);
+      logDebug(`gateway client error: ${formatGatewayClientErrorForLog(err)}`);
       if (!this.connectSent) {
         this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
       }
@@ -533,7 +573,7 @@ export class GatewayClient {
           this.backoffMs = Math.min(this.backoffMs, 250);
         }
         this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
-        const msg = `gateway connect failed: ${String(err)}`;
+        const msg = `gateway connect failed: ${formatGatewayClientErrorForLog(err)}`;
         if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE) {
           logDebug(msg);
         } else {
@@ -747,7 +787,7 @@ export class GatewayClient {
         }
       }
     } catch (err) {
-      logDebug(`gateway client parse error: ${String(err)}`);
+      logDebug(`gateway client parse error: ${formatGatewayClientErrorForLog(err)}`);
     }
   }
 


### PR DESCRIPTION
## Summary

The gateway client logged raw `String(err)` in three diagnostic paths — the WebSocket `error` handler, the connect-failure handler, and the message parse-error handler. When an error string embeds the gateway target URL, that URL can carry credentials (`//user:pass@host` userinfo or sensitive query parameters such as `?token=…`), which then leak into debug/error logs.

This PR redacts credential-bearing URLs from those diagnostic log lines while leaving programmatic error handling untouched.

## Changes

- Add a self-contained `formatGatewayClientErrorForLog(err)` helper in `src/gateway/client.ts` that:
  - replaces `//user:pass@` userinfo with `//***:***@`, and
  - masks the values of sensitive URL query parameters (e.g. `?token=secret` → `?token=***`), while preserving the surrounding diagnostic text.
- Route the three diagnostic log sites through the helper:
  - `gateway client error: …` (WebSocket `error` handler)
  - `gateway connect failed: …` (connect-failure handler)
  - `gateway client parse error: …` (message parse-error handler)
- The programmatic `onConnectError` callback continues to receive the raw, unredacted error object — only the logged strings are redacted.
- Add two tests in `src/gateway/client.test.ts` asserting a credential-bearing target URL is masked in the emitted log line for both `//user:pass@` userinfo and a `?token=` query parameter, and that trailing diagnostic text is preserved.

The device-auth-token-clearing error log (`failed clearing stale device-auth token …`) is intentionally left as-is: that error originates from the local device-auth store, not a gateway connection, so it cannot carry a credential-bearing URL.

## Upstream

Mirrors upstream OpenClaw commit `50508b1d0c8` ("fix(gateway): redact credential-bearing diagnostics"). This fork does not vendor upstream's `redactToolPayloadText` / `isSensitiveUrlQueryParamName` helpers, so the URL redaction is inlined; the sensitive-parameter set is the union of the fork's and upstream's lists.

## Verification

- `vitest run --config vitest.gateway.config.ts src/gateway/client.test.ts` → **25 passed (25)**, including the two new redaction tests
- `pnpm tsgo` → 0 errors
- `oxlint --type-aware src/gateway/client.ts src/gateway/client.test.ts` → 0 warnings, 0 errors
- `oxfmt --check` → clean

Closes #2844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
