### PR TITLE
fix(gateway): wire reconcileNodePairingOnConnect into the connect flow (#2744)

### DIFF
--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -402,24 +402,12 @@ describe("gateway node command allowlist", () => {
     }
   });
 
-  // SKIPPED — blocked by gutted PRODUCTION wiring, not a harness gap (see
-  // remoteclaw/remoteclaw#2744). This asserts a node's allowlist-filtered
-  // declared commands appear in the `node.pair.list` PENDING set (the
-  // NODE-pairing system, distinct from device pairing) on connect. Upstream
-  // OpenClaw runs `reconcileNodePairingOnConnect` at connect time to park that
-  // node-pairing pending entry; the RemoteClaw fork gutted that wiring —
-  // `reconcileNodePairingOnConnect` has no call site (only its definition
-  // remains), and `node.pair.list.pending` is written ONLY by the explicit
-  // `node.pair.request` RPC, never on connect. So the pending entry is empty
-  // regardless of local-vs-remote classification: a remote connect
-  // (REMOTE_PEER_HEADERS) parks only a DEVICE-pairing entry — proven by
-  // "requires explicit pairing approval for a remote (non-local-direct) node
-  // connect" above, which exercises the harness's new remote-connect lever. The
-  // connect-time allowlist FILTERING this checks is still covered by "filters
-  // system.run for confusable iOS metadata at connect time" (reads node.list).
-  // Re-enabling needs restoring the gutted connect→node-pairing reconciliation
-  // (a production port, out of this PR's harness-only scope): #2744.
-  test.skip("keeps allowlisted declared commands available before node pairing exists", async () => {
+  // A loopback node connect silently auto-pairs at the DEVICE layer and stays
+  // connected, while `reconcileNodePairingOnConnect` parks a NODE-pairing pending
+  // entry (a distinct system) recording the allowlist-filtered declared commands.
+  // Pending is an operator approval record, not a connect gate: the node's declared
+  // commands remain available before any node pairing exists.
+  test("keeps allowlisted declared commands available before node pairing exists", async () => {
     const findConnectedNode = async (displayName: string) => {
       const listRes = await rpcReq<{
         nodes?: Array<{
@@ -474,14 +462,11 @@ describe("gateway node command allowlist", () => {
     }
   });
 
-  // SKIPPED — same gutted-wiring blocker as the sibling above, not a harness gap
-  // (remoteclaw/remoteclaw#2744): the `node.pair.list` PENDING entry this asserts
-  // on is never created on connect because `reconcileNodePairingOnConnect` is
-  // unwired in the fork. The İOS-confusable allowlist filtering it checks (only
-  // `canvas.snapshot` survives, `system.run` filtered) is exercised at connect
-  // time by "filters system.run for confusable iOS metadata at connect time" via
-  // node.list. Re-enabling needs the production port tracked in #2744.
-  test.skip("records only allowlisted commands in pending node pairing requests", async () => {
+  // The pending node-pairing entry records the allowlist-filtered command set, not
+  // the raw declaration: `İOS` (Turkish dotted capital I) does not lowercase to an
+  // `ios` prefix, so the platform resolves via the `iPhone` device family and
+  // `system.run` is filtered out — only `canvas.snapshot` is recorded for approval.
+  test("records only allowlisted commands in pending node pairing requests", async () => {
     const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const deviceIdentityPath = path.join(
       os.tmpdir(),
@@ -544,6 +529,7 @@ describe("gateway node command allowlist", () => {
   // loopback auto-pair posture are unchanged.
   test("requires explicit pairing approval for a remote (non-local-direct) node connect", async () => {
     const { listDevicePairing, rejectDevicePairing } = await import("../infra/device-pairing.js");
+    const { listNodePairing } = await import("../infra/node-pairing.js");
     const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const deviceIdentity = loadOrCreateDeviceIdentity(
       path.join(
@@ -584,6 +570,15 @@ describe("gateway node command allowlist", () => {
     expect(pending).toHaveLength(1);
     const pendingRoles = pending[0]?.roles ?? (pending[0]?.role ? [pending[0]?.role] : []);
     expect(pendingRoles).toContain("node");
+
+    // The device-pairing gate closes the connection before the connect flow reaches
+    // node-pairing reconciliation, so an unapproved remote node parks NO node-pairing
+    // entry. This pins the ordering: `reconcileNodePairingOnConnect` must stay behind
+    // the device gate and never be reachable by a device the operator has not approved.
+    const nodePending = (await listNodePairing()).pending.filter(
+      (entry) => entry.nodeId === deviceIdentity.deviceId,
+    );
+    expect(nodePending).toHaveLength(0);
 
     // Clean up the pending entry so it cannot leak into sibling tests (the suite
     // shares device-pairing state — there is no per-test reset).

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -16,7 +16,11 @@ import {
   verifyDeviceToken,
 } from "../../../infra/device-pairing.js";
 import { emitDiagnosticEvent } from "../../../infra/diagnostic-events.js";
-import { updatePairedNodeMetadata } from "../../../infra/node-pairing.js";
+import {
+  getPairedNode,
+  requestNodePairing,
+  updatePairedNodeMetadata,
+} from "../../../infra/node-pairing.js";
 import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
@@ -44,7 +48,7 @@ import {
   isTrustedProxyAddress,
   resolveClientIp,
 } from "../../net.js";
-import { resolveNodeCommandAllowlist } from "../../node-command-policy.js";
+import { reconcileNodePairingOnConnect } from "../../node-connect-reconcile.js";
 import { checkBrowserOrigin } from "../../origin-check.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import {
@@ -1060,16 +1064,27 @@ export function attachGatewayWsMessageHandler(params: {
           : null;
 
         if (role === "node") {
-          const cfg = loadConfig();
-          const allowlist = resolveNodeCommandAllowlist(cfg, {
-            platform: connectParams.client.platform,
-            deviceFamily: connectParams.client.deviceFamily,
+          // Must stay in sync with NodeRegistry.register, so the pending pairing entry
+          // is keyed by the same id the node is registered and invoked under.
+          const nodeIdForPairing = connectParams.device?.id ?? connectParams.client.id;
+          const reconciled = await reconcileNodePairingOnConnect({
+            cfg: loadConfig(),
+            connectParams,
+            pairedNode: await getPairedNode(nodeIdForPairing),
+            reportedClientIp,
+            requestPairing: (input) => requestNodePairing(input),
           });
-          const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
-          const filtered = declared
-            .map((cmd) => cmd.trim())
-            .filter((cmd) => cmd.length > 0 && allowlist.has(cmd));
-          connectParams.commands = filtered;
+          // Connect admission belongs to the device-pairing gate above. A node-pairing
+          // pending entry is an operator approval record only — rejecting the connect
+          // here would break secure-on-loopback silent local pairing.
+          connectParams.commands = reconciled.effectiveCommands;
+          if (reconciled.pendingPairing?.created) {
+            buildRequestContext().broadcast(
+              "node.pair.requested",
+              reconciled.pendingPairing.request,
+              { dropIfSlow: true },
+            );
+          }
         }
 
         const shouldTrackPresence = !isGatewayCliClient(connectParams.client);


### PR DESCRIPTION
## What & why

`reconcileNodePairingOnConnect` (`src/gateway/node-connect-reconcile.ts`) was fully
defined and fork-adapted but had **no call site** — the node-pairing-on-connect wiring was
accidentally gutted during an upstream sync. As a result `node.pair.list.pending` was
populated only by the explicit `node.pair.request` RPC, never on connect. Closes #2744.

This wires the existing reconciler into the gateway WS connect flow, in the
`role === "node"` block, replacing a duplicated inline allowlist filter.

## Behaviour

On a node connect (when not already paired with an unchanged command set), the gateway now
parks a **node-pairing** pending entry recording the node's allowlist-filtered declared
commands and broadcasts `node.pair.requested` — mirroring the existing `node.pair.request`
RPC path (`server-methods/nodes.ts`).

The pending entry is an **operator approval record only**; it never gates the connect.
Connect admission remains entirely with the device-pairing gate above this block.

### Scope discipline

This is a minimal fork-shaped restore. The stripped upstream machinery is **not** brought
back: `beginNodePairingConnect`, `requestNodePairingFromConnect`, the node reapproval
coordinator, `NodePairingRateLimitError`, cleanup-claims, caps/permissions reconciliation.
`server.node-pairing-authz.test.ts` is **not** reintroduced.

### The regression trap (issue-flagged) is avoided

A naive wiring that rejected the connect when it parked a pending entry would break the
secure-on-loopback silent-local-pairing path. It doesn't here:

- **Loopback** node connects still silently auto-pair at the device layer and stay
  connected with commands available (the two un-skipped tests exercise exactly this).
- **Remote** (non-local-direct) node connects are still rejected with `PAIRING_REQUIRED`
  by the device-pairing gate *above* this block, so reconciliation is never reached and no
  node-pairing entry is parked.
- The trusted-proxy loopback rejection is untouched.

### Security note

For a paired node declaring **newly-allowlisted** commands, the wiring is *strictly more
restrictive* than the old inline filter: it withholds the new commands and parks a
re-approval instead of granting them. No path widens capability. Approval still requires
operator scopes.

## Tests

- Un-skips the two blocked tests in `server.roles-allowlist-update.test.ts`
  (`keeps allowlisted declared commands available before node pairing exists`,
  `records only allowlisted commands in pending node pairing requests`) — their bodies are
  unchanged; only the `skip` marker and comments differ.
- Adds a negative assertion to the remote-connect test: an unapproved remote node parks
  **zero** node-pairing entries (pins the ordering invariant — reconciliation stays behind
  the device gate).
- Full gateway suite: **173 files, 1861 passed, 0 failed** (skips 5 → 3; the two target
  tests now run). `pnpm check` green; all fork-integrity gates pass.

## Follow-up

#2854 — deduplicate the three-site `nodeId` derivation (currently a comment-enforced
invariant), deferred to keep this auth-surface diff minimal.

## Review notes

Auth-surface change. A fresh-context security-architect review found no defects across
capability-elevation, loopback preservation, gutted-surface reintroduction, auth-bypass,
remote reachability, DoS, nodeId spoofing, broadcast leakage, TOCTOU, and error-path
(fail-closed) checks. An independent adversarial AC validation returned CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
