### PR TITLE
fix(logging): redact the file-log write path so logs.tail can't leak secrets (#2848)

### DIFF
--- a/src/logging/logger-redaction.test.ts
+++ b/src/logging/logger-redaction.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getChildLogger, resetLogger, setLoggerOverride } from "./logger.js";
+import { createSubsystemLogger } from "./subsystem.js";
+
+// Regression coverage for issue #2848 (redaction-coverage audit): the file log
+// sink is served to remote operator clients via the gateway `logs.tail` method
+// and the CLI `logs` command, and neither redacts on read. Redaction therefore
+// has to happen at write time in the tslog file transport (`buildLogger`), which
+// is the single choke point every file feeder funnels through. Before the fix
+// these paths wrote raw secrets to the log file.
+
+function tmpLogPath(name: string): string {
+  return path.join(
+    os.tmpdir(),
+    `remoteclaw-redact-${name}-${process.pid}-${process.hrtime.bigint()}.log`,
+  );
+}
+
+function readLog(file: string): string {
+  return fs.existsSync(file) ? fs.readFileSync(file, "utf-8") : "";
+}
+
+describe("file log write-path redaction", () => {
+  afterEach(() => {
+    setLoggerOverride(null);
+    resetLogger();
+  });
+
+  it("redacts secrets written through the subsystem logger", () => {
+    const file = tmpLogPath("subsystem");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    createSubsystemLogger("gateway/client").error(
+      "connect failed token=supersecretvalue1234567890 sk-abcdefghijklmnop123456",
+    );
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("supersecretvalue1234567890");
+    expect(content).not.toContain("sk-abcdefghijklmnop123456");
+    // The surrounding diagnostic text is preserved so logs stay useful.
+    expect(content).toContain("connect failed");
+    fs.rmSync(file, { force: true });
+  });
+
+  it("redacts secrets written through a direct getChildLogger caller", () => {
+    // Direct getLogger()/getChildLogger() callers (cron, plugins, bonjour, …)
+    // bypass the subsystem console-redaction and the console.* capture layer, so
+    // only the transport-level redaction protects them.
+    const file = tmpLogPath("child");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    getChildLogger({ subsystem: "cron-delivery" }).info(
+      "delivering webhook ?access_token=leakedtokenvalue0987654321 done",
+    );
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("leakedtokenvalue0987654321");
+    expect(content).toContain("delivering webhook");
+    fs.rmSync(file, { force: true });
+  });
+
+  it("redacts a credential that begins the log message", () => {
+    // A credential at the very start of a value would sit right after the JSON
+    // string-open quote once serialized, which the redactor treats as a non-word
+    // boundary — so the transport redacts each raw positional string first, in
+    // raw text, matching what the console sink does with the raw message.
+    const file = tmpLogPath("valuestart");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    createSubsystemLogger("gateway/client").error("token=hunter2secretpassword1234567 rejected");
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("hunter2secretpassword1234567");
+    expect(content).toContain("rejected");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
+
+  it("redacts a credential inside a nested object argument", () => {
+    // Object args reach the transport as nested objects; redaction recurses into
+    // their string leaves rather than relying on a post-serialization pass that
+    // the JSON quote would defeat.
+    const file = tmpLogPath("nested");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    createSubsystemLogger("gateway").error("auth failed", {
+      detail: "token=hunter2secretpassword1234567",
+    });
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("hunter2secretpassword1234567");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
+
+  it("keeps the record valid JSON when a secret ends a nested value", () => {
+    // Regression guard: redacting the *serialized* record would let a raw-text
+    // value class run past the value's closing quote and swallow adjacent JSON
+    // structure, corrupting the line. Redacting the raw leaf avoids that.
+    const file = tmpLogPath("nested-end");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    createSubsystemLogger("gateway").error("connect failed", {
+      detail: "retry token=SECRETVALUE1234567890",
+    });
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("SECRETVALUE1234567890");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      const parsed = JSON.parse(rawLine) as Record<string, unknown>;
+      // The adjacent message field must survive intact (no structure bleed).
+      expect(JSON.stringify(parsed)).toContain("connect failed");
+    }
+    fs.rmSync(file, { force: true });
+  });
+
+  it("redacts a credential inside a logged Error's message", () => {
+    // `logger.error("…", err)` is the most common shape that carries a secret
+    // (e.g. "auth failed" + an error whose message embeds the rejected token).
+    // tslog expands the Error into a plain { message, stack, … } object, so the
+    // recursive leaf redaction reaches the message string.
+    const file = tmpLogPath("error");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    getChildLogger({ subsystem: "gateway" }).error(
+      "request rejected",
+      new Error("upstream said token=ERRSECRETvalue1234567890 is invalid"),
+    );
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("ERRSECRETvalue1234567890");
+    // The line is still written (not dropped) and stays parseable.
+    expect(content).toContain("request rejected");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
+
+  it("redacts a secret bound into a child logger's context (_meta.name)", () => {
+    // getChildLogger(bindings) stores the bindings as the child logger's name,
+    // which tslog surfaces as `_meta.name`. A plugin binding request-scoped
+    // context could embed a credential there, so the transport redacts `_meta`'s
+    // caller-derived fields (name / parentNames) too — not just positional args.
+    const file = tmpLogPath("meta");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    getChildLogger({
+      subsystem: "webhook",
+      url: "https://hook.example/cb?access_token=METASECRETvalue1234567890",
+    }).info("dispatching");
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("METASECRETvalue1234567890");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
+
+  it("preserves non-secret content and keeps the record valid JSON", () => {
+    const file = tmpLogPath("json");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    createSubsystemLogger("startup").info("service ready on port 8080");
+
+    const content = readLog(file).trim();
+    expect(content).toContain("service ready on port 8080");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -12,6 +12,7 @@ import type { ConsoleStyle } from "./console.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
+import { redactSensitiveText } from "./redact.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
 
@@ -159,6 +160,59 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
   return levelToMinLevel(level) >= levelToMinLevel(settings.level);
 }
 
+// Redact every string leaf of a caller-provided log argument in raw text, so a
+// credential is masked in the same form the console sink sees it — before JSON
+// serialization can wrap it in quotes or split it across structure. Objects and
+// arrays recurse (a fresh copy is built; the input is never mutated, so sibling
+// transports see the original); non-strings (numbers, booleans, Date) pass
+// through. See the file transport in `buildLogger` for why redaction must run
+// here, pre-serialization, rather than over the serialized JSON string.
+//
+// Known limitation: a value that materializes its string only at serialization
+// time via an own-enumerable `toJSON()` returning a secret-bearing string is not
+// reached (the recursion sees the object's fields, not the string JSON.stringify
+// later emits). This is non-regressive — the previous serialized-string pass had
+// the same blind spot — and no in-tree caller logs such a shape.
+function redactLogArgLeaves(value: unknown): unknown {
+  if (typeof value === "string") {
+    return redactSensitiveText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(redactLogArgLeaves);
+  }
+  if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = redactLogArgLeaves(nested);
+    }
+    return out;
+  }
+  return value;
+}
+
+// tslog's `_meta` is framework-generated — runtime info, timestamp, source path,
+// log level — and carries no caller secrets, WITH two exceptions: `name` and
+// `parentNames` echo the label/bindings passed to getChildLogger(), which are
+// caller-controlled (a plugin could bind request-scoped context that embeds a
+// credential). Redact just those two fields and pass the rest of `_meta` through
+// untouched, so the hot path skips recursing the (secret-free) source-path graph.
+function redactLogMeta(meta: unknown): unknown {
+  if (meta === null || typeof meta !== "object") {
+    return meta;
+  }
+  const source = meta as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...source };
+  if (typeof source.name === "string") {
+    out.name = redactSensitiveText(source.name);
+  }
+  if (Array.isArray(source.parentNames)) {
+    out.parentNames = source.parentNames.map((entry) =>
+      typeof entry === "string" ? redactSensitiveText(entry) : entry,
+    );
+  }
+  return out;
+}
+
 function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   const logger = new TsLogger<LogObj>({
     name: "remoteclaw",
@@ -185,7 +239,33 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   logger.attachTransport((logObj: LogObj) => {
     try {
       const time = formatTimestamp(logObj.date ?? new Date(), { style: "long" });
-      const line = JSON.stringify({ ...logObj, time });
+      // Redact at write ("redact-at-source"). This file sink is served to remote
+      // operator clients via the gateway `logs.tail` method and the CLI `logs`
+      // command, neither of which redacts on read; the console sinks redact
+      // separately. This transport is the sole writer and the single choke point
+      // for every file feeder — subsystem file logging, the patched console.*
+      // capture, and direct getLogger()/getChildLogger() callers — so it scrubs
+      // the record here, which also hardens the on-disk file against direct
+      // filesystem access.
+      //
+      // Redaction runs over each string LEAF of the caller-provided arguments,
+      // in raw text, BEFORE serialization — never over the serialized JSON.
+      // Regex-redacting serialized JSON is unsafe: a raw-text value class such as
+      // `token=[^\s&#]+` runs past a value's closing quote and eats adjacent
+      // structure (corrupting the line), and a credential beginning a value sits
+      // after a `"` the redactor treats as a non-word boundary (and leaks).
+      // Redacting raw leaves — where a value ends at the string's own boundary —
+      // avoids both and keeps the record valid JSON once re-serialized. tslog's
+      // own `_meta` is mostly framework-generated (runtime info, source path);
+      // its two caller-derived fields (child-logger name/parentNames) are redacted
+      // by `redactLogMeta` while the rest is passed through to keep this hot path
+      // cheap.
+      const record: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(logObj)) {
+        record[key] = key === "_meta" ? redactLogMeta(value) : redactLogArgLeaves(value);
+      }
+      record.time = time;
+      const line = JSON.stringify(record);
       const payload = `${line}\n`;
       const payloadBytes = Buffer.byteLength(payload, "utf8");
       const nextBytes = currentFileBytes + payloadBytes;


### PR DESCRIPTION
## What & why

Redaction-coverage audit of every log-**write** path (issue #2848). The audit found one real gap, and it contradicts a premise in the issue.

**Issue premise:** "Read paths (log tail via the gateway `logs.tail` method and the CLI) intentionally return the already-redacted file contents — redact-at-source is the correct architecture."

**What the audit found:** the file contents were **not** redacted. Log redaction was wired into the **console** sinks only. The tslog file transport in `src/logging/logger.ts` `buildLogger` — the **sole writer** to the on-disk log, and the single choke point every feeder funnels through — serialized the record **raw**:

- subsystem file logging (`logToFile`) — redacts the console emission, but the file child logger writes raw;
- the patched global `console.*` capture — redacts console, forwards raw to the file logger;
- direct `getLogger()` / `getChildLogger()` callers (cron-delivery, plugins runtime-logging, gateway server-cron, bonjour) — bypass both console layers entirely.

Because the gateway `logs.tail` server method (scope `operator.read`) and the CLI `logs` command return raw file slices with **no** read-time redaction, a secret logged through any of those feeders reached a remote operator-scoped client un-redacted — and sat raw on disk. Verified empirically on the pre-fix tree: `token=…`, `sk-…`, and URL `?access_token=…` secrets logged via all three feeders all landed raw in the file.

This is the defense-in-depth gap #2848 asked to close. It's complementary to the already-merged gateway-client fix (#2846/#2850), which hardened the client's *console/string* path; this closes the *file* path for **all** callers at one choke point.

## The fix

Redact at write ("redact-at-source"), **JSON-aware**, at that single transport:

- Recurse each caller argument and run the existing `redactSensitiveText` on every **string leaf** in raw text, **before** serialization — never regex-redact the serialized JSON string. Regex over serialized JSON is unsafe two ways, both verified during review: a raw-text value class (`token=[^\s&#]+`) runs past a value's closing quote and eats adjacent structure (invalid JSON + field bleed); and a credential that *begins* a value sits right after a `"`, which the redactor treats as a non-word boundary (so it leaks). Redacting raw leaves — where a value ends at the string's own boundary — avoids both and keeps every line valid JSON once re-serialized.
- tslog expands an `Error` argument into a plain `{ message, stack, … }` object, so **error messages** (the most common secret carrier: `logger.error("auth failed", err)`) are covered too.
- `_meta`'s two caller-derived fields (`name` / `parentNames`, which echo the label/bindings passed to `getChildLogger()`) are redacted; the rest of `_meta` is framework-generated (runtime, source path, level, timestamp) and passed through to keep the hot path cheap.
- The transport's `try/catch` stays **fail-closed**: a redaction throw drops the line, never writes it raw. Byte-accounting for the size cap is computed on the redacted payload.

`src/logging/redact.ts` is **unchanged** — the fix reuses the shared redactor rather than forking pattern logic. The whole change is one production file plus tests.

Redacting at the transport choke point is strictly more complete than the per-site lint rule the issue floated as optional scope: every file write is now scrubbed regardless of the call site, current or future. (A lint rule flagging raw `String(err)` at call sites could still be added later as a redundant catch-net, but is no longer load-bearing for the file sink.)

## Tests

New `src/logging/logger-redaction.test.ts` writes to a real temp log file and asserts the secret is absent and every line parses as JSON, covering:

- subsystem logger; direct `getChildLogger` caller;
- credential at the **start** of a value (the serialized-`"`-boundary case);
- secret under a **non-credential key** in a nested object;
- secret at a value's **end** (JSON-validity / no-structure-bleed guard);
- secret inside a logged **`Error`**'s message;
- secret bound into a child logger's **context** (`_meta`).

Gates green locally: 8/8 redaction tests, full logging suite 170 passed, `oxfmt` clean, `tsgo` clean, `oxlint` 0 warnings / 0 errors.

## Scope / follow-ups (out of scope here)

- **Read-time redaction** of `logs.tail` / CLI stays out of scope — intentionally not integrated in this fork; write-time is the fix by design (and it also protects direct filesystem access to the log). A skipped test already documents that read paths return raw slices.
- **Pre-existing `redact.ts` pattern-coverage limits** (unchanged here — `redact.ts` is byte-identical to origin/main; these affect *every* path, positional included, and are non-regressive):
  - A credential-*named* key with a non-self-evident value — e.g. `{ password: "plainvalue" }` — is not masked, because `redactSensitiveText` keys on assignment/URL/JSON-field *syntax* in a string, not on arbitrary nested-object key names.
  - A bare `token=…` assignment that sits *immediately after a `"`* is missed by the standalone pattern's `(^|[\s,;])` boundary (the boundary deliberately excludes `"` — widening it regressed ~20 raw-text prose sinks like `password="…"` in an earlier attempt, so `redact.ts` was left untouched). This surfaces for `_meta.name`/`parentNames`, which tslog hands to the transport already serialized (so they're redacted as a *string*, not as raw leaves like positional args). The `_meta` redaction still catches the common shapes — JSON-field `"token":"…"`, `sk-`/`ghp_`/`Bearer`/URL-embedded credentials, and `password` values — a strict improvement over writing `_meta` raw; the residual is the same string-boundary class as above.
  - The durable fix for this whole class is upstream's structured field-value helper (noted in `redact.ts` as having no fork consumer yet). Tracked as a follow-up in #2852, not blocking.

Closes #2848.

---

Created but **not** merged — awaiting independent security review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
