### PR TITLE
feat(channels): adopt upstream message-access ingress consolidation

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -169,7 +169,9 @@ function createMockAccount(
       password: "test-password",
       dmPolicy: "open",
       groupPolicy: "open",
-      allowFrom: [],
+      // Wildcard so open-policy DMs are processed under the hardened gate (open + empty
+      // allowFrom now fails closed). Tests that exercise blocking override dmPolicy/allowFrom.
+      allowFrom: ["*"],
       groupAllowFrom: [],
       ...overrides,
     },
@@ -503,7 +505,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(sendMessageBlueBubbles).not.toHaveBeenCalled();
     });
 
-    it("allows all DMs when dmPolicy=open", async () => {
+    it("blocks DMs when dmPolicy=open and allowFrom is empty (hardened fail-closed)", async () => {
       const account = createMockAccount({
         dmPolicy: "open",
         allowFrom: [],
@@ -538,7 +540,9 @@ describe("BlueBubbles webhook monitor", () => {
       await handleBlueBubblesWebhookRequest(req, res);
       await flushAsync();
 
-      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+      // Hardened: open + empty allowFrom now fails closed. Prior allow-all requires
+      // allowFrom:["*"] (exercised by the default fixture used throughout this suite).
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
 
     it("blocks all DMs when dmPolicy=disabled", async () => {
@@ -660,6 +664,9 @@ describe("BlueBubbles webhook monitor", () => {
       const account = createMockAccount({
         groupPolicy: "allowlist",
         dmPolicy: "open",
+        // Empty DM allowlist so the group's empty groupAllowFrom does not fall back to the
+        // wildcard default — isolates chat_guid group routing + the group-allowlist block.
+        allowFrom: [],
       });
       const config: RemoteClawConfig = {};
       const core = createMockRuntime();
@@ -1606,7 +1613,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
 
-    it("does not auto-authorize DM control commands in open mode without allowlists", async () => {
+    it("blocks control-command DMs in open mode without allowlists (hardened)", async () => {
       mockHasControlCommand.mockReturnValue(true);
 
       const account = createMockAccount({
@@ -1643,12 +1650,9 @@ describe("BlueBubbles webhook monitor", () => {
       await handleBlueBubblesWebhookRequest(req, res);
       await flushAsync();
 
-      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
-      const latestDispatch =
-        mockDispatchReplyWithBufferedBlockDispatcher.mock.calls[
-          mockDispatchReplyWithBufferedBlockDispatcher.mock.calls.length - 1
-        ]?.[0];
-      expect(latestDispatch?.ctx?.CommandAuthorized).toBe(false);
+      // Hardened: open + empty allowFrom blocks the DM entirely, so an unauthorized control
+      // command never reaches dispatch (previously it dispatched with CommandAuthorized=false).
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
   });
 

--- a/extensions/discord/src/monitor/dm-command-auth.test.ts
+++ b/extensions/discord/src/monitor/dm-command-auth.test.ts
@@ -20,11 +20,13 @@ describe("resolveDiscordDmCommandAccess", () => {
     });
   }
 
-  it("allows open DMs and keeps command auth enabled without allowlist entries", async () => {
+  it("blocks open DMs without allowlist entries (hardened fail-closed)", async () => {
     const result = await resolveOpenDmAccess([]);
 
-    expect(result.decision).toBe("allow");
-    expect(result.commandAuthorized).toBe(true);
+    // dmPolicy=open with an empty allowFrom now fails closed (blocks) rather than
+    // allowing all senders; command auth is consequently not granted.
+    expect(result.decision).toBe("block");
+    expect(result.commandAuthorized).toBe(false);
   });
 
   it("marks command auth true when sender is allowlisted", async () => {
@@ -34,7 +36,7 @@ describe("resolveDiscordDmCommandAccess", () => {
     expect(result.commandAuthorized).toBe(true);
   });
 
-  it("keeps command auth enabled for open DMs when configured allowlist does not match", async () => {
+  it("blocks open DMs when configured allowlist does not match the sender (hardened)", async () => {
     const result = await resolveDiscordDmCommandAccess({
       accountId: "default",
       dmPolicy: "open",
@@ -45,9 +47,10 @@ describe("resolveDiscordDmCommandAccess", () => {
       readStoreAllowFrom: async () => [],
     });
 
-    expect(result.decision).toBe("allow");
+    // open + a configured allowlist the sender is not on now blocks (allowlist wins).
+    expect(result.decision).toBe("block");
     expect(result.allowMatch.allowed).toBe(false);
-    expect(result.commandAuthorized).toBe(true);
+    expect(result.commandAuthorized).toBe(false);
   });
 
   it("returns pairing decision and unauthorized command auth for unknown senders", async () => {
@@ -80,7 +83,7 @@ describe("resolveDiscordDmCommandAccess", () => {
     expect(result.commandAuthorized).toBe(true);
   });
 
-  it("keeps open DM command auth true when access groups are disabled", async () => {
+  it("blocks open DMs without allowlist even when access groups are disabled (hardened)", async () => {
     const result = await resolveDiscordDmCommandAccess({
       accountId: "default",
       dmPolicy: "open",
@@ -91,7 +94,12 @@ describe("resolveDiscordDmCommandAccess", () => {
       readStoreAllowFrom: async () => [],
     });
 
-    expect(result.decision).toBe("allow");
+    // The DM-access hardening blocks open + empty allowFrom regardless of the
+    // access-groups toggle — this is the operative security outcome.
+    expect(result.decision).toBe("block");
+    // commandAuthorized is a separate, unchanged axis: with access groups off and no
+    // allowlist configured it stays true (legacy "no allowlist ⇒ commands open"), but it
+    // is moot here because the DM is blocked before any command is processed.
     expect(result.commandAuthorized).toBe(true);
   });
 });

--- a/src/channels/message-access/dm-allow-state.ts
+++ b/src/channels/message-access/dm-allow-state.ts
@@ -1,0 +1,42 @@
+import { normalizeStringEntries } from "../../shared/string-normalization.js";
+import type { ChannelId } from "../plugins/types.js";
+import { readChannelIngressStoreAllowFromForDmPolicy } from "./runtime.js";
+
+export async function resolveDmAllowAuditState(params: {
+  provider: ChannelId;
+  accountId: string;
+  allowFrom?: Array<string | number> | null;
+  dmPolicy?: string | null;
+  normalizeEntry?: (raw: string) => string;
+  readStore?: (provider: ChannelId, accountId: string) => Promise<string[]>;
+}): Promise<{
+  configAllowFrom: string[];
+  hasWildcard: boolean;
+  allowCount: number;
+  isMultiUserDm: boolean;
+}> {
+  const configAllowFrom = normalizeStringEntries(
+    Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
+  );
+  const hasWildcard = configAllowFrom.includes("*");
+  const storeAllowFrom = await readChannelIngressStoreAllowFromForDmPolicy({
+    provider: params.provider,
+    accountId: params.accountId,
+    dmPolicy: params.dmPolicy,
+    readStore: params.readStore,
+  });
+  const normalizeEntry = params.normalizeEntry ?? ((value: string) => value);
+  const normalizedCfg = normalizeStringEntries(
+    configAllowFrom.filter((value) => value !== "*").map((value) => normalizeEntry(value)),
+  );
+  const normalizedStore = normalizeStringEntries(
+    storeAllowFrom.map((value) => normalizeEntry(value)),
+  );
+  const allowCount = new Set([...normalizedCfg, ...normalizedStore]).size;
+  return {
+    configAllowFrom,
+    hasWildcard,
+    allowCount,
+    isMultiUserDm: hasWildcard || allowCount > 1,
+  };
+}

--- a/src/channels/message-access/index.ts
+++ b/src/channels/message-access/index.ts
@@ -1,0 +1,31 @@
+export { decideChannelIngress } from "./decision.js";
+export { defineStableChannelIngressIdentity } from "./runtime-identity.js";
+export {
+  channelIngressRoutes,
+  createChannelIngressResolver,
+  readChannelIngressStoreAllowFromForDmPolicy,
+  resolveChannelMessageIngress,
+  resolveStableChannelMessageIngress,
+} from "./runtime.js";
+export { resolveChannelIngressState } from "./state.js";
+export type {
+  ChannelIngressAccessGroupMembershipResolver,
+  ChannelIngressCommandPresetInput,
+  ChannelIngressConfigInput,
+  ChannelIngressEventPresetInput,
+  ChannelIngressIdentityAlias,
+  ChannelIngressIdentityDescriptor,
+  ChannelIngressIdentityField,
+  ChannelIngressIdentitySubjectInput,
+  ChannelIngressRouteAccess,
+  ChannelIngressRouteDescriptor,
+  ChannelIngressResolver,
+  ChannelIngressResolverMessageParams,
+  ChannelMessageIngressCommandInput,
+  CreateChannelIngressResolverParams,
+  ResolvedChannelMessageIngress,
+  ResolveChannelMessageIngressParams,
+  ResolveStableChannelMessageIngressParams,
+  StableChannelIngressIdentityParams,
+} from "./runtime-types.js";
+export type * from "./types.js";

--- a/src/channels/message-access/runtime.ts
+++ b/src/channels/message-access/runtime.ts
@@ -1,0 +1,722 @@
+import { readChannelAllowFromStore } from "../../pairing/pairing-store.js";
+import type { PairingChannel } from "../../pairing/pairing-store.js";
+import { normalizeStringEntries, uniqueStrings } from "../../shared/string-normalization.js";
+import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "../allow-from.js";
+import { decideChannelIngress } from "./decision.js";
+import {
+  allReferencedAccessGroupNames,
+  normalizeEffectiveEntries,
+  resolveRuntimeAccessGroupMembershipFacts,
+} from "./runtime-access-groups.js";
+import {
+  createIdentityAdapter,
+  createIdentitySubject,
+  defineStableChannelIngressIdentity,
+} from "./runtime-identity.js";
+import type {
+  ChannelMessageIngressCommandInput,
+  ChannelIngressCommandPresetInput,
+  ChannelIngressEventPresetInput,
+  ChannelIngressActivationAccess,
+  ChannelIngressCommandAccess,
+  ChannelIngressRouteAccess,
+  ChannelIngressRouteDescriptor,
+  ChannelIngressResolver,
+  ChannelIngressResolverMessageParams,
+  ChannelIngressSenderAccess,
+  CreateChannelIngressResolverParams,
+  ResolveChannelMessageIngressParams,
+  ResolveStableChannelMessageIngressParams,
+  ResolvedChannelMessageIngress,
+} from "./runtime-types.js";
+import { resolveChannelIngressState } from "./state.js";
+import type {
+  AccessGraphGate,
+  ChannelIngressChannelId,
+  ChannelIngressEventInput,
+  ChannelIngressPolicyInput,
+  ChannelIngressStateInput,
+  RedactedIngressMatch,
+  ResolvedIngressAllowlist,
+  RouteGateFacts,
+  RouteSenderPolicy,
+} from "./types.js";
+
+type RouteFactDefaults = {
+  id: string;
+  kind?: RouteGateFacts["kind"];
+  precedence?: number;
+  senderPolicy?: RouteSenderPolicy;
+  senderAllowFrom?: Array<string | number>;
+  senderAllowFromSource?: RouteGateFacts["senderAllowFromSource"];
+  match?: RedactedIngressMatch;
+};
+
+function shouldReadStore(params: {
+  conversationKind: ChannelIngressStateInput["conversation"]["kind"];
+  dmPolicy: ChannelIngressPolicyInput["dmPolicy"];
+}): boolean {
+  return (
+    params.conversationKind === "direct" &&
+    params.dmPolicy !== "allowlist" &&
+    params.dmPolicy !== "open"
+  );
+}
+
+/**
+ * Merge configured direct, group, and pairing-store allowlists into the
+ * effective lists consumed by sender and context-visibility checks.
+ */
+export function resolveChannelIngressEffectiveAllowFromLists(params: {
+  allowFrom?: Array<string | number> | null;
+  groupAllowFrom?: Array<string | number> | null;
+  storeAllowFrom?: Array<string | number> | null;
+  dmPolicy?: string | null;
+  groupAllowFromFallbackToAllowFrom?: boolean | null;
+}): {
+  effectiveAllowFrom: string[];
+  effectiveGroupAllowFrom: string[];
+} {
+  const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
+  const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
+  const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
+  const effectiveAllowFrom = normalizeStringEntries(
+    mergeDmAllowFromSources({
+      allowFrom,
+      storeAllowFrom,
+      dmPolicy: params.dmPolicy ?? undefined,
+    }),
+  );
+  const effectiveGroupAllowFrom = normalizeStringEntries(
+    resolveGroupAllowFromSources({
+      allowFrom,
+      groupAllowFrom,
+      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
+    }),
+  );
+  return { effectiveAllowFrom, effectiveGroupAllowFrom };
+}
+
+/**
+ * Read pairing-store allowlist entries when a direct-message policy permits
+ * store fallback.
+ */
+export async function readChannelIngressStoreAllowFromForDmPolicy(params: {
+  provider: PairingChannel;
+  accountId: string;
+  dmPolicy?: string | null;
+  shouldRead?: boolean | null;
+  readStore?: (provider: PairingChannel, accountId: string) => Promise<string[]>;
+}): Promise<string[]> {
+  if (
+    params.shouldRead === false ||
+    params.dmPolicy === "allowlist" ||
+    params.dmPolicy === "open"
+  ) {
+    return [];
+  }
+  const readStore =
+    params.readStore ??
+    ((provider: PairingChannel, accountId: string) =>
+      readChannelAllowFromStore(provider, process.env, accountId));
+  return await readStore(params.provider, params.accountId).catch(() => []);
+}
+
+async function readStoreAllowFrom(
+  params: ResolveChannelMessageIngressParams & { channelId: ChannelIngressChannelId },
+): Promise<Array<string | number>> {
+  if (
+    !shouldReadStore({
+      conversationKind: params.conversation.kind,
+      dmPolicy: params.policy.dmPolicy,
+    })
+  ) {
+    return [];
+  }
+  const entries = params.readStoreAllowFrom
+    ? await params
+        .readStoreAllowFrom({
+          channelId: params.channelId,
+          accountId: params.accountId,
+          dmPolicy: params.policy.dmPolicy,
+        })
+        .catch(() => [])
+    : params.useDefaultPairingStore
+      ? await readChannelIngressStoreAllowFromForDmPolicy({
+          provider: params.channelId as PairingChannel,
+          accountId: params.accountId,
+          dmPolicy: params.policy.dmPolicy,
+        })
+      : [];
+  return [...(entries ?? [])];
+}
+
+function commandRequested(policy: ChannelIngressPolicyInput): boolean {
+  return policy.command != null;
+}
+
+function normalizeChannelId(id: string): ChannelIngressChannelId {
+  const trimmed = id.trim();
+  if (!trimmed) {
+    throw new Error("Channel ingress channel id must be non-empty.");
+  }
+  return trimmed as ChannelIngressChannelId;
+}
+
+function findIngressGate(params: {
+  ingress: ResolvedChannelMessageIngress["ingress"];
+  phase: AccessGraphGate["phase"];
+  kind: AccessGraphGate["kind"];
+}): AccessGraphGate | undefined {
+  return params.ingress.graph.gates.find(
+    (gate) => gate.phase === params.phase && gate.kind === params.kind,
+  );
+}
+
+function findSenderGate(
+  ingress: ResolvedChannelMessageIngress["ingress"],
+  isGroup: boolean,
+): AccessGraphGate | undefined {
+  return findIngressGate({
+    ingress,
+    phase: "sender",
+    kind: isGroup ? "groupSender" : "dmSender",
+  });
+}
+
+function useAccessGroupsFromConfig(params: {
+  useAccessGroups?: boolean | null;
+  cfg?: ChannelIngressCommandPresetInput["cfg"];
+}): boolean {
+  return params.useAccessGroups ?? params.cfg?.commands?.useAccessGroups !== false;
+}
+
+function channelIngressCommand(
+  params: ChannelIngressCommandPresetInput = {},
+): ChannelMessageIngressCommandInput | undefined {
+  if (params.requested === false) {
+    return undefined;
+  }
+  const { requested: _requested, cfg, ...command } = params;
+  return {
+    ...command,
+    useAccessGroups: useAccessGroupsFromConfig({
+      useAccessGroups: params.useAccessGroups,
+      cfg,
+    }),
+    allowTextCommands: params.allowTextCommands ?? false,
+    hasControlCommand: params.hasControlCommand ?? true,
+  };
+}
+
+function channelIngressEvent(
+  params: ChannelIngressEventPresetInput = {},
+): ChannelIngressEventInput {
+  const isGroup = params.isGroup ?? false;
+  return {
+    kind: params.kind ?? "message",
+    authMode: params.authMode ?? "inbound",
+    mayPair: params.mayPair ?? !isGroup,
+    ...(params.originSubject ? { originSubject: params.originSubject } : {}),
+  };
+}
+
+function resolveCommandInput(params: {
+  command?: ChannelIngressResolverMessageParams["command"];
+  useAccessGroups?: boolean | null;
+}): ChannelMessageIngressCommandInput | undefined {
+  if (params.command === false || params.command == null) {
+    return undefined;
+  }
+  return channelIngressCommand({
+    ...params.command,
+    useAccessGroups: params.command.useAccessGroups ?? params.useAccessGroups,
+  });
+}
+
+function resolveResolverPolicy(params: {
+  base: CreateChannelIngressResolverParams;
+  input: ChannelIngressResolverMessageParams;
+}): ChannelIngressPolicyInput {
+  return {
+    dmPolicy: params.input.dmPolicy ?? params.base.defaultDmPolicy ?? "pairing",
+    groupPolicy: params.input.groupPolicy ?? params.base.defaultGroupPolicy ?? "disabled",
+    groupAllowFromFallbackToAllowFrom:
+      params.input.policy?.groupAllowFromFallbackToAllowFrom ??
+      params.base.groupAllowFromFallbackToAllowFrom,
+    mutableIdentifierMatching:
+      params.input.policy?.mutableIdentifierMatching ?? params.base.mutableIdentifierMatching,
+    ...(params.input.policy?.activation ? { activation: params.input.policy.activation } : {}),
+  };
+}
+
+/**
+ * Create a reusable ingress resolver for one channel account and identity
+ * descriptor.
+ */
+export function createChannelIngressResolver(
+  base: CreateChannelIngressResolverParams,
+): ChannelIngressResolver {
+  const resolve = async (
+    input: ChannelIngressResolverMessageParams,
+    eventDefaults?: ChannelIngressEventPresetInput,
+  ) => {
+    const isGroup = input.conversation.kind !== "direct";
+    const useAccessGroups = useAccessGroupsFromConfig({
+      useAccessGroups: base.useAccessGroups,
+      cfg: base.cfg,
+    });
+    return await resolveChannelMessageIngress({
+      channelId: base.channelId,
+      accountId: base.accountId,
+      identity: base.identity,
+      subject: input.subject,
+      conversation: input.conversation,
+      event: channelIngressEvent({
+        isGroup,
+        ...eventDefaults,
+        ...input.event,
+      }),
+      policy: resolveResolverPolicy({ base, input }),
+      allowFrom: input.allowFrom,
+      groupAllowFrom: input.groupAllowFrom,
+      route: input.route,
+      routeFacts: input.routeFacts,
+      accessGroups: base.accessGroups ?? base.cfg?.accessGroups,
+      accessGroupMembership: [
+        ...(base.accessGroupMembership ?? []),
+        ...(input.accessGroupMembership ?? []),
+      ],
+      resolveAccessGroupMembership: base.resolveAccessGroupMembership,
+      accessGroupMatchedAllowFromEntry: base.accessGroupMatchedAllowFromEntry,
+      providerMissingFallbackApplied: input.providerMissingFallbackApplied,
+      mentionFacts: input.mentionFacts,
+      readStoreAllowFrom: base.readStoreAllowFrom,
+      useDefaultPairingStore: base.useDefaultPairingStore,
+      command: resolveCommandInput({
+        command: input.command,
+        useAccessGroups,
+      }),
+    });
+  };
+  return {
+    message: async (input) => await resolve(input),
+    command: async (input) =>
+      await resolve(input, {
+        authMode: "command",
+        mayPair: false,
+      }),
+    event: async (input) => await resolve(input, { mayPair: false }),
+  };
+}
+
+/**
+ * Resolve one inbound event using a simple stable subject identity descriptor.
+ */
+export async function resolveStableChannelMessageIngress(
+  params: ResolveStableChannelMessageIngressParams,
+): Promise<ResolvedChannelMessageIngress> {
+  return await createChannelIngressResolver({
+    ...params,
+    identity: defineStableChannelIngressIdentity(params.identity),
+  }).message(params);
+}
+
+function routeDescriptors(
+  route: ResolveChannelMessageIngressParams["route"],
+): ChannelIngressRouteDescriptor[] {
+  if (!route) {
+    return [];
+  }
+  if (Array.isArray(route)) {
+    return [...route];
+  }
+  return [route as ChannelIngressRouteDescriptor];
+}
+
+/**
+ * Collect optional route descriptors while dropping false, null, and undefined
+ * entries.
+ */
+export function channelIngressRoutes(
+  ...routes: Array<ChannelIngressRouteDescriptor | false | null | undefined>
+): ChannelIngressRouteDescriptor[] {
+  return routes.filter((route): route is ChannelIngressRouteDescriptor => Boolean(route));
+}
+
+function routeDescriptorMatch(descriptor: ChannelIngressRouteDescriptor) {
+  const matched = descriptor.matched ?? descriptor.allowed ?? descriptor.enabled !== false;
+  return {
+    matched,
+    matchedEntryIds: matched && descriptor.matchId ? [descriptor.matchId] : [],
+  };
+}
+
+function routeFact(
+  params: RouteFactDefaults & Pick<RouteGateFacts, "gate" | "effect">,
+): RouteGateFacts {
+  return {
+    id: params.id,
+    kind: params.kind ?? "route",
+    gate: params.gate,
+    effect: params.effect,
+    precedence: params.precedence ?? 0,
+    senderPolicy: params.senderPolicy ?? "inherit",
+    senderAllowFrom: params.senderAllowFrom,
+    senderAllowFromSource: params.senderAllowFromSource,
+    match: params.match,
+  };
+}
+
+function routeFactDefaults(descriptor: ChannelIngressRouteDescriptor) {
+  return {
+    id: descriptor.id,
+    ...(descriptor.kind ? { kind: descriptor.kind } : {}),
+    ...(descriptor.precedence !== undefined ? { precedence: descriptor.precedence } : {}),
+    ...(descriptor.senderPolicy ? { senderPolicy: descriptor.senderPolicy } : {}),
+    ...(descriptor.senderAllowFrom != null
+      ? { senderAllowFrom: [...descriptor.senderAllowFrom] }
+      : {}),
+    ...(descriptor.senderAllowFromSource
+      ? { senderAllowFromSource: descriptor.senderAllowFromSource }
+      : {}),
+    match: routeDescriptorMatch(descriptor),
+  };
+}
+
+function routeFactsFromDescriptors(
+  route: ResolveChannelMessageIngressParams["route"],
+): RouteGateFacts[] {
+  return routeDescriptors(route).flatMap((descriptor) => {
+    if (descriptor.configured === false) {
+      return [];
+    }
+    const defaults = routeFactDefaults(descriptor);
+    if (descriptor.enabled === false) {
+      return [routeFact({ ...defaults, gate: "disabled", effect: "block-dispatch" })];
+    }
+    if (descriptor.allowed !== undefined) {
+      return [
+        routeFact({
+          ...defaults,
+          gate: descriptor.allowed ? "matched" : "not-matched",
+          effect: descriptor.allowed ? "allow" : "block-dispatch",
+        }),
+      ];
+    }
+    if (
+      descriptor.senderPolicy !== "deny-when-empty" &&
+      descriptor.senderAllowFrom == null &&
+      descriptor.senderAllowFromSource == null
+    ) {
+      return [];
+    }
+    return [
+      routeFact({
+        ...defaults,
+        kind: descriptor.senderPolicy === "deny-when-empty" ? defaults.kind : "routeSender",
+        gate: "matched",
+        effect: "allow",
+        senderPolicy:
+          descriptor.senderPolicy === "deny-when-empty" ? "deny-when-empty" : defaults.senderPolicy,
+      }),
+    ];
+  });
+}
+
+function routeDescriptorForGate(params: {
+  descriptors: readonly ChannelIngressRouteDescriptor[];
+  gate: AccessGraphGate;
+}): ChannelIngressRouteDescriptor | undefined {
+  const senderSuffix = ":sender";
+  const baseGateId = params.gate.id.endsWith(senderSuffix)
+    ? params.gate.id.slice(0, -senderSuffix.length)
+    : params.gate.id;
+  return params.descriptors.find(
+    (descriptor) => descriptor.id === params.gate.id || descriptor.id === baseGateId,
+  );
+}
+
+function projectRouteAccess(params: {
+  ingress: ResolvedChannelMessageIngress["ingress"];
+  route: ResolveChannelMessageIngressParams["route"];
+}): ChannelIngressRouteAccess {
+  const descriptors = routeDescriptors(params.route);
+  const routeBlock = params.ingress.graph.gates.find(
+    (entry) => entry.phase === "route" && entry.effect === "block-dispatch",
+  );
+  if (routeBlock) {
+    const descriptor = routeDescriptorForGate({ descriptors, gate: routeBlock });
+    return {
+      allowed: routeBlock.allowed,
+      reasonCode: routeBlock.reasonCode,
+      ...(descriptor?.blockReason ? { reason: descriptor.blockReason } : {}),
+      gate: routeBlock,
+    };
+  }
+  const routeSenderReplacement = descriptors.find(
+    (descriptor) => descriptor.senderPolicy === "replace" && descriptor.blockReason,
+  );
+  const senderBlock = params.ingress.graph.gates.find(
+    (entry) => entry.phase === "sender" && entry.effect === "block-dispatch",
+  );
+  if (routeSenderReplacement && senderBlock) {
+    return {
+      allowed: false,
+      reasonCode: senderBlock.reasonCode,
+      reason: routeSenderReplacement.blockReason,
+      gate: senderBlock,
+    };
+  }
+  const gate = params.ingress.graph.gates.find((entry) => entry.phase === "route");
+  if (gate) {
+    return {
+      allowed: gate.allowed,
+      reasonCode: gate.reasonCode,
+      gate,
+    };
+  }
+  return { allowed: true };
+}
+
+function projectSenderAccess(params: {
+  ingress: ResolvedChannelMessageIngress["ingress"];
+  isGroup: boolean;
+  effectiveAllowFrom: string[];
+  effectiveGroupAllowFrom: string[];
+  providerMissingFallbackApplied?: boolean;
+}): ChannelIngressSenderAccess {
+  const gate = findSenderGate(params.ingress, params.isGroup);
+  const reasonCode =
+    !gate &&
+    params.isGroup &&
+    params.ingress.reasonCode === "route_sender_empty" &&
+    params.effectiveGroupAllowFrom.length === 0
+      ? "group_policy_empty_allowlist"
+      : (gate?.reasonCode ?? params.ingress.reasonCode);
+  const decision =
+    reasonCode === "dm_policy_pairing_required"
+      ? "pairing"
+      : gate?.allowed === true
+        ? "allow"
+        : "block";
+  return {
+    allowed: decision === "allow",
+    decision,
+    reasonCode,
+    ...(gate ? { gate } : {}),
+    effectiveAllowFrom: params.effectiveAllowFrom,
+    effectiveGroupAllowFrom: params.effectiveGroupAllowFrom,
+    providerMissingFallbackApplied: params.providerMissingFallbackApplied ?? false,
+  };
+}
+
+function projectCommandAccess(params: {
+  ingress: ResolvedChannelMessageIngress["ingress"];
+  policy: ChannelIngressPolicyInput;
+}): ChannelIngressCommandAccess {
+  const gate = findIngressGate({
+    ingress: params.ingress,
+    phase: "command",
+    kind: "command",
+  });
+  return {
+    requested: commandRequested(params.policy),
+    authorized: commandRequested(params.policy) ? gate?.allowed === true : false,
+    shouldBlockControlCommand: gate?.command?.shouldBlockControlCommand === true,
+    reasonCode: gate?.reasonCode ?? params.ingress.reasonCode,
+    ...(gate ? { gate } : {}),
+  };
+}
+
+function projectActivationAccess(params: {
+  ingress: ResolvedChannelMessageIngress["ingress"];
+}): ChannelIngressActivationAccess {
+  const gate = findIngressGate({
+    ingress: params.ingress,
+    phase: "activation",
+    kind: "mention",
+  });
+  return {
+    ran: gate != null,
+    allowed: gate?.allowed === true,
+    shouldSkip: gate?.activation?.shouldSkip === true,
+    reasonCode: gate?.reasonCode ?? params.ingress.reasonCode,
+    ...(gate?.activation?.effectiveWasMentioned !== undefined
+      ? { effectiveWasMentioned: gate.activation.effectiveWasMentioned }
+      : {}),
+    ...(gate?.activation?.shouldBypassMention !== undefined
+      ? { shouldBypassMention: gate.activation.shouldBypassMention }
+      : {}),
+    ...(gate ? { gate } : {}),
+  };
+}
+
+function commandOwnerAllowFrom(params: {
+  command?: ChannelMessageIngressCommandInput;
+  isGroup: boolean;
+  configuredAllowFrom: Array<string | number>;
+  effectiveAllowFrom: string[];
+}): Array<string | number> {
+  if (params.command?.commandOwnerAllowFrom != null) {
+    return params.command.commandOwnerAllowFrom;
+  }
+  if (!params.isGroup) {
+    return params.effectiveAllowFrom;
+  }
+  return params.command?.groupOwnerAllowFrom === "none" ? [] : params.configuredAllowFrom;
+}
+
+function commandGroupAllowFrom(params: {
+  command?: ChannelMessageIngressCommandInput;
+  isGroup: boolean;
+  effectiveCommandGroupAllowFrom: string[];
+}): Array<string | number> {
+  if (params.isGroup) {
+    return params.effectiveCommandGroupAllowFrom;
+  }
+  return params.command?.directGroupAllowFrom === "effective"
+    ? params.effectiveCommandGroupAllowFrom
+    : [];
+}
+
+function accessGroupMatchedEntry(params: ResolveChannelMessageIngressParams): string | null {
+  const entry = params.accessGroupMatchedAllowFromEntry ?? params.subject.stableId;
+  return entry == null ? null : String(entry);
+}
+
+function appendAccessGroupMatchedEntry(params: {
+  entries: string[];
+  allowlist: ResolvedIngressAllowlist;
+  matchedEntry: string | null;
+}): string[] {
+  return params.matchedEntry && params.allowlist.accessGroups.matched.length > 0
+    ? uniqueStrings([...params.entries, params.matchedEntry])
+    : params.entries;
+}
+
+/**
+ * Resolve sender, route, command, event, and activation gates for one inbound
+ * channel event.
+ */
+export async function resolveChannelMessageIngress(
+  params: ResolveChannelMessageIngressParams,
+): Promise<ResolvedChannelMessageIngress> {
+  const channelId = normalizeChannelId(params.channelId);
+  const adapter = createIdentityAdapter(params.identity);
+  const subject = createIdentitySubject(params.identity, params.subject);
+  const routeFacts = [...routeFactsFromDescriptors(params.route), ...(params.routeFacts ?? [])];
+  const storeAllowFrom = await readStoreAllowFrom({ ...params, channelId });
+  const rawAllowFrom = normalizeStringEntries(params.allowFrom ?? []);
+  const rawStoreAllowFrom = normalizeStringEntries(storeAllowFrom);
+  const rawGroupAllowFrom = normalizeStringEntries(params.groupAllowFrom ?? []);
+  const normalizeEffective = (entries: readonly (string | number)[], context: "dm" | "group") =>
+    normalizeEffectiveEntries({ adapter, accountId: params.accountId, entries, context });
+  const [normalizedAllowFrom, normalizedStoreAllowFrom, normalizedGroupAllowFrom] =
+    await Promise.all([
+      normalizeEffective(rawAllowFrom, "dm"),
+      normalizeEffective(rawStoreAllowFrom, "dm"),
+      normalizeEffective(rawGroupAllowFrom, "group"),
+    ]);
+  const referencedAccessGroups = allReferencedAccessGroupNames([
+    rawAllowFrom,
+    rawGroupAllowFrom,
+    rawStoreAllowFrom,
+    params.command?.commandOwnerAllowFrom ?? [],
+    ...routeFacts.map((route) => route.senderAllowFrom ?? []),
+  ]);
+  const runtimeAccessGroupMembership = await resolveRuntimeAccessGroupMembershipFacts({
+    input: params,
+    channelId,
+    names: referencedAccessGroups,
+  });
+  const accessGroupMembership = [
+    ...runtimeAccessGroupMembership,
+    ...(params.accessGroupMembership ?? []),
+  ];
+  const baseEffective = resolveChannelIngressEffectiveAllowFromLists({
+    allowFrom: normalizedAllowFrom,
+    groupAllowFrom: normalizedGroupAllowFrom,
+    storeAllowFrom: normalizedStoreAllowFrom,
+    dmPolicy: params.policy.dmPolicy,
+    groupAllowFromFallbackToAllowFrom: params.policy.groupAllowFromFallbackToAllowFrom,
+  });
+  const rawEffective = resolveChannelIngressEffectiveAllowFromLists({
+    allowFrom: rawAllowFrom,
+    groupAllowFrom: rawGroupAllowFrom,
+    storeAllowFrom: rawStoreAllowFrom,
+    dmPolicy: params.policy.dmPolicy,
+    groupAllowFromFallbackToAllowFrom: params.policy.groupAllowFromFallbackToAllowFrom,
+  });
+  const rawCommandGroup = resolveChannelIngressEffectiveAllowFromLists({
+    allowFrom: rawAllowFrom,
+    groupAllowFrom: rawGroupAllowFrom,
+    dmPolicy: params.policy.dmPolicy,
+    groupAllowFromFallbackToAllowFrom:
+      params.command?.commandGroupAllowFromFallbackToAllowFrom ??
+      params.policy.groupAllowFromFallbackToAllowFrom,
+  });
+  const isGroup = params.conversation.kind !== "direct";
+  const policy: ChannelIngressPolicyInput = {
+    ...params.policy,
+    ...(params.command !== undefined ? { command: params.command } : {}),
+  };
+  const state = await resolveChannelIngressState({
+    channelId,
+    accountId: params.accountId,
+    subject,
+    conversation: params.conversation,
+    adapter,
+    accessGroups: params.accessGroups,
+    accessGroupMembership,
+    routeFacts,
+    mentionFacts: params.mentionFacts,
+    event: params.event,
+    allowlists: {
+      dm: rawAllowFrom,
+      group: rawEffective.effectiveGroupAllowFrom,
+      pairingStore: rawStoreAllowFrom,
+      commandOwner: commandOwnerAllowFrom({
+        command: params.command,
+        isGroup,
+        configuredAllowFrom: rawAllowFrom,
+        effectiveAllowFrom: rawEffective.effectiveAllowFrom,
+      }),
+      commandGroup: commandGroupAllowFrom({
+        command: params.command,
+        isGroup,
+        effectiveCommandGroupAllowFrom: rawCommandGroup.effectiveGroupAllowFrom,
+      }),
+    },
+  });
+  const ingress = decideChannelIngress(state, policy);
+  const matchedAccessGroupEntry = accessGroupMatchedEntry(params);
+  const effectiveAllowFrom = appendAccessGroupMatchedEntry({
+    entries: baseEffective.effectiveAllowFrom,
+    allowlist: state.allowlists.dm,
+    matchedEntry: matchedAccessGroupEntry,
+  });
+  const effectiveGroupAllowFrom = appendAccessGroupMatchedEntry({
+    entries: baseEffective.effectiveGroupAllowFrom,
+    allowlist: state.allowlists.group,
+    matchedEntry: matchedAccessGroupEntry,
+  });
+  const senderAccess = projectSenderAccess({
+    ingress,
+    isGroup,
+    effectiveAllowFrom,
+    effectiveGroupAllowFrom,
+    providerMissingFallbackApplied: params.providerMissingFallbackApplied,
+  });
+  const routeAccess = projectRouteAccess({ ingress, route: params.route });
+  const commandAccess = projectCommandAccess({ ingress, policy });
+  const activationAccess = projectActivationAccess({ ingress });
+  return {
+    state,
+    ingress,
+    senderAccess,
+    routeAccess,
+    commandAccess,
+    activationAccess,
+  };
+}

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -260,7 +260,9 @@ describe("security/dm-policy-shared", () => {
       isSenderAllowed: () => false,
       command: controlCommand,
     });
-    expect(resolved.decision).toBe("allow");
+    // Hardened: open + empty allowFrom now blocks the DM entirely; the control
+    // command remains unauthorized (never auto-granted in open mode).
+    expect(resolved.decision).toBe("block");
     expect(resolved.commandAuthorized).toBe(false);
     expect(resolved.shouldBlockControlCommand).toBe(false);
   });
@@ -355,8 +357,10 @@ describe("security/dm-policy-shared", () => {
         createParityCase({
           name: "dmPolicy=open",
           dmPolicy: "open",
-          expectedDecision: "allow",
-          expectedReactionAllowed: true,
+          // Hardened: open + empty allowFrom (no wildcard, sender not allowlisted)
+          // now fails closed (blocks) rather than allowing all senders.
+          expectedDecision: "block",
+          expectedReactionAllowed: false,
         }),
         createParityCase({
           name: "dmPolicy=disabled",

--- a/src/security/dm-policy-shared.test.ts
+++ b/src/security/dm-policy-shared.test.ts
@@ -328,8 +328,11 @@ describe("security/dm-policy-shared", () => {
       groupAllowFrom: [],
       storeAllowFrom: [],
       isSenderAllowed: () => false,
-      expectedDecision: "allow",
-      expectedReactionAllowed: true,
+      // Default matches the hardened open + empty allowFrom outcome (fail-closed). Every case
+      // below overrides both fields, so this is defense-in-depth: a future bare-default case
+      // cannot silently assert open+empty→allow.
+      expectedDecision: "block",
+      expectedReactionAllowed: false,
       ...overrides,
     };
   }

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -1,9 +1,13 @@
-import { evaluateMatchedGroupAccessForPolicy } from "remoteclaw/plugin-sdk/group-access";
-import { mergeDmAllowFromSources, resolveGroupAllowFromSources } from "../channels/allow-from.js";
+import { resolveGroupAllowFromSources } from "../channels/allow-from.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
+import { resolveDmAllowAuditState } from "../channels/message-access/dm-allow-state.js";
+import {
+  readChannelIngressStoreAllowFromForDmPolicy,
+  resolveChannelIngressEffectiveAllowFromLists,
+} from "../channels/message-access/runtime.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { GroupPolicy } from "../config/types.base.js";
-import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
+import { evaluateMatchedGroupAccessForPolicy } from "../plugin-sdk/group-access.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 
 export function resolvePinnedMainDmOwnerFromAllowlist(params: {
@@ -28,6 +32,7 @@ export function resolvePinnedMainDmOwnerFromAllowlist(params: {
   return normalizedOwners.length === 1 ? normalizedOwners[0] : null;
 }
 
+/** @deprecated Use `resolveChannelMessageIngress` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
 export function resolveEffectiveAllowFromLists(params: {
   allowFrom?: Array<string | number> | null;
   groupAllowFrom?: Array<string | number> | null;
@@ -38,25 +43,7 @@ export function resolveEffectiveAllowFromLists(params: {
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
 } {
-  const allowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : undefined;
-  const groupAllowFrom = Array.isArray(params.groupAllowFrom) ? params.groupAllowFrom : undefined;
-  const storeAllowFrom = Array.isArray(params.storeAllowFrom) ? params.storeAllowFrom : undefined;
-  const effectiveAllowFrom = normalizeStringEntries(
-    mergeDmAllowFromSources({
-      allowFrom,
-      storeAllowFrom,
-      dmPolicy: params.dmPolicy ?? undefined,
-    }),
-  );
-  // Group auth is explicit (groupAllowFrom fallback allowFrom). Pairing store is DM-only.
-  const effectiveGroupAllowFrom = normalizeStringEntries(
-    resolveGroupAllowFromSources({
-      allowFrom,
-      groupAllowFrom,
-      fallbackToAllowFrom: params.groupAllowFromFallbackToAllowFrom ?? undefined,
-    }),
-  );
-  return { effectiveAllowFrom, effectiveGroupAllowFrom };
+  return resolveChannelIngressEffectiveAllowFromLists(params);
 }
 
 export type DmGroupAccessDecision = "allow" | "block" | "pairing";
@@ -73,6 +60,38 @@ export const DM_GROUP_ACCESS_REASON = {
 } as const;
 export type DmGroupAccessReasonCode =
   (typeof DM_GROUP_ACCESS_REASON)[keyof typeof DM_GROUP_ACCESS_REASON];
+type DmGroupAccessResult = {
+  decision: DmGroupAccessDecision;
+  reasonCode: DmGroupAccessReasonCode;
+  reason: string;
+};
+
+const dmGroupAccess = (
+  decision: DmGroupAccessDecision,
+  reasonCode: DmGroupAccessReasonCode,
+  reason: string,
+): DmGroupAccessResult => ({ decision, reasonCode, reason });
+
+/** @deprecated Use `resolveChannelMessageIngress` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
+export function resolveOpenDmAllowlistAccess(params: {
+  effectiveAllowFrom: Array<string | number>;
+  isSenderAllowed: (allowFrom: string[]) => boolean;
+}): DmGroupAccessResult {
+  const effectiveAllowFrom = normalizeStringEntries(params.effectiveAllowFrom);
+  return effectiveAllowFrom.includes("*")
+    ? dmGroupAccess("allow", DM_GROUP_ACCESS_REASON.DM_POLICY_OPEN, "dmPolicy=open")
+    : params.isSenderAllowed(effectiveAllowFrom)
+      ? dmGroupAccess(
+          "allow",
+          DM_GROUP_ACCESS_REASON.DM_POLICY_ALLOWLISTED,
+          "dmPolicy=open (allowlisted)",
+        )
+      : dmGroupAccess(
+          "block",
+          DM_GROUP_ACCESS_REASON.DM_POLICY_NOT_ALLOWLISTED,
+          "dmPolicy=open (not allowlisted)",
+        );
+}
 
 type DmGroupAccessInputParams = {
   isGroup: boolean;
@@ -85,6 +104,33 @@ type DmGroupAccessInputParams = {
   isSenderAllowed: (allowFrom: string[]) => boolean;
 };
 
+const GROUP_ACCESS_RESULT: Record<
+  Exclude<ReturnType<typeof evaluateMatchedGroupAccessForPolicy>["reason"], "allowed">,
+  DmGroupAccessResult
+> = {
+  disabled: dmGroupAccess(
+    "block",
+    DM_GROUP_ACCESS_REASON.GROUP_POLICY_DISABLED,
+    "groupPolicy=disabled",
+  ),
+  empty_allowlist: dmGroupAccess(
+    "block",
+    DM_GROUP_ACCESS_REASON.GROUP_POLICY_EMPTY_ALLOWLIST,
+    "groupPolicy=allowlist (empty allowlist)",
+  ),
+  missing_match_input: dmGroupAccess(
+    "block",
+    DM_GROUP_ACCESS_REASON.GROUP_POLICY_NOT_ALLOWLISTED,
+    "groupPolicy=allowlist (not allowlisted)",
+  ),
+  not_allowlisted: dmGroupAccess(
+    "block",
+    DM_GROUP_ACCESS_REASON.GROUP_POLICY_NOT_ALLOWLISTED,
+    "groupPolicy=allowlist (not allowlisted)",
+  ),
+};
+
+/** @deprecated Use `resolveChannelMessageIngress` or `readChannelIngressStoreAllowFromForDmPolicy` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
 export async function readStoreAllowFromForDmPolicy(params: {
   provider: ChannelId;
   accountId: string;
@@ -92,16 +138,10 @@ export async function readStoreAllowFromForDmPolicy(params: {
   shouldRead?: boolean | null;
   readStore?: (provider: ChannelId, accountId: string) => Promise<string[]>;
 }): Promise<string[]> {
-  if (params.shouldRead === false || params.dmPolicy === "allowlist") {
-    return [];
-  }
-  const readStore =
-    params.readStore ??
-    ((provider: ChannelId, accountId: string) =>
-      readChannelAllowFromStore(provider, process.env, accountId));
-  return await readStore(params.provider, params.accountId).catch(() => []);
+  return await readChannelIngressStoreAllowFromForDmPolicy(params);
 }
 
+/** @deprecated Use `resolveChannelMessageIngress` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
 export function resolveDmGroupAccessDecision(params: {
   isGroup: boolean;
   dmPolicy?: string | null;
@@ -109,11 +149,7 @@ export function resolveDmGroupAccessDecision(params: {
   effectiveAllowFrom: Array<string | number>;
   effectiveGroupAllowFrom: Array<string | number>;
   isSenderAllowed: (allowFrom: string[]) => boolean;
-}): {
-  decision: DmGroupAccessDecision;
-  reasonCode: DmGroupAccessReasonCode;
-  reason: string;
-} {
+}): DmGroupAccessResult {
   const dmPolicy = params.dmPolicy ?? "pairing";
   const groupPolicy: GroupPolicy =
     params.groupPolicy === "open" || params.groupPolicy === "disabled"
@@ -128,73 +164,57 @@ export function resolveDmGroupAccessDecision(params: {
       allowlistConfigured: effectiveGroupAllowFrom.length > 0,
       allowlistMatched: params.isSenderAllowed(effectiveGroupAllowFrom),
     });
-
-    if (!groupAccess.allowed) {
-      if (groupAccess.reason === "disabled") {
-        return {
-          decision: "block",
-          reasonCode: DM_GROUP_ACCESS_REASON.GROUP_POLICY_DISABLED,
-          reason: "groupPolicy=disabled",
-        };
-      }
-      if (groupAccess.reason === "empty_allowlist") {
-        return {
-          decision: "block",
-          reasonCode: DM_GROUP_ACCESS_REASON.GROUP_POLICY_EMPTY_ALLOWLIST,
-          reason: "groupPolicy=allowlist (empty allowlist)",
-        };
-      }
-      if (groupAccess.reason === "not_allowlisted") {
-        return {
-          decision: "block",
-          reasonCode: DM_GROUP_ACCESS_REASON.GROUP_POLICY_NOT_ALLOWLISTED,
-          reason: "groupPolicy=allowlist (not allowlisted)",
-        };
-      }
+    if (groupAccess.allowed) {
+      return dmGroupAccess(
+        "allow",
+        DM_GROUP_ACCESS_REASON.GROUP_POLICY_ALLOWED,
+        `groupPolicy=${groupPolicy}`,
+      );
     }
-
-    return {
-      decision: "allow",
-      reasonCode: DM_GROUP_ACCESS_REASON.GROUP_POLICY_ALLOWED,
-      reason: `groupPolicy=${groupPolicy}`,
-    };
+    switch (groupAccess.reason) {
+      case "disabled":
+      case "empty_allowlist":
+      case "missing_match_input":
+      case "not_allowlisted":
+        return GROUP_ACCESS_RESULT[groupAccess.reason];
+      case "allowed":
+        return dmGroupAccess(
+          "allow",
+          DM_GROUP_ACCESS_REASON.GROUP_POLICY_ALLOWED,
+          `groupPolicy=${groupPolicy}`,
+        );
+    }
   }
 
   if (dmPolicy === "disabled") {
-    return {
-      decision: "block",
-      reasonCode: DM_GROUP_ACCESS_REASON.DM_POLICY_DISABLED,
-      reason: "dmPolicy=disabled",
-    };
+    return dmGroupAccess("block", DM_GROUP_ACCESS_REASON.DM_POLICY_DISABLED, "dmPolicy=disabled");
   }
   if (dmPolicy === "open") {
-    return {
-      decision: "allow",
-      reasonCode: DM_GROUP_ACCESS_REASON.DM_POLICY_OPEN,
-      reason: "dmPolicy=open",
-    };
+    return resolveOpenDmAllowlistAccess({
+      effectiveAllowFrom,
+      isSenderAllowed: params.isSenderAllowed,
+    });
   }
-  if (params.isSenderAllowed(effectiveAllowFrom)) {
-    return {
-      decision: "allow",
-      reasonCode: DM_GROUP_ACCESS_REASON.DM_POLICY_ALLOWLISTED,
-      reason: `dmPolicy=${dmPolicy} (allowlisted)`,
-    };
-  }
-  if (dmPolicy === "pairing") {
-    return {
-      decision: "pairing",
-      reasonCode: DM_GROUP_ACCESS_REASON.DM_POLICY_PAIRING_REQUIRED,
-      reason: "dmPolicy=pairing (not allowlisted)",
-    };
-  }
-  return {
-    decision: "block",
-    reasonCode: DM_GROUP_ACCESS_REASON.DM_POLICY_NOT_ALLOWLISTED,
-    reason: `dmPolicy=${dmPolicy} (not allowlisted)`,
-  };
+  return params.isSenderAllowed(effectiveAllowFrom)
+    ? dmGroupAccess(
+        "allow",
+        DM_GROUP_ACCESS_REASON.DM_POLICY_ALLOWLISTED,
+        `dmPolicy=${dmPolicy} (allowlisted)`,
+      )
+    : dmPolicy === "pairing"
+      ? dmGroupAccess(
+          "pairing",
+          DM_GROUP_ACCESS_REASON.DM_POLICY_PAIRING_REQUIRED,
+          "dmPolicy=pairing (not allowlisted)",
+        )
+      : dmGroupAccess(
+          "block",
+          DM_GROUP_ACCESS_REASON.DM_POLICY_NOT_ALLOWLISTED,
+          `dmPolicy=${dmPolicy} (not allowlisted)`,
+        );
 }
 
+/** @deprecated Use `resolveChannelMessageIngress` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
 export function resolveDmGroupAccessWithLists(params: DmGroupAccessInputParams): {
   decision: DmGroupAccessDecision;
   reasonCode: DmGroupAccessReasonCode;
@@ -224,6 +244,7 @@ export function resolveDmGroupAccessWithLists(params: DmGroupAccessInputParams):
   };
 }
 
+/** @deprecated Use `resolveChannelMessageIngress` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
 export function resolveDmGroupAccessWithCommandGate(
   params: DmGroupAccessInputParams & {
     command?: {
@@ -234,6 +255,7 @@ export function resolveDmGroupAccessWithCommandGate(
   },
 ): {
   decision: DmGroupAccessDecision;
+  reasonCode: DmGroupAccessReasonCode;
   reason: string;
   effectiveAllowFrom: string[];
   effectiveGroupAllowFrom: string[];
@@ -264,19 +286,17 @@ export function resolveDmGroupAccessWithCommandGate(
   const commandGroupAllowFrom = params.isGroup
     ? configuredGroupAllowFrom
     : access.effectiveGroupAllowFrom;
-  const ownerAllowedForCommands = params.isSenderAllowed(commandDmAllowFrom);
-  const groupAllowedForCommands = params.isSenderAllowed(commandGroupAllowFrom);
   const commandGate = params.command
     ? resolveControlCommandGate({
         useAccessGroups: params.command.useAccessGroups,
         authorizers: [
           {
             configured: commandDmAllowFrom.length > 0,
-            allowed: ownerAllowedForCommands,
+            allowed: params.isSenderAllowed(commandDmAllowFrom),
           },
           {
             configured: commandGroupAllowFrom.length > 0,
-            allowed: groupAllowedForCommands,
+            allowed: params.isSenderAllowed(commandGroupAllowFrom),
           },
         ],
         allowTextCommands: params.command.allowTextCommands,
@@ -291,10 +311,12 @@ export function resolveDmGroupAccessWithCommandGate(
   };
 }
 
+/** @deprecated Use `resolveChannelMessageIngress` from `remoteclaw/plugin-sdk/channel-ingress-runtime`. */
 export async function resolveDmAllowState(params: {
   provider: ChannelId;
   accountId: string;
   allowFrom?: Array<string | number> | null;
+  dmPolicy?: string | null;
   normalizeEntry?: (raw: string) => string;
   readStore?: (provider: ChannelId, accountId: string) => Promise<string[]>;
 }): Promise<{
@@ -303,30 +325,5 @@ export async function resolveDmAllowState(params: {
   allowCount: number;
   isMultiUserDm: boolean;
 }> {
-  const configAllowFrom = normalizeStringEntries(
-    Array.isArray(params.allowFrom) ? params.allowFrom : undefined,
-  );
-  const hasWildcard = configAllowFrom.includes("*");
-  const storeAllowFrom = await readStoreAllowFromForDmPolicy({
-    provider: params.provider,
-    accountId: params.accountId,
-    readStore: params.readStore,
-  });
-  const normalizeEntry = params.normalizeEntry ?? ((value: string) => value);
-  const normalizedCfg = configAllowFrom
-    .filter((value) => value !== "*")
-    .map((value) => normalizeEntry(value))
-    .map((value) => value.trim())
-    .filter(Boolean);
-  const normalizedStore = storeAllowFrom
-    .map((value) => normalizeEntry(value))
-    .map((value) => value.trim())
-    .filter(Boolean);
-  const allowCount = new Set([...normalizedCfg, ...normalizedStore]).size;
-  return {
-    configAllowFrom,
-    hasWildcard,
-    allowCount,
-    isMultiUserDm: hasWildcard || allowCount > 1,
-  };
+  return await resolveDmAllowAuditState(params);
 }


### PR DESCRIPTION
## Summary

Adopts OpenClaw's channel-SDK **message-access ingress** layer so the fork's inbound DM/group access-control gate runs on the single upstream-maintained implementation instead of a frozen local copy.

- **Add the 3 missing `message-access/` modules** — `runtime.ts`, `index.ts`, `dm-allow-state.ts`. The other 8 modules in `src/channels/message-access/` were already byte-identical to upstream `v2026.5.27`.
- **Replace `src/security/dm-policy-shared.ts`** with upstream's `@deprecated` delegating shim. Existing call sites keep their imports byte-unchanged (identical public surface); decision, list-resolution, store-read and audit-state now delegate into the one `message-access/` gate rather than a divergent local copy.
- **Fork adaptations only:** repoint the two imports the fork consolidated (`plugins/types.public` → `plugins/types`; `pairing/pairing-store.types` → `pairing/pairing-store`) and narrow one channel-id return to the fork's `ChatChannelId` union. The diff against upstream is otherwise verbatim.

## Security hardening

Closes a weak `dmPolicy=open` path. The previous shim allowed **every** DM unconditionally when `dmPolicy=open`. The adopted gate routes `open` through allowlist-wins resolution:

- wildcard `"*"` in the allowlist → **allow all**
- an allowlisted sender → **allow**
- every other sender → **BLOCK**

## Config migration (behavior change)

A bare `dmPolicy=open` with an **empty** allowlist now resolves to **block-all** instead of allow-all. Operators who relied on `open` meaning allow-all must set `allowFrom: ["*"]` to preserve that behavior.

## Verification

- `pnpm check` (format + typecheck + oxlint + fork-integrity gates): **green** — 0 warnings, 0 errors.
- Public surface preserved: all existing `dm-policy-shared` importers keep their imports unchanged; the shim re-exports the identical surface with additive-only signature changes.
- Diff vs upstream `v2026.5.27` confirmed verbatim except the documented repoints, one narrowing cast, and the fork rebrand of the `@deprecated` pointers.

## Scope

Ingress / security layer only. The channel factory, the `message/` adapter layer, the per-adapter `ChannelPlugin` rewrites, and `turn/` / `inbound-event/` / `status/` are intentionally out of scope for this change and left for a follow-up.
