### PR TITLE
feat(security): wire --auth override into the security-audit CLI (#2864)

### DIFF
--- a/src/cli/security-cli.test.ts
+++ b/src/cli/security-cli.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseGatewayAuthMode } from "./security-cli.js";
+
+describe("parseGatewayAuthMode", () => {
+  it("returns undefined when the flag is absent or blank", () => {
+    expect(parseGatewayAuthMode(undefined)).toBeUndefined();
+    expect(parseGatewayAuthMode("")).toBeUndefined();
+    expect(parseGatewayAuthMode("   ")).toBeUndefined();
+  });
+
+  it("accepts every valid gateway auth mode", () => {
+    expect(parseGatewayAuthMode("none")).toBe("none");
+    expect(parseGatewayAuthMode("token")).toBe("token");
+    expect(parseGatewayAuthMode("password")).toBe("password");
+    expect(parseGatewayAuthMode("trusted-proxy")).toBe("trusted-proxy");
+  });
+
+  it("normalizes case and surrounding whitespace", () => {
+    expect(parseGatewayAuthMode("  NONE  ")).toBe("none");
+    expect(parseGatewayAuthMode("Token")).toBe("token");
+  });
+
+  it("throws a clear error on an unrecognized mode", () => {
+    expect(() => parseGatewayAuthMode("bogus")).toThrow(/Invalid --auth value/);
+    expect(() => parseGatewayAuthMode("trusted proxy")).toThrow(/Invalid --auth value/);
+  });
+});

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -1,8 +1,10 @@
 import type { Command } from "commander";
 import { loadConfig } from "../config/config.js";
+import type { GatewayAuthMode } from "../config/types.gateway.js";
 import { defaultRuntime } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { fixSecurityFootguns } from "../security/fix.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { isRich, theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
@@ -13,7 +15,23 @@ type SecurityAuditOptions = {
   json?: boolean;
   deep?: boolean;
   fix?: boolean;
+  auth?: string;
 };
+
+/**
+ * Parse the `--auth` value into a validated Gateway auth mode. Returns undefined
+ * when the flag is absent; throws on an unrecognized mode.
+ */
+export function parseGatewayAuthMode(value: string | undefined): GatewayAuthMode | undefined {
+  const mode = normalizeOptionalLowercaseString(value);
+  if (!mode) {
+    return undefined;
+  }
+  if (mode === "none" || mode === "token" || mode === "password" || mode === "trusted-proxy") {
+    return mode;
+  }
+  throw new Error('Invalid --auth value. Use "none", "token", "password", or "trusted-proxy".');
+}
 
 function formatSummary(summary: { critical: number; warn: number; info: number }): string {
   const rich = isRich();
@@ -37,6 +55,10 @@ export function registerSecurityCli(program: Command) {
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ["remoteclaw security audit", "Run a local security audit."],
           ["remoteclaw security audit --deep", "Include best-effort live Gateway probe checks."],
+          [
+            "remoteclaw security audit --auth none",
+            "Audit as if gateway auth were disabled (diagnostic what-if).",
+          ],
           ["remoteclaw security audit --fix", "Apply safe remediations and file-permission fixes."],
           ["remoteclaw security audit --json", "Output machine-readable JSON."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/security", "docs.remoteclaw.org/cli/security")}\n`,
@@ -46,9 +68,14 @@ export function registerSecurityCli(program: Command) {
     .command("audit")
     .description("Audit config + local state for common security foot-guns")
     .option("--deep", "Attempt live Gateway probe (best-effort)", false)
+    .option(
+      "--auth <mode>",
+      'Runtime "what-if" gateway auth mode for HTTP/hooks shared-secret checks ("none"|"token"|"password"|"trusted-proxy")',
+    )
     .option("--fix", "Apply safe fixes (tighten defaults + chmod state/config)", false)
     .option("--json", "Print JSON", false)
     .action(async (opts: SecurityAuditOptions) => {
+      const authMode = parseGatewayAuthMode(opts.auth);
       const fixResult = opts.fix ? await fixSecurityFootguns().catch((_err) => null) : null;
 
       const cfg = loadConfig();
@@ -57,6 +84,7 @@ export function registerSecurityCli(program: Command) {
         deep: Boolean(opts.deep),
         includeFilesystem: true,
         includeChannelSecurity: true,
+        auditGatewayAuthOverride: authMode ? { mode: authMode } : undefined,
       });
 
       if (opts.json) {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -2640,6 +2640,35 @@ description: test skill
     expectNoFinding(res, "gateway.http.no_auth");
   });
 
+  it("threads auditGatewayAuthOverride through runSecurityAudit into gateway HTTP auth checks", async () => {
+    const cfg: RemoteClawConfig = {
+      gateway: {
+        bind: "loopback",
+        auth: { mode: "token", token: "secret" },
+        http: {
+          endpoints: {
+            chatCompletions: { enabled: true },
+            responses: { enabled: true },
+          },
+        },
+      },
+    };
+
+    // Baseline: the configured token auth suppresses the finding, and the
+    // override defaults to undefined so runtime behavior is unchanged.
+    const baseline = await audit(cfg, { env: {} });
+    expectNoFinding(baseline, "gateway.http.no_auth");
+
+    // A `--auth none` what-if override forces the resolved mode to "none",
+    // surfacing the finding even though the config still carries a token —
+    // proving the override reaches the collector leaf via runSecurityAudit.
+    const overridden = await audit(cfg, {
+      env: {},
+      auditGatewayAuthOverride: { mode: "none" },
+    });
+    expectFinding(overridden, "gateway.http.no_auth", "warn");
+  });
+
   it("reports HTTP API session-key override surfaces when enabled", async () => {
     const cfg: RemoteClawConfig = {
       gateway: {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -7,6 +7,7 @@ import { listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { ConfigFileSnapshot, RemoteClawConfig } from "../config/config.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
+import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
@@ -84,6 +85,12 @@ export type SecurityAuditReport = {
   };
 };
 
+/** Runtime "what-if" Gateway auth override for config-only audit checks (diagnostic; CLI `--auth`). */
+export type SecurityAuditGatewayAuthOverride = Pick<
+  GatewayAuthConfig,
+  "mode" | "token" | "password"
+>;
+
 export type SecurityAuditOptions = {
   config: RemoteClawConfig;
   sourceConfig?: RemoteClawConfig;
@@ -110,6 +117,8 @@ export type SecurityAuditOptions = {
   configSnapshot?: ConfigFileSnapshot | null;
   /** Optional cache for code-safety summaries across repeated deep audits. */
   codeSafetySummaryCache?: Map<string, Promise<unknown>>;
+  /** Optional explicit Gateway auth mode/secret for config-only audit checks (diagnostic what-if). */
+  auditGatewayAuthOverride?: SecurityAuditGatewayAuthOverride;
 };
 
 type AuditExecutionContext = {
@@ -129,6 +138,7 @@ type AuditExecutionContext = {
   plugins?: ReturnType<typeof listChannelPlugins>;
   configSnapshot: ConfigFileSnapshot | null;
   codeSafetySummaryCache: Map<string, Promise<unknown>>;
+  auditGatewayAuthOverride?: SecurityAuditGatewayAuthOverride;
 };
 
 function countBySeverity(findings: SecurityAuditFinding[]): SecurityAuditSummary {
@@ -1125,6 +1135,7 @@ async function createAuditExecutionContext(
     plugins: opts.plugins,
     configSnapshot,
     codeSafetySummaryCache: opts.codeSafetySummaryCache ?? new Map<string, Promise<unknown>>(),
+    auditGatewayAuthOverride: opts.auditGatewayAuthOverride,
   };
 }
 
@@ -1141,8 +1152,16 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectLoggingFindings(cfg));
   findings.push(...collectElevatedFindings(cfg));
   findings.push(...collectExecRuntimeFindings(cfg));
-  findings.push(...collectHooksHardeningFindings(cfg, env));
-  findings.push(...collectGatewayHttpNoAuthFindings(cfg, env));
+  findings.push(
+    ...collectHooksHardeningFindings(cfg, env, {
+      gatewayAuthOverride: context.auditGatewayAuthOverride,
+    }),
+  );
+  findings.push(
+    ...collectGatewayHttpNoAuthFindings(cfg, env, {
+      gatewayAuthOverride: context.auditGatewayAuthOverride,
+    }),
+  );
   findings.push(...collectGatewayHttpSessionKeyOverrideFindings(cfg));
   findings.push(...collectSandboxDockerNoopFindings(cfg));
   findings.push(...collectSandboxDangerousConfigFindings(cfg));


### PR DESCRIPTION
## Summary

Wires a `--auth` override into the `remoteclaw security audit` CLI so an operator can run an audit against a **what-if** gateway auth configuration. Diagnostic convenience only — **not** a security fix.

Closes #2864.

## What changed

- **`src/cli/security-cli.ts`**: new `--auth <mode>` option (`none|token|password|trusted-proxy`), validated by `parseGatewayAuthMode` (throws a clear error on an unrecognized mode). Builds a mode-only `auditGatewayAuthOverride` and passes it to `runSecurityAudit`.
- **`src/security/audit.ts`**: new `SecurityAuditGatewayAuthOverride` type + optional `auditGatewayAuthOverride` field on `SecurityAuditOptions`, threaded through `AuditExecutionContext` / `createAuditExecutionContext` into the two collector leaves that **already** accept `gatewayAuthOverride` — `collectHooksHardeningFindings` and `collectGatewayHttpNoAuthFindings`.
- Tests: integration test proving the override reaches the leaf via `runSecurityAudit` (`audit.test.ts`), plus a unit test for `parseGatewayAuthMode` (`security-cli.test.ts`).

## Scope & decisions (for review)

- **Pure CLI plumbing.** No collector leaf signature changes; no runtime auth-resolution logic changes. When `--auth` is absent the override is `undefined`, so `collectX(cfg, env, { gatewayAuthOverride: undefined })` is byte-identical to the previous `collectX(cfg, env)` calls — audit behavior is unchanged. The two other production callers of `runSecurityAudit` (`status.command.ts`) never set the field.
- **`--auth <mode>` only** (no `--token`/`--password`). The override is mode-only; the credential is sourced from the resolved config. Upstream's `--token`/`--password` companions are coupled to upstream's `deepProbeAuth` surface, which this fork does not carry — adding them here would ship dead options.
- **Local `collectGatewayConfigFindings` left override-unaware** (intentional). The fork's `runSecurityAudit` uses a local 2-arg `collectGatewayConfigFindings` that does not take an override; wiring an override into it would alter runtime auth resolution (out of scope). Net effect: `--auth` affects the HTTP/hooks shared-secret checks (the leaves that already accept the override); the option help text is scoped to say exactly that. Re-integrating the ported `audit-gateway-config.ts` leaf is separate fork-reconciliation work.
- **Known pre-existing quirk (not addressed):** `--auth token`/`--auth password` on a config with no matching secret makes `gateway.http.no_auth` fire with a detail string that hardcodes `mode="none"`. This is a pre-existing leaf detail-string quirk (fires identically if the config itself declared token/password mode without a secret); the mode-only override just makes it newly reachable from the CLI. Out of scope here (it lives in a collector leaf).

## Testing

- `pnpm check` green (format + tsgo + oxlint + fork gates: rebrand, lobster-leak, css-drift, no-zombie-imports, stub-debt, throwing-stub-callers, obsolescence).
- New tests pass; full `src/cli/security-cli.test.ts` + `src/security/audit.test.ts` = **99 passed**.
- `parseGatewayAuthMode` unit-tested for all valid modes, case/whitespace normalization, blank→undefined, and invalid→throws.
- Integration test: token-configured gateway suppresses `gateway.http.no_auth`; a `--auth none` override surfaces it — proving the override threads through `runSecurityAudit` into the leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
