### PR TITLE
feat(plugin-sdk): carve channel-plugin factory (createChatChannelPlugin) into the fork

### DIFF
--- a/src/channels/plugins/threading-helpers.ts
+++ b/src/channels/plugins/threading-helpers.ts
@@ -1,0 +1,32 @@
+import type { RemoteClawConfig } from "../../config/config.js";
+import type { ReplyToMode } from "../../config/types.base.js";
+import type { ChannelThreadingAdapter } from "./types.core.js";
+
+type ReplyToModeResolver = NonNullable<ChannelThreadingAdapter["resolveReplyToMode"]>;
+
+export function createStaticReplyToModeResolver(mode: ReplyToMode): ReplyToModeResolver {
+  return () => mode;
+}
+
+export function createTopLevelChannelReplyToModeResolver(channelId: string): ReplyToModeResolver {
+  return ({ cfg }) => {
+    const channelConfig = (
+      cfg.channels as Record<string, { replyToMode?: ReplyToMode }> | undefined
+    )?.[channelId];
+    return channelConfig?.replyToMode ?? "off";
+  };
+}
+
+export function createScopedAccountReplyToModeResolver<TAccount>(params: {
+  resolveAccount: (cfg: RemoteClawConfig, accountId?: string | null) => TAccount;
+  resolveReplyToMode: (
+    account: TAccount,
+    chatType?: string | null,
+  ) => ReplyToMode | null | undefined;
+  fallback?: ReplyToMode;
+}): ReplyToModeResolver {
+  return ({ cfg, accountId, chatType }) =>
+    params.resolveReplyToMode(params.resolveAccount(cfg, accountId), chatType) ??
+    params.fallback ??
+    "off";
+}

--- a/src/plugin-sdk/channel-core.ts
+++ b/src/plugin-sdk/channel-core.ts
@@ -1,0 +1,333 @@
+// Channel-plugin factory carved from upstream OpenClaw `src/plugin-sdk/core.ts`
+// (v5.27) into the RemoteClaw fork. The fork's own `plugin-sdk/core.ts` is a
+// gutted barrel; the real chat-channel builders live here so channel adapters
+// can import them without dragging the gutted execution runtime. Wired to the
+// fork-kept `channels/plugins/helpers.js`, the fork's channel `registry.js`
+// (`getChatChannelMeta`), the `types.*` modules, and the ported
+// `channels/plugins/threading-helpers.js` helper.
+//
+// Adapted to the fork's leaner channel-plugin surface: upstream v5.27 fields
+// absent in the fork are dropped rather than reintroduced — `conversationBindings`,
+// `setupWizard`/`doctor`/`gatewayMethodDescriptors` (not on `ChannelPlugin`),
+// `collectAuditFindings` (not on `ChannelSecurityAdapter`), and
+// `inheritSharedDefaultsFromDefaultAccount` (not on `buildAccountScopedDmSecurityPolicy`).
+import { buildAccountScopedDmSecurityPolicy } from "../channels/plugins/helpers.js";
+import {
+  createScopedAccountReplyToModeResolver,
+  createTopLevelChannelReplyToModeResolver,
+} from "../channels/plugins/threading-helpers.js";
+import type {
+  ChannelOutboundAdapter,
+  ChannelPairingAdapter,
+  ChannelSecurityAdapter,
+} from "../channels/plugins/types.adapters.js";
+import type {
+  ChannelId,
+  ChannelMeta,
+  ChannelPollResult,
+  ChannelThreadingAdapter,
+} from "../channels/plugins/types.core.js";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import { getChatChannelMeta, normalizeChatChannelId } from "../channels/registry.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import type { ReplyToMode } from "../config/types.base.js";
+import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
+
+function createInlineTextPairingAdapter(params: {
+  idLabel: string;
+  message: string;
+  normalizeAllowEntry?: ChannelPairingAdapter["normalizeAllowEntry"];
+  notify: (
+    params: Parameters<NonNullable<ChannelPairingAdapter["notifyApproval"]>>[0] & {
+      message: string;
+    },
+  ) => Promise<void> | void;
+}): ChannelPairingAdapter {
+  return {
+    idLabel: params.idLabel,
+    normalizeAllowEntry: params.normalizeAllowEntry,
+    notifyApproval: async (ctx) => {
+      await params.notify({ ...ctx, message: params.message });
+    },
+  };
+}
+
+// The fork resolves bundled chat-channel metadata via its own channel registry
+// (`getChatChannelMeta`), which is precomputed at module load. `ChannelPlugin`
+// ids are the broad `ChannelId`; normalize to a known chat channel first and
+// fall back to `undefined` for non-bundled ids (spreading `undefined` is a no-op).
+function resolveSdkChatChannelMeta(id: ChannelId): ChannelMeta | undefined {
+  const channelId = normalizeChatChannelId(id);
+  return channelId ? getChatChannelMeta(channelId) : undefined;
+}
+
+export type CreateChannelPluginBaseOptions<TResolvedAccount> = {
+  id: ChannelPlugin<TResolvedAccount>["id"];
+  meta?: Partial<NonNullable<ChannelPlugin<TResolvedAccount>["meta"]>>;
+  capabilities?: ChannelPlugin<TResolvedAccount>["capabilities"];
+  commands?: ChannelPlugin<TResolvedAccount>["commands"];
+  agentPrompt?: ChannelPlugin<TResolvedAccount>["agentPrompt"];
+  streaming?: ChannelPlugin<TResolvedAccount>["streaming"];
+  reload?: ChannelPlugin<TResolvedAccount>["reload"];
+  gatewayMethods?: ChannelPlugin<TResolvedAccount>["gatewayMethods"];
+  configSchema?: ChannelPlugin<TResolvedAccount>["configSchema"];
+  config?: ChannelPlugin<TResolvedAccount>["config"];
+  security?: ChannelPlugin<TResolvedAccount>["security"];
+  setup: NonNullable<ChannelPlugin<TResolvedAccount>["setup"]>;
+  groups?: ChannelPlugin<TResolvedAccount>["groups"];
+};
+
+export type CreatedChannelPluginBase<TResolvedAccount> = Pick<
+  ChannelPlugin<TResolvedAccount>,
+  "id" | "meta" | "setup"
+> &
+  Partial<
+    Pick<
+      ChannelPlugin<TResolvedAccount>,
+      | "capabilities"
+      | "commands"
+      | "agentPrompt"
+      | "streaming"
+      | "reload"
+      | "gatewayMethods"
+      | "configSchema"
+      | "config"
+      | "security"
+      | "groups"
+    >
+  >;
+
+export type ChatChannelPluginBase<TResolvedAccount, Probe, Audit> = Omit<
+  ChannelPlugin<TResolvedAccount, Probe, Audit>,
+  "security" | "pairing" | "threading" | "outbound"
+> &
+  Partial<
+    Pick<
+      ChannelPlugin<TResolvedAccount, Probe, Audit>,
+      "security" | "pairing" | "threading" | "outbound"
+    >
+  >;
+
+export type ChatChannelSecurityOptions<TResolvedAccount extends { accountId?: string | null }> = {
+  dm: {
+    channelKey: string;
+    resolvePolicy: (account: TResolvedAccount) => string | null | undefined;
+    resolveAllowFrom: (account: TResolvedAccount) => Array<string | number> | null | undefined;
+    resolveFallbackAccountId?: (account: TResolvedAccount) => string | null | undefined;
+    defaultPolicy?: string;
+    allowFromPathSuffix?: string;
+    policyPathSuffix?: string;
+    approveChannelId?: string;
+    approveHint?: string;
+    normalizeEntry?: (raw: string) => string;
+  };
+  collectWarnings?: ChannelSecurityAdapter<TResolvedAccount>["collectWarnings"];
+};
+
+export type ChatChannelPairingOptions = {
+  text: {
+    idLabel: string;
+    message: string;
+    normalizeAllowEntry?: ChannelPairingAdapter["normalizeAllowEntry"];
+    notify: (
+      params: Parameters<NonNullable<ChannelPairingAdapter["notifyApproval"]>>[0] & {
+        message: string;
+      },
+    ) => Promise<void> | void;
+  };
+};
+
+export type ChatChannelThreadingReplyModeOptions<TResolvedAccount> =
+  | { topLevelReplyToMode: string }
+  | {
+      scopedAccountReplyToMode: {
+        resolveAccount: (cfg: RemoteClawConfig, accountId?: string | null) => TResolvedAccount;
+        resolveReplyToMode: (
+          account: TResolvedAccount,
+          chatType?: string | null,
+        ) => ReplyToMode | null | undefined;
+        fallback?: ReplyToMode;
+      };
+    }
+  | {
+      resolveReplyToMode: NonNullable<ChannelThreadingAdapter["resolveReplyToMode"]>;
+    };
+
+export type ChatChannelThreadingOptions<TResolvedAccount> =
+  ChatChannelThreadingReplyModeOptions<TResolvedAccount> &
+    Omit<ChannelThreadingAdapter, "resolveReplyToMode">;
+
+export type ChatChannelAttachedOutboundOptions = {
+  base: Omit<ChannelOutboundAdapter, "sendText" | "sendMedia" | "sendPoll">;
+  attachedResults: {
+    channel: string;
+    sendText?: (
+      ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0],
+    ) => MaybePromise<Omit<OutboundDeliveryResult, "channel">>;
+    sendMedia?: (
+      ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendMedia"]>>[0],
+    ) => MaybePromise<Omit<OutboundDeliveryResult, "channel">>;
+    sendPoll?: (
+      ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendPoll"]>>[0],
+    ) => MaybePromise<Omit<ChannelPollResult, "channel">>;
+  };
+};
+
+type MaybePromise<T> = T | Promise<T>;
+
+function createInlineAttachedChannelResultAdapter(
+  params: ChatChannelAttachedOutboundOptions["attachedResults"],
+) {
+  return {
+    sendText: params.sendText
+      ? async (ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0]) => ({
+          channel: params.channel,
+          ...(await params.sendText!(ctx)),
+        })
+      : undefined,
+    sendMedia: params.sendMedia
+      ? async (ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendMedia"]>>[0]) => ({
+          channel: params.channel,
+          ...(await params.sendMedia!(ctx)),
+        })
+      : undefined,
+    sendPoll: params.sendPoll
+      ? async (ctx: Parameters<NonNullable<ChannelOutboundAdapter["sendPoll"]>>[0]) => ({
+          channel: params.channel,
+          ...(await params.sendPoll!(ctx)),
+        })
+      : undefined,
+  } satisfies Pick<ChannelOutboundAdapter, "sendText" | "sendMedia" | "sendPoll">;
+}
+
+function resolveChatChannelSecurity<TResolvedAccount extends { accountId?: string | null }>(
+  security:
+    | ChannelSecurityAdapter<TResolvedAccount>
+    | ChatChannelSecurityOptions<TResolvedAccount>
+    | undefined,
+): ChannelSecurityAdapter<TResolvedAccount> | undefined {
+  if (!security) {
+    return undefined;
+  }
+  if (!("dm" in security)) {
+    return security;
+  }
+  return {
+    resolveDmPolicy: ({ cfg, accountId, account }) =>
+      buildAccountScopedDmSecurityPolicy({
+        cfg,
+        channelKey: security.dm.channelKey,
+        accountId,
+        fallbackAccountId: security.dm.resolveFallbackAccountId?.(account) ?? account.accountId,
+        policy: security.dm.resolvePolicy(account),
+        allowFrom: security.dm.resolveAllowFrom(account) ?? [],
+        defaultPolicy: security.dm.defaultPolicy,
+        allowFromPathSuffix: security.dm.allowFromPathSuffix,
+        policyPathSuffix: security.dm.policyPathSuffix,
+        approveChannelId: security.dm.approveChannelId,
+        approveHint: security.dm.approveHint,
+        normalizeEntry: security.dm.normalizeEntry,
+      }),
+    ...(security.collectWarnings ? { collectWarnings: security.collectWarnings } : {}),
+  };
+}
+
+function resolveChatChannelPairing(
+  pairing: ChannelPairingAdapter | ChatChannelPairingOptions | undefined,
+): ChannelPairingAdapter | undefined {
+  if (!pairing) {
+    return undefined;
+  }
+  if (!("text" in pairing)) {
+    return pairing;
+  }
+  return createInlineTextPairingAdapter(pairing.text);
+}
+
+function resolveChatChannelThreading<TResolvedAccount>(
+  threading: ChannelThreadingAdapter | ChatChannelThreadingOptions<TResolvedAccount> | undefined,
+): ChannelThreadingAdapter | undefined {
+  if (!threading) {
+    return undefined;
+  }
+  if (!("topLevelReplyToMode" in threading) && !("scopedAccountReplyToMode" in threading)) {
+    return threading;
+  }
+
+  let resolveReplyToMode: ChannelThreadingAdapter["resolveReplyToMode"];
+  if ("topLevelReplyToMode" in threading) {
+    resolveReplyToMode = createTopLevelChannelReplyToModeResolver(threading.topLevelReplyToMode);
+  } else {
+    resolveReplyToMode = createScopedAccountReplyToModeResolver<TResolvedAccount>(
+      threading.scopedAccountReplyToMode,
+    );
+  }
+
+  return {
+    ...threading,
+    resolveReplyToMode,
+  };
+}
+
+function resolveChatChannelOutbound(
+  outbound: ChannelOutboundAdapter | ChatChannelAttachedOutboundOptions | undefined,
+): ChannelOutboundAdapter | undefined {
+  if (!outbound) {
+    return undefined;
+  }
+  if (!("attachedResults" in outbound)) {
+    return outbound;
+  }
+  return {
+    ...outbound.base,
+    ...createInlineAttachedChannelResultAdapter(outbound.attachedResults),
+  };
+}
+
+// Shared higher-level builder for chat-style channels that mostly compose
+// scoped DM security, text pairing, reply threading, and attached send results.
+export function createChatChannelPlugin<
+  TResolvedAccount extends { accountId?: string | null },
+  Probe = unknown,
+  Audit = unknown,
+>(params: {
+  base: ChatChannelPluginBase<TResolvedAccount, Probe, Audit>;
+  security?:
+    | ChannelSecurityAdapter<TResolvedAccount>
+    | ChatChannelSecurityOptions<TResolvedAccount>;
+  pairing?: ChannelPairingAdapter | ChatChannelPairingOptions;
+  threading?: ChannelThreadingAdapter | ChatChannelThreadingOptions<TResolvedAccount>;
+  outbound?: ChannelOutboundAdapter | ChatChannelAttachedOutboundOptions;
+}): ChannelPlugin<TResolvedAccount, Probe, Audit> {
+  return {
+    ...params.base,
+    ...(params.security ? { security: resolveChatChannelSecurity(params.security) } : {}),
+    ...(params.pairing ? { pairing: resolveChatChannelPairing(params.pairing) } : {}),
+    ...(params.threading ? { threading: resolveChatChannelThreading(params.threading) } : {}),
+    ...(params.outbound ? { outbound: resolveChatChannelOutbound(params.outbound) } : {}),
+  } as ChannelPlugin<TResolvedAccount, Probe, Audit>;
+}
+
+// Shared base object for channel plugins that only need to override a few optional surfaces.
+export function createChannelPluginBase<TResolvedAccount>(
+  params: CreateChannelPluginBaseOptions<TResolvedAccount>,
+): CreatedChannelPluginBase<TResolvedAccount> {
+  return {
+    id: params.id,
+    meta: {
+      ...resolveSdkChatChannelMeta(params.id),
+      ...params.meta,
+    },
+    ...(params.capabilities ? { capabilities: params.capabilities } : {}),
+    ...(params.commands ? { commands: params.commands } : {}),
+    ...(params.agentPrompt ? { agentPrompt: params.agentPrompt } : {}),
+    ...(params.streaming ? { streaming: params.streaming } : {}),
+    ...(params.reload ? { reload: params.reload } : {}),
+    ...(params.gatewayMethods ? { gatewayMethods: params.gatewayMethods } : {}),
+    ...(params.configSchema ? { configSchema: params.configSchema } : {}),
+    ...(params.config ? { config: params.config } : {}),
+    ...(params.security ? { security: params.security } : {}),
+    ...(params.groups ? { groups: params.groups } : {}),
+    setup: params.setup,
+  } as CreatedChannelPluginBase<TResolvedAccount>;
+}


### PR DESCRIPTION
Adopt upstream v2026.5.27's channel-plugin factory `createChatChannelPlugin` into the fork via a gut-clean **carve** (factory-first; adapter migrations follow in later PRs). This converges the fork's ~20 hand-built channel adapters onto upstream's shared plugin factory over a sequence of small PRs — this first one lands the factory itself with **zero adapter changes**.

## What

- New `src/plugin-sdk/channel-core.ts` (real implementation): `createChatChannelPlugin`, `createChannelPluginBase`, the carved option types (`ChatChannel*Options`, `CreateChannelPluginBaseOptions`, `CreatedChannelPluginBase`), and 6 module-private resolver helpers.
- New `src/channels/plugins/threading-helpers.ts` (ported verbatim from upstream, rebranded).
- **Zero adapters touched.** The factory is inert — not barrel-exported; nothing imports it yet.

## Why carve, not adopt the file wholesale

At v2026.5.27 upstream's `channel-core.ts` is a thin re-export shim over `core.ts`; importing it whole evaluates the entire `core.ts` barrel, which drags in ~184 execution-engine modules this fork deliberately guts (Pi runtime, model-provider registry, context compaction). The factory *functions* themselves are pure object-spread — carving them and wiring to the fork's existing helpers reaches **zero gutted-runtime import edges**.

## Fork adaptations (all forced by the fork's leaner type surface; verified non-regressive)

- `resolveSdkChatChannelMeta` re-wired to the fork's existing `getChatChannelMeta` (`channels/registry.ts`) rather than duplicating upstream's meta-helper chain (the fork narrowed `ChatChannelId` and trimmed `ChannelMeta`).
- Dropped fields absent from the fork's types: `conversationBindings`, `setupWizard`, `doctor`, `gatewayMethodDescriptors` (fork `ChannelPlugin`), `collectAuditFindings` (fork `ChannelSecurityAdapter`), `inheritSharedDefaultsFromDefaultAccount` (fork `buildAccountScopedDmSecurityPolicy`).
- `resolveChatChannelSecurity` forwards all 11 DM-security parameters the fork's `buildAccountScopedDmSecurityPolicy` accepts, byte-identically (including the `?? account.accountId` and `?? []` fallbacks).

## Verification

- `pnpm check` green; `tsgo` 0 errors; rebrand-leakage check clean; no gutted-runtime edges.
- Independent adversarial security review: **CLEAN**. It confirmed the factory's `resolveDmPolicy` feeds only the audit/doctor diagnostic surface (`security/audit-channel.ts`, `commands/doctor-security.ts`), **not** the live inbound-DM allow/block gate (`channels/message-access/sender-gates.ts`) — so this diff cannot regress the live DM gate, and its blast radius is bounded to diagnostics. Both dropped security-adjacent params were confirmed unreachable in the fork (the fork's types never carried them).
