### PR TITLE
feat(gateway): close version-skewed local node on connect (#2863)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -95,6 +95,11 @@ import {
   shouldClearUnboundScopesForMissingDeviceIdentity,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
+import {
+  isReleasedVersion,
+  resolveLocalNodeId,
+  shouldCloseNodeForVersionSkew,
+} from "./node-version-skew.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -1064,6 +1069,44 @@ export function attachGatewayWsMessageHandler(params: {
           : null;
 
         if (role === "node") {
+          // Version skew: close the co-located local node host so its OS supervisor
+          // restarts it on the gateway's version. Scoped to the same-install local node —
+          // the connecting client's instanceId must match this install's node.json nodeId;
+          // SSH-tunneled remote nodes share loopback but carry a different instanceId, so
+          // they are exempt (closing them would not trigger a local supervisor restart).
+          // Runs before pairing reconcile and setClient/presence so a rejected node leaves
+          // no phantom online state or pending-pairing record. The client-side handler for
+          // the CLIENT_VERSION_MISMATCH detail code already exists (client.ts) to receive it.
+          if (isLocalClient) {
+            const gatewayVersion = resolveRuntimeServiceVersion(process.env);
+            const clientVersion = connectParams.client.version;
+            // A dev-versioned gateway never kicks a node, so short-circuit on the cheap
+            // released-gateway check before reading node.json — the same-install identity
+            // read only matters once a released skew is actually possible.
+            if (
+              isReleasedVersion(gatewayVersion) &&
+              shouldCloseNodeForVersionSkew({
+                localNodeId: await resolveLocalNodeId(),
+                clientInstanceId: connectParams.client.instanceId,
+                clientVersion,
+                gatewayVersion,
+              })
+            ) {
+              markHandshakeFailure("node-version-mismatch", { clientVersion, gatewayVersion });
+              logWsControl.info(
+                `node version mismatch conn=${connId} client=${formatForLog(clientLabel)} clientVersion=${formatForLog(clientVersion)} gatewayVersion=${formatForLog(gatewayVersion)}; closing for supervisor restart`,
+              );
+              sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, "client version mismatch", {
+                details: {
+                  code: ConnectErrorDetailCodes.CLIENT_VERSION_MISMATCH,
+                  clientVersion,
+                  gatewayVersion,
+                },
+              });
+              close(1008, "client version mismatch");
+              return;
+            }
+          }
           // Must stay in sync with NodeRegistry.register, so the pending pairing entry
           // is keyed by the same id the node is registered and invoked under.
           const nodeIdForPairing = connectParams.device?.id ?? connectParams.client.id;

--- a/src/gateway/server/ws-connection/node-version-skew.test.ts
+++ b/src/gateway/server/ws-connection/node-version-skew.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  isReleasedVersion,
+  resolveLocalNodeId,
+  shouldCloseNodeForVersionSkew,
+} from "./node-version-skew.js";
+
+describe("isReleasedVersion", () => {
+  test("accepts calendar release versions", () => {
+    expect(isReleasedVersion("2026.5.27")).toBe(true);
+    expect(isReleasedVersion("2026.5.27-beta.1")).toBe(true);
+    expect(isReleasedVersion("2026.12.0")).toBe(true);
+    expect(isReleasedVersion("2026.5.27+build.9")).toBe(true);
+  });
+
+  test("rejects dev / prerelease / non-calendar versions", () => {
+    expect(isReleasedVersion("dev")).toBe(false);
+    expect(isReleasedVersion("0.0.0")).toBe(false);
+    expect(isReleasedVersion("0.2.0")).toBe(false);
+    expect(isReleasedVersion("1.2.3")).toBe(false);
+    expect(isReleasedVersion("")).toBe(false);
+    expect(isReleasedVersion("v2026.5.27")).toBe(false);
+    expect(isReleasedVersion("202.5.27")).toBe(false); // 3-digit year
+    expect(isReleasedVersion("2026.5")).toBe(false); // missing patch
+  });
+});
+
+describe("shouldCloseNodeForVersionSkew", () => {
+  const base = {
+    localNodeId: "node-abc",
+    clientInstanceId: "node-abc",
+    clientVersion: "2026.5.20",
+    gatewayVersion: "2026.5.27",
+  };
+
+  test("closes when same-install local node runs a different released version", () => {
+    expect(shouldCloseNodeForVersionSkew(base)).toBe(true);
+  });
+
+  test("trims the client instanceId before matching the local node id", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientInstanceId: "  node-abc  " })).toBe(true);
+  });
+
+  test("exempt: no local node id resolved (no co-located node host)", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, localNodeId: null })).toBe(false);
+  });
+
+  test("exempt: instanceId does not match local node id (remote / SSH-tunneled node)", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientInstanceId: "node-other" })).toBe(false);
+  });
+
+  test("exempt: client instanceId missing or blank", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientInstanceId: undefined })).toBe(false);
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientInstanceId: "   " })).toBe(false);
+  });
+
+  test("exempt: versions are equal", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientVersion: "2026.5.27" })).toBe(false);
+  });
+
+  test("exempt: a version is missing", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientVersion: undefined })).toBe(false);
+    expect(shouldCloseNodeForVersionSkew({ ...base, gatewayVersion: undefined })).toBe(false);
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientVersion: "" })).toBe(false);
+  });
+
+  test("exempt: client version is not a release (dev node vs released gateway)", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, clientVersion: "dev" })).toBe(false);
+  });
+
+  test("exempt: gateway version is not a release (dev gateway never kicks a node)", () => {
+    expect(shouldCloseNodeForVersionSkew({ ...base, gatewayVersion: "dev" })).toBe(false);
+  });
+});
+
+describe("resolveLocalNodeId", () => {
+  const priorStateDir = process.env.REMOTECLAW_STATE_DIR;
+  const created: string[] = [];
+
+  afterEach(async () => {
+    if (priorStateDir === undefined) {
+      delete process.env.REMOTECLAW_STATE_DIR;
+    } else {
+      process.env.REMOTECLAW_STATE_DIR = priorStateDir;
+    }
+    await Promise.all(created.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  async function withStateDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "rc-node-skew-"));
+    created.push(dir);
+    process.env.REMOTECLAW_STATE_DIR = dir;
+    return dir;
+  }
+
+  test("returns the trimmed nodeId from node.json", async () => {
+    const dir = await withStateDir();
+    await fs.writeFile(
+      path.join(dir, "node.json"),
+      JSON.stringify({ version: 1, nodeId: "  node-xyz  " }),
+    );
+    expect(await resolveLocalNodeId()).toBe("node-xyz");
+  });
+
+  test("returns null when node.json is absent", async () => {
+    await withStateDir();
+    expect(await resolveLocalNodeId()).toBeNull();
+  });
+
+  test("returns null when nodeId is empty or missing", async () => {
+    const dir = await withStateDir();
+    await fs.writeFile(path.join(dir, "node.json"), JSON.stringify({ version: 1, nodeId: "   " }));
+    expect(await resolveLocalNodeId()).toBeNull();
+    await fs.writeFile(path.join(dir, "node.json"), JSON.stringify({ version: 1 }));
+    expect(await resolveLocalNodeId()).toBeNull();
+  });
+
+  test("returns null when node.json is malformed", async () => {
+    const dir = await withStateDir();
+    await fs.writeFile(path.join(dir, "node.json"), "not json{");
+    expect(await resolveLocalNodeId()).toBeNull();
+  });
+});

--- a/src/gateway/server/ws-connection/node-version-skew.ts
+++ b/src/gateway/server/ws-connection/node-version-skew.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../../../config/paths.js";
+
+/** Match production release versions (YYYY.M.PATCH or YYYY.M.PATCH-beta.N). */
+const RELEASED_VERSION_RE = /^\d{4}\.\d+\.\d+/;
+
+/**
+ * True when `version` looks like a shipped release (calendar-versioned), false for
+ * dev / prerelease placeholders (e.g. "dev", "0.0.0"). The version-skew guard only
+ * fires between two released versions so a dev-versioned gateway never kicks a node.
+ */
+export function isReleasedVersion(version: string): boolean {
+  return RELEASED_VERSION_RE.test(version);
+}
+
+const NODE_HOST_CONFIG_FILE = "node.json";
+
+/**
+ * Read this install's local node host id from `<stateDir>/node.json`, or `null` when
+ * there is no local node host configured (file absent, unreadable, or without a
+ * usable `nodeId`). Used to scope the version-skew guard to the co-located
+ * same-install node — the local node host writes its `nodeId` here and reports it
+ * back as the connect `instanceId`.
+ */
+export async function resolveLocalNodeId(): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(resolveStateDir(), NODE_HOST_CONFIG_FILE), "utf8");
+    const parsed = JSON.parse(raw) as { nodeId?: unknown };
+    const nodeId = typeof parsed.nodeId === "string" ? parsed.nodeId.trim() : "";
+    return nodeId.length > 0 ? nodeId : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether a connecting node should be closed for a *released* client/gateway
+ * version skew. The caller gates on `role === "node" && isLocalClient` (a cheap
+ * pre-check that also avoids the node.json read for non-local connects); this
+ * predicate encodes the version-skew-specific conditions:
+ *   - the same-install local node is identifiable (`localNodeId` resolved) and the
+ *     connecting client's `instanceId` matches it — co-located same-install node.
+ *     SSH-tunneled remote nodes share loopback but carry a different instanceId, so
+ *     they are exempt (closing them would not trigger a local supervisor restart), and
+ *   - both the client and gateway report *released* versions that differ.
+ *
+ * Closing the co-located local node host lets its OS supervisor restart it on the
+ * gateway's version; hence the narrow same-install scoping.
+ */
+export function shouldCloseNodeForVersionSkew(params: {
+  localNodeId: string | null;
+  clientInstanceId: string | undefined;
+  clientVersion: string | undefined;
+  gatewayVersion: string | undefined;
+}): boolean {
+  const clientInstanceId = params.clientInstanceId?.trim();
+  if (!params.localNodeId || !clientInstanceId || clientInstanceId !== params.localNodeId) {
+    return false;
+  }
+  const { clientVersion, gatewayVersion } = params;
+  if (!clientVersion || !gatewayVersion || clientVersion === gatewayVersion) {
+    return false;
+  }
+  return isReleasedVersion(clientVersion) && isReleasedVersion(gatewayVersion);
+}


### PR DESCRIPTION
## Summary

Closes #2863. Wires the **missing server-side half** of the node version-skew guard.
The fork already carried the client half — the `CLIENT_VERSION_MISMATCH` connect detail
code and the client-side pause-reconnect handler (`src/gateway/client.ts:638`) — but there
was **no server emitter**, so the guard never fired.

Now, in the connect handshake, a co-located same-install local node that reports a *released*
version differing from the gateway's *released* version is closed with
`close(1008, "client version mismatch")` and the existing detail code, so its OS supervisor
restarts it on the matching version.

**Operational hardening, not a security change** — nodes authenticate first (a bad gateway
token is rejected before any version check runs), so the guard loses no authn/authz coverage.

## What changed

- **New** `src/gateway/server/ws-connection/node-version-skew.ts` — a pure, exhaustively
  unit-tested sibling module (mirrors the existing `connect-policy.ts` pattern):
  - `isReleasedVersion(v)` — matches calendar releases `^\d{4}\.\d+\.\d+`
  - `resolveLocalNodeId()` — reads this install's `node.json` nodeId (null if none)
  - `shouldCloseNodeForVersionSkew(...)` — the decision predicate
- **New** `src/gateway/server/ws-connection/node-version-skew.test.ts` — 15 unit tests.
- **Edit** `src/gateway/server/ws-connection/message-handler.ts` — wires the guard into the
  connect handshake at the top of `if (role === "node")`.

## Design notes

The guard is deliberately narrow:
- **scoped to the same-install local node**: `role === "node" && isLocalClient` whose connect
  `instanceId` matches this install's `node.json` `nodeId`. SSH-tunneled remote nodes share
  loopback but carry a different instanceId, so they are **exempt** (closing them would not
  trigger a local supervisor restart);
- **gated on both sides running released versions** (`isReleasedVersion`): a dev-versioned
  gateway never kicks a node — and this is why the guard is a genuine no-op across the whole
  test suite (dev version `0.8.0` fails `isReleasedVersion`), not a masked regression;
- **placed before pairing reconcile and `setClient`/presence**: avoids phantom online state on
  rejection AND sidesteps upstream's pending-pairing cleanup machinery that this fork does not
  carry (rejecting before `reconcileNodePairingOnConnect` means no pending pairing is created).

Ports the intent of upstream's `message-handler.ts` version-skew emitter into the fork's
structure, using the fork's own helpers (`resolveRuntimeServiceVersion`,
`sendHandshakeErrorResponse`, `markHandshakeFailure`).

## Verification

- New unit lane: **15 passed** (`vitest.gateway.config.ts`).
- Full gateway lane: **179 files, 1900 passed | 4 skipped**.
- `pnpm check` green (format, tsgo, oxlint 0/0, lobster, css-drift).
- Fork-integrity gates: throwing-stub (0 violations), zombie-import, stub-debt,
  obsolescence (47==47), rebrand — all pass.
- Independent fresh-context **validate** and **polish** passes both returned **CLEAN**
  (all 5 ACs pass; the reachable-state expansion review found every exemption proven).

Change touches `src/gateway/`, not `src/middleware/`, so the LIVE smoke-test lane is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
