### PR TITLE
chore: bump upstream version indicators to v2026.5.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/remoteclaw"><img src="https://img.shields.io/npm/v/remoteclaw?style=for-the-badge" alt="npm version"></a>
   <a href="https://github.com/remoteclaw/remoteclaw/releases"><img src="https://img.shields.io/github/v/release/remoteclaw/remoteclaw?include_prereleases&display_name=release&style=for-the-badge&label=GITHUB" alt="GitHub release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg?style=for-the-badge" alt="AGPL-3.0-only License"></a>
-  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.5.12"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.5.12-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.5.12"></a>
+  <a href="https://github.com/openclaw/openclaw/releases/tag/v2026.5.18"><img src="https://img.shields.io/badge/upstream-OpenClaw_v2026.5.18-teal?style=for-the-badge" alt="Upstream: OpenClaw v2026.5.18"></a>
 </p>
 
 **RemoteClaw** is AI agent middleware. It connects agent CLIs you already run — Claude Code, Gemini CLI, Codex, OpenCode — to the messaging channels you already use, so you can reach your agents from anywhere: your phone, your team Slack, your WhatsApp, anywhere.

--- a/package.json
+++ b/package.json
@@ -474,5 +474,5 @@
     ]
   },
   "upstreamRepo": "remoteclaw/remoteclaw",
-  "upstreamVersion": "2026.5.12"
+  "upstreamVersion": "2026.5.18"
 }


### PR DESCRIPTION
Bumps the fork's upstream-version indicators to reflect the completed content-only DIFF-SYNC to OpenClaw v2026.5.18:

- `package.json` `upstreamVersion`: `2026.5.12` → `2026.5.18`
- README upstream badge: `v2026.5.12` → `v2026.5.18`

Cosmetic metadata only — no code or behavior change. Follows the established per-sync version-indicator bump pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)