### PR TITLE
feat(diagnostics-prometheus): adopt upstream Prometheus metrics exporter (#2861)

### DIFF
--- a/extensions/diagnostics-prometheus/api.ts
+++ b/extensions/diagnostics-prometheus/api.ts
@@ -1,0 +1,1 @@
+export * from "remoteclaw/plugin-sdk/diagnostics-prometheus";

--- a/extensions/diagnostics-prometheus/index.ts
+++ b/extensions/diagnostics-prometheus/index.ts
@@ -1,0 +1,22 @@
+import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk/diagnostics-prometheus";
+import { emptyPluginConfigSchema } from "remoteclaw/plugin-sdk/diagnostics-prometheus";
+import { createDiagnosticsPrometheusExporter } from "./src/service.js";
+
+const plugin = {
+  id: "diagnostics-prometheus",
+  name: "Diagnostics Prometheus",
+  description: "Expose RemoteClaw diagnostics metrics in Prometheus text format",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: RemoteClawPluginApi) {
+    const exporter = createDiagnosticsPrometheusExporter();
+    api.registerService(exporter.service);
+    api.registerHttpRoute({
+      path: "/api/diagnostics/prometheus",
+      auth: "gateway",
+      match: "exact",
+      handler: exporter.handler,
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/diagnostics-prometheus/npm-shrinkwrap.json
+++ b/extensions/diagnostics-prometheus/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@remoteclaw/diagnostics-prometheus",
+  "version": "0.8.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@remoteclaw/diagnostics-prometheus",
+      "version": "0.8.0"
+    }
+  }
+}

--- a/extensions/diagnostics-prometheus/package.json
+++ b/extensions/diagnostics-prometheus/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@remoteclaw/diagnostics-prometheus",
+  "version": "0.8.0",
+  "description": "RemoteClaw diagnostics Prometheus exporter for runtime metrics",
+  "type": "module",
+  "remoteclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.20"
+    },
+    "build": {
+      "remoteclawVersion": "2026.4.20"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/diagnostics-prometheus/remoteclaw.plugin.json
+++ b/extensions/diagnostics-prometheus/remoteclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "diagnostics-prometheus",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DiagnosticEventPayload, RemoteClawPluginServiceContext } from "../api.js";
+import { emitDiagnosticEvent } from "../api.js";
+import { createDiagnosticsPrometheusExporter, testApi } from "./service.js";
+
+function baseEvent(): Pick<DiagnosticEventPayload, "seq" | "ts"> {
+  return { seq: 1, ts: 1700000000000 };
+}
+
+describe("diagnostics-prometheus service", () => {
+  it("records run metrics without raw diagnostic identifiers", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "run.completed",
+      runId: "run-should-not-export",
+      sessionKey: "session-should-not-export",
+      provider: "openai",
+      model: "gpt-5.4",
+      channel: "discord",
+      trigger: "message",
+      durationMs: 1500,
+      outcome: "completed",
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain("# TYPE remoteclaw_run_completed_total counter");
+    expect(rendered).toContain(
+      'remoteclaw_run_completed_total{channel="discord",model="gpt-5.4",outcome="completed",provider="openai",trigger="message"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_run_duration_seconds_sum{channel="discord",model="gpt-5.4",outcome="completed",provider="openai",trigger="message"} 1.5',
+    );
+    expect(rendered).not.toContain("run-should-not-export");
+    expect(rendered).not.toContain("session-should-not-export");
+  });
+
+  it("records hook-blocked run metrics with safe blocker originator only", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "run.completed",
+      runId: "run-should-not-export",
+      sessionKey: "session-should-not-export",
+      provider: "openai",
+      model: "gpt-5.4",
+      channel: "slack",
+      trigger: "message",
+      durationMs: 250,
+      outcome: "blocked",
+      blockedBy: "policy-plugin",
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'remoteclaw_run_completed_total{blocked_by="policy-plugin",channel="slack",model="gpt-5.4",outcome="blocked",provider="openai",trigger="message"} 1',
+    );
+    expect(rendered).not.toContain("run-should-not-export");
+    expect(rendered).not.toContain("session-should-not-export");
+  });
+
+  it("redacts and bounds label values", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "tool.execution.error",
+      toolName: "shell\nbad",
+      durationMs: 25,
+      errorCategory: "Bearer sk-secret-token-value",
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'remoteclaw_tool_execution_total{error_category="other",outcome="error",params_kind="unknown",tool="tool"} 1',
+    );
+    expect(rendered).not.toContain("Bearer");
+    expect(rendered).not.toContain("sk-secret");
+  });
+
+  it("records operator-critical diagnostic signals missing from generic run metrics", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    for (const event of [
+      {
+        ...baseEvent(),
+        type: "tool.execution.blocked",
+        toolName: "browser",
+        deniedReason: "tools.deny",
+        reason: "matched browser",
+        paramsSummary: { kind: "object" },
+      },
+      {
+        ...baseEvent(),
+        type: "session.stuck",
+        sessionId: "session-should-not-export",
+        sessionKey: "key-should-not-export",
+        state: "processing",
+        ageMs: 12_000,
+        reason: "startup-sweep",
+      },
+      {
+        ...baseEvent(),
+        type: "payload.large",
+        surface: "gateway.frame",
+        action: "rejected",
+        bytes: 2048,
+        limitBytes: 1024,
+        channel: "web",
+        pluginId: "agent:qa:otel-trace-smoke",
+        reason: "body-too-large",
+      },
+    ] satisfies DiagnosticEventPayload[]) {
+      testApi.recordDiagnosticEvent(store, event);
+    }
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'remoteclaw_tool_execution_blocked_total{denied_reason="tools.deny",params_kind="object",tool="browser"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_session_stuck_total{reason="startup-sweep",state="processing"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_session_stuck_age_seconds_sum{reason="startup-sweep",state="processing"} 12',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_payload_large_total{action="rejected",channel="web",plugin="none",reason="body-too-large",surface="gateway.frame"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_payload_large_bytes_sum{action="rejected",channel="web",plugin="none",reason="body-too-large",surface="gateway.frame"} 2048',
+    );
+    expect(rendered).not.toContain("session-should-not-export");
+    expect(rendered).not.toContain("key-should-not-export");
+    expect(rendered).not.toContain("agent:qa:otel-trace-smoke");
+  });
+
+  it("records webhook ingress and liveness warning metrics", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "webhook.received",
+      channel: "telegram",
+      updateType: "message",
+      chatId: "chat-should-not-export",
+    });
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "webhook.processed",
+      channel: "telegram",
+      updateType: "message",
+      chatId: "chat-should-not-export",
+      durationMs: 250,
+    });
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "webhook.error",
+      channel: "telegram",
+      updateType: "message",
+      chatId: "chat-should-not-export",
+      error: "Bearer sk-secret",
+    });
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "diagnostic.liveness.warning",
+      reasons: ["event_loop_delay", "cpu"],
+      intervalMs: 30_000,
+      eventLoopDelayP99Ms: 250,
+      eventLoopDelayMaxMs: 900,
+      eventLoopUtilization: 0.95,
+      cpuCoreRatio: 1.4,
+      active: 2,
+      waiting: 1,
+      queued: 4,
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'remoteclaw_webhook_received_total{channel="telegram",webhook="message"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_webhook_error_total{channel="telegram",webhook="message"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_webhook_duration_seconds_sum{channel="telegram",webhook="message"} 0.25',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_liveness_warning_total{reason="event_loop_delay:cpu"} 1',
+    );
+    expect(rendered).toContain('remoteclaw_liveness_sessions{state="active"} 2');
+    expect(rendered).toContain(
+      'remoteclaw_liveness_event_loop_delay_p99_seconds_sum{reason="event_loop_delay:cpu"} 0.25',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_liveness_cpu_core_ratio_sum{reason="event_loop_delay:cpu"} 1.4',
+    );
+    expect(rendered).not.toContain("chat-should-not-export");
+    expect(rendered).not.toContain("sk-secret");
+  });
+
+  it("drops session-shaped queue lane labels", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "queue.lane.enqueue",
+      lane: "session:Agent:qa:otel-trace-smoke",
+      queueSize: 2,
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain('remoteclaw_queue_lane_size{lane="session"} 2');
+    expect(rendered).not.toContain("Agent:qa:otel-trace-smoke");
+  });
+
+  it("keeps only the bounded prefix from scoped queue lane labels", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "queue.lane.enqueue",
+      lane: "dreaming-narrative:session-main",
+      queueSize: 2,
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain('remoteclaw_queue_lane_size{lane="dreaming-narrative"} 2');
+    expect(rendered).not.toContain("session-main");
+  });
+
+  it("bounds inbound message-processed labels without exporting raw chat identifiers", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "message.processed",
+      channel: "telegram/custom",
+      chatId: "chat-should-not-export",
+      messageId: "message-should-not-export",
+      outcome: "completed",
+      reason: "progress draft / message tool 123",
+      durationMs: 25,
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'remoteclaw_message_processed_total{channel="unknown",outcome="completed",reason="none"} 1',
+    );
+    expect(rendered).not.toContain("chat-should-not-export");
+    expect(rendered).not.toContain("message-should-not-export");
+    expect(rendered).not.toContain("progress draft");
+  });
+
+  it("records session recovery metrics without exporting raw ids", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    testApi.recordDiagnosticEvent(store, {
+      ...baseEvent(),
+      type: "session.recovery.completed",
+      sessionId: "session-should-not-export",
+      sessionKey: "key-should-not-export",
+      state: "processing",
+      stateGeneration: 2,
+      ageMs: 12_000,
+      queueDepth: 1,
+      reason: "startup-sweep",
+      activeWorkKind: "tool_call",
+      allowActiveAbort: true,
+      status: "released",
+      action: "abort-active-run",
+    });
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain(
+      'remoteclaw_session_recovery_total{action="abort-active-run",active_work_kind="tool_call",state="processing",status="released"} 1',
+    );
+    expect(rendered).toContain(
+      'remoteclaw_session_recovery_age_seconds_sum{action="abort-active-run",active_work_kind="tool_call",state="processing",status="released"} 12',
+    );
+    expect(rendered).not.toContain("session-should-not-export");
+    expect(rendered).not.toContain("key-should-not-export");
+  });
+
+  it("caps metric series growth and reports dropped series", () => {
+    const store = testApi.createPrometheusMetricStore();
+
+    for (let index = 0; index < 2100; index += 1) {
+      testApi.recordDiagnosticEvent(store, {
+        ...baseEvent(),
+        type: "model.call.completed",
+        runId: `run-${index}`,
+        callId: `call-${index}`,
+        provider: "openai",
+        model: `model.${index}`,
+        durationMs: 10,
+      });
+    }
+
+    const rendered = testApi.renderPrometheusMetrics(store);
+
+    expect(rendered).toContain("# TYPE remoteclaw_prometheus_series_dropped_total counter");
+    expect(rendered).toContain("remoteclaw_prometheus_series_dropped_total ");
+  });
+
+  it("subscribes to internal diagnostics and renders scrape text", () => {
+    const exporter = createDiagnosticsPrometheusExporter();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    const ctx = {
+      config: {} as never,
+      stateDir: "/tmp/remoteclaw-prometheus-test",
+      logger,
+    } satisfies RemoteClawPluginServiceContext;
+
+    exporter.service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "model.usage",
+      provider: "openai",
+      model: "gpt-5.4",
+      usage: { input: 12, output: 3, total: 15 },
+    });
+
+    expect(exporter.render()).toContain(
+      'remoteclaw_model_tokens_total{channel="unknown",model="gpt-5.4",provider="openai",token_type="input"} 12',
+    );
+
+    exporter.service.stop?.();
+
+    expect(exporter.render()).toBe("");
+  });
+});

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -1,0 +1,803 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type {
+  DiagnosticEventPayload,
+  RemoteClawPluginHttpRouteHandler,
+  RemoteClawPluginService,
+} from "../api.js";
+import { onInternalDiagnosticEvent, redactSensitiveText } from "../api.js";
+
+type LabelSet = Record<string, string>;
+
+type CounterSample = {
+  help: string;
+  labels: LabelSet;
+  value: number;
+};
+
+type HistogramSample = {
+  buckets: number[];
+  counts: number[];
+  count: number;
+  help: string;
+  labels: LabelSet;
+  sum: number;
+};
+
+type GaugeSample = {
+  help: string;
+  labels: LabelSet;
+  value: number;
+};
+
+type MetricSnapshot = {
+  counters: Map<string, CounterSample>;
+  gauges: Map<string, GaugeSample>;
+  histograms: Map<string, HistogramSample>;
+};
+
+type PrometheusMetricStore = ReturnType<typeof createPrometheusMetricStore>;
+
+const DURATION_BUCKETS_SECONDS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600,
+];
+const TOKEN_BUCKETS = [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576];
+const BYTE_BUCKETS = [
+  1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824,
+  4294967296, 17179869184,
+];
+const RATIO_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 4, 8, 16];
+const LOW_CARDINALITY_VALUE_RE = /^[A-Za-z0-9_.:-]{1,120}$/u;
+const MAX_PROMETHEUS_SERIES = 2048;
+const DROPPED_SERIES_COUNTER_NAME = "remoteclaw_prometheus_series_dropped_total";
+function lowCardinalityLabel(value: string | undefined, fallback = "unknown"): string {
+  if (!value) {
+    return fallback;
+  }
+  const redacted = redactSensitiveText(value.trim());
+  const redactedLower = redacted.toLowerCase();
+  if (redactedLower.startsWith("agent:") || redactedLower.includes(":agent:")) {
+    return fallback;
+  }
+  return LOW_CARDINALITY_VALUE_RE.test(redacted) ? redacted : fallback;
+}
+
+function lowCardinalityQueueLaneLabel(value: string | undefined, fallback = "unknown"): string {
+  if (!value) {
+    return fallback;
+  }
+  const redacted = redactSensitiveText(value.trim());
+  const redactedLower = redacted.toLowerCase();
+  if (redactedLower.startsWith("agent:")) {
+    return fallback;
+  }
+  const scopedLaneIndex = redacted.indexOf(":");
+  const lane = scopedLaneIndex >= 0 ? redacted.slice(0, scopedLaneIndex) : redacted;
+  return LOW_CARDINALITY_VALUE_RE.test(lane) ? lane : fallback;
+}
+
+function numericValue(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function seconds(ms: number | undefined): number | undefined {
+  const value = numericValue(ms);
+  return value === undefined ? undefined : value / 1000;
+}
+
+function sortedLabels(labels: LabelSet): [string, string][] {
+  return Object.entries(labels).toSorted(([left], [right]) => left.localeCompare(right));
+}
+
+function metricKey(name: string, labels: LabelSet): string {
+  return `${name}|${JSON.stringify(sortedLabels(labels))}`;
+}
+
+function escapeHelp(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+}
+
+function formatLabels(labels: LabelSet): string {
+  const entries = sortedLabels(labels);
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries.map(([key, value]) => `${key}="${escapeLabelValue(value)}"`).join(",")}}`;
+}
+
+function formatPrometheusNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  return Number.isInteger(value) ? String(value) : String(Number(value.toPrecision(12)));
+}
+
+function createPrometheusMetricStore() {
+  const counters = new Map<string, CounterSample>();
+  const gauges = new Map<string, GaugeSample>();
+  const histograms = new Map<string, HistogramSample>();
+  let droppedSeries = 0;
+
+  const canCreateSeries = <T>(map: Map<string, T>, key: string, metricName: string): boolean => {
+    if (map.has(key)) {
+      return true;
+    }
+    if (metricName === DROPPED_SERIES_COUNTER_NAME) {
+      return true;
+    }
+    if (counters.size + gauges.size + histograms.size < MAX_PROMETHEUS_SERIES) {
+      return true;
+    }
+    droppedSeries += 1;
+    return false;
+  };
+
+  const counter = (name: string, help: string, labels: LabelSet, amount = 1) => {
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return;
+    }
+    const key = metricKey(name, labels);
+    if (!canCreateSeries(counters, key, name)) {
+      return;
+    }
+    const existing = counters.get(key);
+    if (existing) {
+      existing.value += amount;
+      return;
+    }
+    counters.set(key, { help, labels, value: amount });
+  };
+
+  const gauge = (name: string, help: string, labels: LabelSet, value: number | undefined) => {
+    if (value === undefined || !Number.isFinite(value)) {
+      return;
+    }
+    const key = metricKey(name, labels);
+    if (!canCreateSeries(gauges, key, name)) {
+      return;
+    }
+    gauges.set(key, { help, labels, value });
+  };
+
+  const histogram = (
+    name: string,
+    help: string,
+    labels: LabelSet,
+    value: number | undefined,
+    buckets = DURATION_BUCKETS_SECONDS,
+  ) => {
+    if (value === undefined || !Number.isFinite(value) || value < 0) {
+      return;
+    }
+    const key = metricKey(name, labels);
+    if (!canCreateSeries(histograms, key, name)) {
+      return;
+    }
+    let sample = histograms.get(key);
+    if (!sample) {
+      sample = {
+        buckets,
+        counts: buckets.map(() => 0),
+        count: 0,
+        help,
+        labels,
+        sum: 0,
+      };
+      histograms.set(key, sample);
+    }
+    sample.count += 1;
+    sample.sum += value;
+    for (let index = 0; index < sample.buckets.length; index += 1) {
+      const bucket = sample.buckets[index];
+      if (bucket !== undefined && value <= bucket) {
+        sample.counts[index] = (sample.counts[index] ?? 0) + 1;
+      }
+    }
+  };
+
+  const snapshot = (): MetricSnapshot => {
+    const counterSnapshot = new Map(counters);
+    if (droppedSeries > 0) {
+      counterSnapshot.set(metricKey(DROPPED_SERIES_COUNTER_NAME, {}), {
+        help: "Prometheus metric series dropped because the exporter series cap was reached.",
+        labels: {},
+        value: droppedSeries,
+      });
+    }
+    return {
+      counters: counterSnapshot,
+      gauges: new Map(gauges),
+      histograms: new Map(histograms),
+    };
+  };
+
+  const reset = () => {
+    counters.clear();
+    gauges.clear();
+    histograms.clear();
+    droppedSeries = 0;
+  };
+
+  return { counter, gauge, histogram, reset, snapshot };
+}
+
+function safeErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? (err.message ?? err.name) : String(err);
+  return redactSensitiveText(message)
+    .replace(/[\u0000\r\n\t\u2028\u2029]/gu, " ")
+    .slice(0, 500);
+}
+
+function renderPrometheusMetrics(store: PrometheusMetricStore): string {
+  const snapshot = store.snapshot();
+  const lines: string[] = [];
+  const emitted = new Set<string>();
+
+  const emitHeader = (name: string, type: "counter" | "gauge" | "histogram", help: string) => {
+    if (emitted.has(name)) {
+      return;
+    }
+    emitted.add(name);
+    lines.push(`# HELP ${name} ${escapeHelp(help)}`);
+    lines.push(`# TYPE ${name} ${type}`);
+  };
+
+  const counterEntries = [...snapshot.counters.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  for (const [key, sample] of counterEntries) {
+    const name = key.split("|", 1)[0] ?? "";
+    emitHeader(name, "counter", sample.help);
+    lines.push(`${name}${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.value)}`);
+  }
+
+  const gaugeEntries = [...snapshot.gauges.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  for (const [key, sample] of gaugeEntries) {
+    const name = key.split("|", 1)[0] ?? "";
+    emitHeader(name, "gauge", sample.help);
+    lines.push(`${name}${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.value)}`);
+  }
+
+  const histogramEntries = [...snapshot.histograms.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  for (const [key, sample] of histogramEntries) {
+    const name = key.split("|", 1)[0] ?? "";
+    emitHeader(name, "histogram", sample.help);
+    for (let index = 0; index < sample.buckets.length; index += 1) {
+      const bucket = sample.buckets[index];
+      if (bucket === undefined) {
+        continue;
+      }
+      lines.push(
+        `${name}_bucket${formatLabels({ ...sample.labels, le: String(bucket) })} ${formatPrometheusNumber(sample.counts[index] ?? 0)}`,
+      );
+    }
+    lines.push(
+      `${name}_bucket${formatLabels({ ...sample.labels, le: "+Inf" })} ${formatPrometheusNumber(sample.count)}`,
+    );
+    lines.push(`${name}_sum${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.sum)}`);
+    lines.push(
+      `${name}_count${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.count)}`,
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function runLabels(evt: {
+  blockedBy?: string;
+  channel?: string;
+  model?: string;
+  outcome?: string;
+  provider?: string;
+  trigger?: string;
+}): LabelSet {
+  return {
+    ...(evt.blockedBy ? { blocked_by: lowCardinalityLabel(evt.blockedBy) } : {}),
+    channel: lowCardinalityLabel(evt.channel),
+    model: lowCardinalityLabel(evt.model),
+    outcome: lowCardinalityLabel(evt.outcome, "unknown"),
+    provider: lowCardinalityLabel(evt.provider),
+    trigger: lowCardinalityLabel(evt.trigger),
+  };
+}
+
+function modelCallLabels(evt: {
+  api?: string;
+  errorCategory?: string;
+  model?: string;
+  provider?: string;
+  transport?: string;
+  type: string;
+}): LabelSet {
+  return {
+    api: lowCardinalityLabel(evt.api),
+    error_category:
+      evt.type === "model.call.error" ? lowCardinalityLabel(evt.errorCategory, "other") : "none",
+    model: lowCardinalityLabel(evt.model),
+    outcome: evt.type === "model.call.error" ? "error" : "completed",
+    provider: lowCardinalityLabel(evt.provider),
+    transport: lowCardinalityLabel(evt.transport),
+  };
+}
+
+function toolExecutionLabels(evt: {
+  errorCategory?: string;
+  paramsSummary?: { kind: string };
+  toolName: string;
+  type: string;
+}): LabelSet {
+  return {
+    error_category:
+      evt.type === "tool.execution.error"
+        ? lowCardinalityLabel(evt.errorCategory, "other")
+        : "none",
+    outcome: evt.type === "tool.execution.error" ? "error" : "completed",
+    params_kind: lowCardinalityLabel(evt.paramsSummary?.kind),
+    tool: lowCardinalityLabel(evt.toolName, "tool"),
+  };
+}
+
+function toolExecutionBlockedLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "tool.execution.blocked" }>,
+): LabelSet {
+  return {
+    denied_reason: lowCardinalityLabel(evt.deniedReason, "other"),
+    params_kind: lowCardinalityLabel(evt.paramsSummary?.kind),
+    tool: lowCardinalityLabel(evt.toolName, "tool"),
+  };
+}
+
+function webhookLabels(
+  evt: Extract<
+    DiagnosticEventPayload,
+    { type: "webhook.received" | "webhook.processed" | "webhook.error" }
+  >,
+): LabelSet {
+  return {
+    channel: lowCardinalityLabel(evt.channel),
+    webhook: lowCardinalityLabel(evt.updateType),
+  };
+}
+
+function sessionStuckLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "session.stuck" }>,
+): LabelSet {
+  return {
+    reason: lowCardinalityLabel(evt.reason, "none"),
+    state: evt.state,
+  };
+}
+
+function sessionRecoveryLabels(
+  evt: Extract<
+    DiagnosticEventPayload,
+    { type: "session.recovery.requested" | "session.recovery.completed" }
+  >,
+): LabelSet {
+  return {
+    action:
+      evt.type === "session.recovery.completed"
+        ? lowCardinalityLabel(evt.action, "unknown")
+        : evt.allowActiveAbort
+          ? "abort"
+          : "recover",
+    active_work_kind: lowCardinalityLabel(evt.activeWorkKind, "none"),
+    state: evt.state,
+    status: evt.type === "session.recovery.completed" ? evt.status : "requested",
+  };
+}
+
+function livenessLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "diagnostic.liveness.warning" }>,
+): LabelSet {
+  return {
+    reason: lowCardinalityLabel(evt.reasons.join(":"), "unknown"),
+  };
+}
+
+function payloadLargeLabels(
+  evt: Extract<DiagnosticEventPayload, { type: "payload.large" }>,
+): LabelSet {
+  return {
+    action: evt.action,
+    channel: lowCardinalityLabel(evt.channel, "none"),
+    plugin: lowCardinalityLabel(evt.pluginId, "none"),
+    reason: lowCardinalityLabel(evt.reason, "none"),
+    surface: lowCardinalityLabel(evt.surface, "unknown"),
+  };
+}
+
+function recordModelUsage(
+  store: PrometheusMetricStore,
+  evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>,
+) {
+  const labels = {
+    channel: lowCardinalityLabel(evt.channel),
+    model: lowCardinalityLabel(evt.model),
+    provider: lowCardinalityLabel(evt.provider),
+  };
+  const usage = evt.usage;
+  const recordTokens = (tokenType: string, value: number | undefined) => {
+    const amount = numericValue(value);
+    if (amount === undefined || amount === 0) {
+      return;
+    }
+    store.counter(
+      "remoteclaw_model_tokens_total",
+      "Model tokens reported by diagnostic usage events.",
+      {
+        ...labels,
+        token_type: tokenType,
+      },
+      amount,
+    );
+    if (tokenType === "input" || tokenType === "output") {
+      store.histogram(
+        "remoteclaw_gen_ai_client_token_usage",
+        "GenAI token usage distribution for input and output tokens.",
+        {
+          model: labels.model,
+          provider: labels.provider,
+          token_type: tokenType,
+        },
+        amount,
+        TOKEN_BUCKETS,
+      );
+    }
+  };
+
+  recordTokens("input", usage.input);
+  recordTokens("output", usage.output);
+  recordTokens("cache_read", usage.cacheRead);
+  recordTokens("cache_write", usage.cacheWrite);
+  recordTokens("prompt", usage.promptTokens);
+  recordTokens("total", usage.total);
+
+  store.counter(
+    "remoteclaw_model_cost_usd_total",
+    "Estimated model cost in USD reported by diagnostic usage events.",
+    labels,
+    numericValue(evt.costUsd) ?? 0,
+  );
+  store.histogram(
+    "remoteclaw_model_usage_duration_seconds",
+    "Model usage event duration in seconds.",
+    labels,
+    seconds(evt.durationMs),
+  );
+}
+
+function recordDiagnosticEvent(store: PrometheusMetricStore, evt: DiagnosticEventPayload): void {
+  switch (evt.type) {
+    case "model.usage":
+      recordModelUsage(store, evt);
+      return;
+    case "run.completed":
+      store.histogram(
+        "remoteclaw_run_duration_seconds",
+        "Agent run duration in seconds.",
+        runLabels(evt),
+        seconds(evt.durationMs),
+      );
+      store.counter(
+        "remoteclaw_run_completed_total",
+        "Agent runs completed by outcome.",
+        runLabels(evt),
+      );
+      return;
+    case "model.call.completed":
+    case "model.call.error":
+      store.histogram(
+        "remoteclaw_model_call_duration_seconds",
+        "Provider model call duration in seconds.",
+        modelCallLabels(evt),
+        seconds(evt.durationMs),
+      );
+      store.counter(
+        "remoteclaw_model_call_total",
+        "Provider model calls completed by outcome.",
+        modelCallLabels(evt),
+      );
+      return;
+    case "tool.execution.completed":
+    case "tool.execution.error":
+      store.histogram(
+        "remoteclaw_tool_execution_duration_seconds",
+        "Tool execution duration in seconds.",
+        toolExecutionLabels(evt),
+        seconds(evt.durationMs),
+      );
+      store.counter(
+        "remoteclaw_tool_execution_total",
+        "Tool executions completed by outcome.",
+        toolExecutionLabels(evt),
+      );
+      return;
+    case "tool.execution.blocked":
+      store.counter(
+        "remoteclaw_tool_execution_blocked_total",
+        "Tool executions blocked by policy or sandbox diagnostics.",
+        toolExecutionBlockedLabels(evt),
+      );
+      return;
+    case "message.processed":
+      store.counter(
+        "remoteclaw_message_processed_total",
+        "Inbound messages processed by outcome.",
+        {
+          channel: lowCardinalityLabel(evt.channel),
+          outcome: evt.outcome,
+          reason: lowCardinalityLabel(evt.reason, "none"),
+        },
+      );
+      store.histogram(
+        "remoteclaw_message_processed_duration_seconds",
+        "Inbound message processing duration in seconds.",
+        {
+          channel: lowCardinalityLabel(evt.channel),
+          outcome: evt.outcome,
+          reason: lowCardinalityLabel(evt.reason, "none"),
+        },
+        seconds(evt.durationMs),
+      );
+      return;
+    case "webhook.received":
+      store.counter(
+        "remoteclaw_webhook_received_total",
+        "Webhook requests received by channel and update type.",
+        webhookLabels(evt),
+      );
+      return;
+    case "webhook.processed":
+      store.histogram(
+        "remoteclaw_webhook_duration_seconds",
+        "Webhook processing duration in seconds.",
+        webhookLabels(evt),
+        seconds(evt.durationMs),
+      );
+      return;
+    case "webhook.error":
+      store.counter(
+        "remoteclaw_webhook_error_total",
+        "Webhook processing errors by channel and update type.",
+        webhookLabels(evt),
+      );
+      return;
+    case "session.recovery.requested":
+    case "session.recovery.completed":
+      store.counter(
+        "remoteclaw_session_recovery_total",
+        "Session recovery observations by status and action.",
+        sessionRecoveryLabels(evt),
+      );
+      store.histogram(
+        "remoteclaw_session_recovery_age_seconds",
+        "Age of sessions selected for recovery in seconds.",
+        sessionRecoveryLabels(evt),
+        seconds(evt.ageMs),
+      );
+      return;
+    case "queue.lane.enqueue":
+    case "queue.lane.dequeue":
+      store.gauge(
+        "remoteclaw_queue_lane_size",
+        "Current diagnostic queue lane size.",
+        {
+          lane: lowCardinalityQueueLaneLabel(evt.lane),
+        },
+        numericValue(evt.queueSize),
+      );
+      if (evt.type === "queue.lane.dequeue") {
+        store.histogram(
+          "remoteclaw_queue_lane_wait_seconds",
+          "Queue lane wait time in seconds.",
+          { lane: lowCardinalityQueueLaneLabel(evt.lane) },
+          seconds(evt.waitMs),
+        );
+      }
+      return;
+    case "session.state":
+      store.counter("remoteclaw_session_state_total", "Session state observations.", {
+        reason: lowCardinalityLabel(evt.reason, "none"),
+        state: evt.state,
+      });
+      if (evt.queueDepth !== undefined) {
+        store.gauge(
+          "remoteclaw_session_queue_depth",
+          "Latest observed session queue depth.",
+          {
+            state: evt.state,
+          },
+          numericValue(evt.queueDepth),
+        );
+      }
+      return;
+    case "session.stuck":
+      store.counter(
+        "remoteclaw_session_stuck_total",
+        "Stale session bookkeeping observations with no active work.",
+        sessionStuckLabels(evt),
+      );
+      store.histogram(
+        "remoteclaw_session_stuck_age_seconds",
+        "Age of stale session bookkeeping observations in seconds.",
+        sessionStuckLabels(evt),
+        seconds(evt.ageMs),
+      );
+      return;
+    case "diagnostic.memory.sample":
+      store.gauge(
+        "remoteclaw_memory_bytes",
+        "Latest process memory usage by memory kind.",
+        { kind: "rss" },
+        evt.memory.rssBytes,
+      );
+      store.gauge(
+        "remoteclaw_memory_bytes",
+        "Latest process memory usage by memory kind.",
+        { kind: "heap_total" },
+        evt.memory.heapTotalBytes,
+      );
+      store.gauge(
+        "remoteclaw_memory_bytes",
+        "Latest process memory usage by memory kind.",
+        { kind: "heap_used" },
+        evt.memory.heapUsedBytes,
+      );
+      store.histogram(
+        "remoteclaw_memory_rss_bytes",
+        "RSS memory sample distribution in bytes.",
+        {},
+        numericValue(evt.memory.rssBytes),
+        BYTE_BUCKETS,
+      );
+      return;
+    case "diagnostic.memory.pressure":
+      store.counter(
+        "remoteclaw_memory_pressure_total",
+        "Memory pressure events by level and reason.",
+        {
+          level: evt.level,
+          reason: evt.reason,
+        },
+      );
+      return;
+    case "diagnostic.liveness.warning":
+      store.counter(
+        "remoteclaw_liveness_warning_total",
+        "Diagnostic liveness warning events.",
+        livenessLabels(evt),
+      );
+      store.gauge(
+        "remoteclaw_liveness_sessions",
+        "Latest session counts reported with diagnostic liveness warnings.",
+        { state: "active" },
+        numericValue(evt.active),
+      );
+      store.gauge(
+        "remoteclaw_liveness_sessions",
+        "Latest session counts reported with diagnostic liveness warnings.",
+        { state: "waiting" },
+        numericValue(evt.waiting),
+      );
+      store.gauge(
+        "remoteclaw_liveness_sessions",
+        "Latest session counts reported with diagnostic liveness warnings.",
+        { state: "queued" },
+        numericValue(evt.queued),
+      );
+      store.histogram(
+        "remoteclaw_liveness_event_loop_delay_p99_seconds",
+        "P99 event-loop delay reported by diagnostic liveness warnings in seconds.",
+        livenessLabels(evt),
+        seconds(evt.eventLoopDelayP99Ms),
+      );
+      store.histogram(
+        "remoteclaw_liveness_event_loop_delay_max_seconds",
+        "Maximum event-loop delay reported by diagnostic liveness warnings in seconds.",
+        livenessLabels(evt),
+        seconds(evt.eventLoopDelayMaxMs),
+      );
+      store.histogram(
+        "remoteclaw_liveness_event_loop_utilization_ratio",
+        "Event-loop utilization reported by diagnostic liveness warnings.",
+        livenessLabels(evt),
+        numericValue(evt.eventLoopUtilization),
+        RATIO_BUCKETS,
+      );
+      store.histogram(
+        "remoteclaw_liveness_cpu_core_ratio",
+        "CPU core ratio reported by diagnostic liveness warnings.",
+        livenessLabels(evt),
+        numericValue(evt.cpuCoreRatio),
+        RATIO_BUCKETS,
+      );
+      return;
+    case "diagnostic.heartbeat":
+      return;
+    case "payload.large":
+      store.counter(
+        "remoteclaw_payload_large_total",
+        "Oversized payload diagnostics by surface and action.",
+        payloadLargeLabels(evt),
+      );
+      store.histogram(
+        "remoteclaw_payload_large_bytes",
+        "Oversized payload byte sizes by surface and action.",
+        payloadLargeLabels(evt),
+        numericValue(evt.bytes),
+        BYTE_BUCKETS,
+      );
+      return;
+    default:
+      return;
+  }
+}
+
+function createMetricsHandler(store: PrometheusMetricStore): RemoteClawPluginHttpRouteHandler {
+  return (req: IncomingMessage, res: ServerResponse) => {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "GET, HEAD");
+      res.end("Method Not Allowed");
+      return true;
+    }
+
+    const body = renderPrometheusMetrics(store);
+    res.statusCode = 200;
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+    if (req.method === "HEAD") {
+      res.end();
+      return true;
+    }
+    res.end(body);
+    return true;
+  };
+}
+
+export function createDiagnosticsPrometheusExporter() {
+  const store = createPrometheusMetricStore();
+  let unsubscribe: (() => void) | undefined;
+
+  const service = {
+    id: "diagnostics-prometheus",
+    start(ctx) {
+      unsubscribe?.();
+      unsubscribe = onInternalDiagnosticEvent((event) => {
+        try {
+          recordDiagnosticEvent(store, event);
+        } catch (err) {
+          ctx.logger.error(
+            `diagnostics-prometheus: event handler failed (${event.type}): ${safeErrorMessage(err)}`,
+          );
+        }
+      });
+    },
+    stop() {
+      unsubscribe?.();
+      unsubscribe = undefined;
+      store.reset();
+    },
+  } satisfies RemoteClawPluginService;
+
+  return {
+    handler: createMetricsHandler(store),
+    render: () => renderPrometheusMetrics(store),
+    service,
+  };
+}
+
+export const testApi = {
+  createPrometheusMetricStore,
+  recordDiagnosticEvent,
+  renderPrometheusMetrics,
+};

--- a/extensions/diagnostics-prometheus/tsconfig.json
+++ b/extensions/diagnostics-prometheus/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -139,6 +139,10 @@
       "types": "./dist/plugin-sdk/diagnostics-otel.d.ts",
       "default": "./dist/plugin-sdk/diagnostics-otel.js"
     },
+    "./plugin-sdk/diagnostics-prometheus": {
+      "types": "./dist/plugin-sdk/diagnostics-prometheus.d.ts",
+      "default": "./dist/plugin-sdk/diagnostics-prometheus.js"
+    },
     "./plugin-sdk/diffs": {
       "types": "./dist/plugin-sdk/diffs.d.ts",
       "default": "./dist/plugin-sdk/diffs.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,8 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
 
+  extensions/diagnostics-prometheus: {}
+
   extensions/discord: {}
 
   extensions/feishu:

--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -57,6 +57,7 @@ const requiredSubpathEntries = [
   "copilot-proxy",
   "device-pair",
   "diagnostics-otel",
+  "diagnostics-prometheus",
   "diffs",
   "feishu",
   "googlechat",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -54,6 +54,8 @@ const requiredPathGroups = [
   "dist/plugin-sdk/device-pair.d.ts",
   "dist/plugin-sdk/diagnostics-otel.js",
   "dist/plugin-sdk/diagnostics-otel.d.ts",
+  "dist/plugin-sdk/diagnostics-prometheus.js",
+  "dist/plugin-sdk/diagnostics-prometheus.d.ts",
   "dist/plugin-sdk/diffs.js",
   "dist/plugin-sdk/diffs.d.ts",
   "dist/plugin-sdk/feishu.js",

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -25,6 +25,7 @@ const entrypoints = [
   "copilot-proxy",
   "device-pair",
   "diagnostics-otel",
+  "diagnostics-prometheus",
   "diffs",
   "feishu",
   "googlechat",

--- a/src/plugin-sdk/diagnostics-prometheus.ts
+++ b/src/plugin-sdk/diagnostics-prometheus.ts
@@ -1,0 +1,13 @@
+// Narrow plugin-sdk surface for the bundled diagnostics-prometheus plugin.
+// Keep this list additive and scoped to the bundled diagnostics-prometheus surface.
+
+export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
+export { emitDiagnosticEvent, onInternalDiagnosticEvent } from "../infra/diagnostic-events.js";
+export { redactSensitiveText } from "../logging/redact.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type {
+  RemoteClawPluginApi,
+  RemoteClawPluginHttpRouteHandler,
+  RemoteClawPluginService,
+  RemoteClawPluginServiceContext,
+} from "../plugins/types.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -15,6 +15,10 @@ const bundledExtensionSubpathLoaders = [
   { id: "copilot-proxy", load: () => import("remoteclaw/plugin-sdk/copilot-proxy") },
   { id: "device-pair", load: () => import("remoteclaw/plugin-sdk/device-pair") },
   { id: "diagnostics-otel", load: () => import("remoteclaw/plugin-sdk/diagnostics-otel") },
+  {
+    id: "diagnostics-prometheus",
+    load: () => import("remoteclaw/plugin-sdk/diagnostics-prometheus"),
+  },
   { id: "diffs", load: () => import("remoteclaw/plugin-sdk/diffs") },
   { id: "feishu", load: () => import("remoteclaw/plugin-sdk/feishu") },
   { id: "googlechat", load: () => import("remoteclaw/plugin-sdk/googlechat") },

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -3,6 +3,7 @@ export const miscExtensionTestRoots = [
   "extensions/brave",
   "extensions/device-pair",
   "extensions/diagnostics-otel",
+  "extensions/diagnostics-prometheus",
   "extensions/duckduckgo",
   "extensions/exa",
   "extensions/firecrawl",

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -35,6 +35,7 @@
     "src/plugin-sdk/copilot-proxy.ts",
     "src/plugin-sdk/device-pair.ts",
     "src/plugin-sdk/diagnostics-otel.ts",
+    "src/plugin-sdk/diagnostics-prometheus.ts",
     "src/plugin-sdk/diffs.ts",
     "src/plugin-sdk/feishu.ts",
     "src/plugin-sdk/google-gemini-cli-auth.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ const pluginSdkSubpaths = [
   "copilot-proxy",
   "device-pair",
   "diagnostics-otel",
+  "diagnostics-prometheus",
   "diffs",
   "feishu",
   "googlechat",


### PR DESCRIPTION
## What

Adopt the upstream OpenClaw `diagnostics-prometheus` Prometheus metrics exporter into the RemoteClaw fork, **adapted** (not copied) to the fork's flat `src/plugin-sdk/` decomposition and modeled on the shipped `extensions/diagnostics-otel` sibling.

The plugin exposes a gateway-authed `GET /api/diagnostics/prometheus` scrape endpoint that renders Prometheus text-format metrics from the fork's internal diagnostic-event stream (runs, model calls, tool executions, webhooks, sessions, queue lanes, memory/liveness, payloads).

Scoped to the **diagnostics-prometheus half** of #2861 only. The clickclack half remains — this PR **references but does not close** the issue.

## Fork adaptation (why this is not a blind copy)

The upstream plugin depends on a trust model that does not exist in the subtractive fork (`ctx.internalDiagnostics.onEvent((event, metadata) => …)` with `DiagnosticEventMetadata` / `isInternalDiagnosticEventMetadata`). The adaptation mirrors what the shipped `diagnostics-otel` plugin already does:

- **Trust model dropped** — subscribes via the fork's `onInternalDiagnosticEvent((evt) => void)` (single param, all internal events trusted); the fork's `RemoteClawPluginServiceContext` has no `internalDiagnostics`.
- **Event switch scoped to the fork's `DiagnosticEventPayload` union** — dropped the upstream-only event cases (`skill.used`, `harness.run.*`, `message.delivery.*`, `message.dispatch.*`, `message.received`, `talk.event`, `session.turn.created`, `diagnostic.async_queue.dropped`, `telemetry.exporter`) plus `model.failover` (defined in `diagnostic-events.ts` but deliberately excluded from the exported union — caught by typecheck), and the `agent` / `tool_owner` / `tool_source` label deltas the fork events don't carry.
- **Rebranded** all `openclaw_*` metric names to `remoteclaw_*`.
- **Security properties retained** — every user-derived label value passes through `redactSensitiveText` + low-cardinality bounding; no raw identifiers (runId / sessionKey / chatId / …) or secrets reach labels; the `MAX_PROMETHEUS_SERIES` cap + `remoteclaw_prometheus_series_dropped_total` bound cardinality.

## Registration

New narrow shim `src/plugin-sdk/diagnostics-prometheus.ts`; the `./plugin-sdk/diagnostics-prometheus` subpath is wired across `package.json` exports, `write-plugin-sdk-entry-dts.ts`, `check-plugin-sdk-exports.mjs`, `release-check.ts` (js + d.ts), `tsconfig.plugin-sdk.dts.json`, `subpaths.test.ts`, `vitest.config.ts`, and `vitest.extension-misc-paths.mjs`. No runtime dependencies → always-bundled (correctly omitted from `optional-bundled-clusters.mjs`). Install metadata already lives in `official-external-plugin-catalog.json` (fork convention), so — mirroring the otel sibling — the extension `package.json` carries no `install` block.

## Verification (all green locally)

- `pnpm check` (format + tsgo + lint + lobster / rebrand / css custom lints)
- `pnpm build` → `dist/plugin-sdk/diagnostics-prometheus.{js,d.ts}` produced
- `pnpm release:check` — "npm pack contents look OK"
- `test/package-manager-config.test.ts` 11/11 (shrinkwrap name + version `0.8.0` consistent, `publishToNpm: true`)
- `src/plugin-sdk/subpaths.test.ts` 11/11 (subpath resolves)
- `extensions/diagnostics-prometheus/src/service.test.ts` 11/11
- Runtime entry smoke — plugin loads, `id: diagnostics-prometheus`, registers service + route
- Fork gates: rebrand, zombie-import, stub-debt, obsolescence, throwing-stub-callers

Adversarially validated in fresh context (verdict: SHIP) and constructively polished for parity with the `diagnostics-otel` sibling.

## Not touched (deliberate, out of tight-acceptance scope)

- `src/plugins/bundled-plugin-metadata.generated.ts` — orphaned artifact (its generator was gutted from the fork; zero live consumers). Cannot regenerate; not runtime- or CI-affecting.
- `docs/.generated/config-baseline.json` — the fork's baseline generator is broken (a gutted export) and un-wired (no CI gate references it); regenerating would introduce unrelated churn.

## Merge

Per the dispatching context, **do not auto-merge** — handed off for independent review + merge by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
