### PR TITLE
fix(channels): wire botLoopProtection end-to-end (restore dropped bot-loop guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Breaking
 
+- **Bot-loop protection now wired end-to-end and enabled by default
+  ([remoteclaw#2868](https://github.com/remoteclaw/remoteclaw/issues/2868)):**
+  The `botLoopProtection` channel setting was previously advertised but inert —
+  the strict config schema rejected it and no adapter consumed it. It is now
+  accepted (additive, all-optional fields) and enforced on the inbound path of
+  the Discord, Google Chat, and Slack adapters, suppressing runaway bot-to-bot
+  message loops. It defaults **on** (`maxEventsPerWindow: 20`, `windowSeconds:
+60`, `cooldownSeconds: 60`), so an existing `allowBots: true` setup with no
+  `botLoopProtection` block now suppresses a bot pair after 20 messages in 60
+  seconds where it previously dispatched unconditionally. To keep the prior
+  behavior, set `botLoopProtection.enabled: false` or raise `maxEventsPerWindow`.
+  Matrix is not yet wired (its inbound path lacks the required configured-bot-sender
+  machinery).
+
 - **Security — fail closed on `dmPolicy: open` without an allowlist
   ([remoteclaw#2870](https://github.com/remoteclaw/remoteclaw/pull/2870)):**
   Direct-message access under `dmPolicy: open` now routes through the adopted

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -776,6 +776,23 @@ export async function preflightDiscordMessage(
   logDebug(
     `[discord-preflight] success: route=${effectiveRoute.agentId} sessionKey=${effectiveRoute.sessionKey}`,
   );
+  const botLoopProtection =
+    author.bot &&
+    !sender.isPluralKit &&
+    allowBotsMode !== "off" &&
+    params.botUserId &&
+    author.id !== params.botUserId
+      ? {
+          scopeId: params.accountId,
+          conversationId: messageChannelId,
+          senderId: author.id,
+          receiverId: params.botUserId,
+          config: params.discordConfig?.botLoopProtection,
+          defaultsConfig: params.cfg.channels?.defaults?.botLoopProtection,
+          defaultEnabled: true,
+          nowMs: resolveTimestampMs(message.timestamp),
+        }
+      : undefined;
   return {
     cfg: params.cfg,
     discordConfig: params.discordConfig,
@@ -835,5 +852,6 @@ export async function preflightDiscordMessage(
     historyEntry,
     threadBindings: params.threadBindings,
     discordRestFetch: params.discordRestFetch,
+    botLoopProtection,
   };
 }

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -1,5 +1,6 @@
 import type { ChannelType, Client, User } from "@buape/carbon";
 import type { HistoryEntry } from "../../../../src/auto-reply/reply/history.js";
+import type { ChannelBotLoopProtectionFacts } from "../../../../src/channels/turn/bot-loop-protection.js";
 import type { ReplyToMode } from "../../../../src/config/config.js";
 import type { SessionBindingRecord } from "../../../../src/infra/outbound/session-binding-service.js";
 import type { resolveAgentRoute } from "../../../../src/routing/resolve-route.js";
@@ -91,6 +92,13 @@ export type DiscordMessagePreflightContext = DiscordMessagePreflightSharedFields
   historyEntry?: HistoryEntry;
   threadBindings: DiscordThreadBindingLookup;
   discordRestFetch?: typeof fetch;
+
+  /**
+   * Bot-to-bot loop protection facts, assembled during preflight when the
+   * message is bot-authored, allowBots-admitted, and not self-authored.
+   * Consumed by the process step to short-circuit before dispatch.
+   */
+  botLoopProtection?: ChannelBotLoopProtectionFacts;
 };
 
 export type DiscordMessagePreflightParams = DiscordMessagePreflightSharedFields & {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_TIMING,
   type StatusReactionAdapter,
 } from "../../../../src/channels/status-reactions.js";
+import { recordChannelBotPairLoopAndCheckSuppression } from "../../../../src/channels/turn/bot-loop-protection.js";
 import { createTypingCallbacks } from "../../../../src/channels/typing.js";
 import { isDangerousNameMatchingEnabled } from "../../../../src/config/dangerous-name-matching.js";
 import { resolveDiscordPreviewStreamMode } from "../../../../src/config/discord-preview-streaming.js";
@@ -129,9 +130,22 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     commandAuthorized,
     discordRestFetch,
     abortSignal,
+    botLoopProtection,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
     return;
+  }
+  if (botLoopProtection) {
+    const botLoopResult = recordChannelBotPairLoopAndCheckSuppression(botLoopProtection);
+    if (botLoopResult.suppressed) {
+      logVerbose(
+        `discord: bot-to-bot loop detected before dispatch setup, suppressing for ${Math.max(
+          0,
+          Math.ceil((botLoopResult.cooldownUntilMs - Date.now()) / 1000),
+        )}s`,
+      );
+      return;
+    }
   }
 
   const ssrfPolicy = cfg.browser?.ssrfPolicy;

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,8 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/googlechat";
+import type {
+  ChannelBotLoopProtectionFacts,
+  RemoteClawConfig,
+} from "remoteclaw/plugin-sdk/googlechat";
 import {
   createWebhookInFlightLimiter,
   createReplyPrefixOptions,
+  recordChannelBotPairLoopAndCheckSuppression,
   registerWebhookTargetWithPluginRoute,
   resolveInboundRouteEnvelopeBuilderWithRuntime,
   resolveWebhookPath,
@@ -104,6 +108,14 @@ function resolveBotDisplayName(params: {
   return "RemoteClaw";
 }
 
+function resolveGoogleChatTimestampMs(eventTime?: string): number | undefined {
+  if (!eventTime) {
+    return undefined;
+  }
+  const parsed = Date.parse(eventTime);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 async function processMessageWithPipeline(params: {
   event: GoogleChatEvent;
   account: ResolvedGoogleChatAccount;
@@ -130,10 +142,12 @@ async function processMessageWithPipeline(params: {
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";
   const senderEmail = sender?.email ?? undefined;
+  const isBotSender = sender?.type?.toUpperCase() === "BOT";
+  const appUserId = account.config.botUser?.trim() || "users/app";
 
   const allowBots = account.config.allowBots === true;
   if (!allowBots) {
-    if (sender?.type?.toUpperCase() === "BOT") {
+    if (isBotSender) {
       logVerbose(core, runtime, `skip bot-authored message (${senderId || "unknown"})`);
       return;
     }
@@ -169,6 +183,34 @@ async function processMessageWithPipeline(params: {
     return;
   }
   const { commandAuthorized, effectiveWasMentioned, groupSystemPrompt } = access;
+
+  const botLoopProtection: ChannelBotLoopProtectionFacts | undefined =
+    allowBots && isBotSender && senderId && senderId !== appUserId
+      ? {
+          scopeId: account.accountId,
+          conversationId: spaceId,
+          senderId,
+          receiverId: appUserId,
+          config: account.config.botLoopProtection,
+          defaultsConfig: config.channels?.defaults?.botLoopProtection,
+          defaultEnabled: true,
+          nowMs: resolveGoogleChatTimestampMs(event.eventTime),
+        }
+      : undefined;
+  if (botLoopProtection) {
+    const botLoopResult = recordChannelBotPairLoopAndCheckSuppression(botLoopProtection);
+    if (botLoopResult.suppressed) {
+      logVerbose(
+        core,
+        runtime,
+        `googlechat: bot-to-bot loop detected, suppressing for ${Math.max(
+          0,
+          Math.ceil((botLoopResult.cooldownUntilMs - Date.now()) / 1000),
+        )}s`,
+      );
+      return;
+    }
+  }
 
   const { route, buildEnvelope } = resolveInboundRouteEnvelopeBuilderWithRuntime({
     cfg: config,

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -6,6 +6,8 @@ import {
   type ChannelMatchSource,
 } from "../../../../src/channels/channel-config.js";
 import type { SlackReactionNotificationMode } from "../../../../src/config/config.js";
+import type { ChannelBotLoopProtectionConfig } from "../../../../src/config/types.bot-loop-protection.js";
+import { mergePairLoopGuardConfig } from "../../../../src/plugin-sdk/pair-loop-guard-runtime.js";
 import type { SlackMessageEvent } from "../types.js";
 import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from "./allow-list.js";
 
@@ -13,6 +15,7 @@ export type SlackChannelConfigResolved = {
   allowed: boolean;
   requireMention: boolean;
   allowBots?: boolean;
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
@@ -25,6 +28,7 @@ export type SlackChannelConfigEntry = {
   allow?: boolean;
   requireMention?: boolean;
   allowBots?: boolean;
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
@@ -143,6 +147,10 @@ export function resolveSlackChannelConfig(params: {
     firstDefined(resolved.requireMention, fallback?.requireMention, requireMentionDefault) ??
     requireMentionDefault;
   const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
+  const botLoopProtection = mergePairLoopGuardConfig(
+    fallback?.botLoopProtection,
+    matched?.botLoopProtection,
+  );
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
   const systemPrompt = firstDefined(resolved.systemPrompt, fallback?.systemPrompt);
@@ -150,6 +158,7 @@ export function resolveSlackChannelConfig(params: {
     allowed,
     requireMention,
     allowBots,
+    botLoopProtection,
     users,
     skills,
     systemPrompt,

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -6,10 +6,15 @@ import type { ReplyPayload } from "../../../../../src/auto-reply/types.js";
 import { removeAckReactionAfterReply } from "../../../../../src/channels/ack-reactions.js";
 import { logAckFailure, logTypingFailure } from "../../../../../src/channels/logging.js";
 import { createReplyPrefixOptions } from "../../../../../src/channels/reply-prefix.js";
+import {
+  recordChannelBotPairLoopAndCheckSuppression,
+  type ChannelBotLoopProtectionFacts,
+} from "../../../../../src/channels/turn/bot-loop-protection.js";
 import { createTypingCallbacks } from "../../../../../src/channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../../../src/config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../../../src/globals.js";
 import { resolveAgentOutboundIdentity } from "../../../../../src/infra/outbound/identity.js";
+import { mergePairLoopGuardConfig } from "../../../../../src/plugin-sdk/pair-loop-guard-runtime.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../../../src/security/dm-policy-shared.js";
 import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
@@ -70,10 +75,65 @@ function shouldUseStreaming(params: {
   return true;
 }
 
+function resolveSlackMessageTimestampMs(
+  message: PreparedSlackMessage["message"],
+): number | undefined {
+  const ts = message.event_ts ?? message.ts;
+  if (!ts) {
+    return undefined;
+  }
+  const parsed = Number(ts);
+  return Number.isFinite(parsed) ? Math.trunc(parsed * 1000) : undefined;
+}
+
+function resolveSlackBotLoopProtection(
+  prepared: PreparedSlackMessage,
+): ChannelBotLoopProtectionFacts | undefined {
+  const senderBotId = prepared.message.bot_id;
+  if (!senderBotId) {
+    return undefined;
+  }
+  const receiverBotId = prepared.ctx.botId || prepared.ctx.botUserId;
+  if (
+    !receiverBotId ||
+    senderBotId === prepared.ctx.botId ||
+    prepared.message.user === prepared.ctx.botUserId
+  ) {
+    return undefined;
+  }
+  return {
+    scopeId: prepared.route.accountId,
+    conversationId: prepared.message.channel,
+    senderId: senderBotId,
+    receiverId: receiverBotId,
+    config: mergePairLoopGuardConfig(
+      prepared.account.config.botLoopProtection,
+      prepared.channelConfig?.botLoopProtection,
+    ),
+    defaultsConfig: prepared.ctx.cfg.channels?.defaults?.botLoopProtection,
+    defaultEnabled: true,
+    nowMs: resolveSlackMessageTimestampMs(prepared.message),
+  };
+}
+
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
   const { ctx, account, message, route } = prepared;
   const cfg = ctx.cfg;
   const runtime = ctx.runtime;
+
+  const botLoopProtection = resolveSlackBotLoopProtection(prepared);
+  if (botLoopProtection) {
+    const botLoopResult = recordChannelBotPairLoopAndCheckSuppression(botLoopProtection);
+    if (botLoopResult.suppressed) {
+      logVerbose(
+        `slack: bot-to-bot loop detected, suppressing for ${Math.max(
+          0,
+          Math.ceil((botLoopResult.cooldownUntilMs - Date.now()) / 1000),
+        )}s`,
+      );
+      return;
+    }
+  }
 
   // Resolve agent identity for Slack chat:write.customize overrides.
   const outboundIdentity = resolveAgentOutboundIdentity(cfg, route.agentId);

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -314,12 +314,14 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       : null;
 
   let botUserId = "";
+  let botId = "";
   let teamId = "";
   let apiAppId = "";
   const expectedApiAppIdFromAppToken = parseApiAppIdFromAppToken(appToken);
   try {
     const auth = await app.client.auth.test({ token: botToken });
     botUserId = auth.user_id ?? "";
+    botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";
     apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
   } catch {
@@ -339,6 +341,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     app,
     runtime,
     botUserId,
+    botId,
     teamId,
     apiAppId,
     historyLimit,

--- a/src/channels/turn/bot-loop-protection.test.ts
+++ b/src/channels/turn/bot-loop-protection.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearChannelBotPairLoopGuardForTests,
+  recordChannelBotPairLoopAndCheckSuppression,
+  type ChannelBotLoopProtectionFacts,
+} from "./bot-loop-protection.js";
+
+// Acceptance test for remoteclaw#2868: the botLoopProtection guard is wired into
+// the bot-capable adapters' inbound preflight and short-circuits (drops, does NOT
+// dispatch) once a single {scope, conversation, sender, receiver} pair exceeds its
+// event budget. This models the exact decision the discord/googlechat/slack adapters
+// perform: assemble facts -> record+check -> if suppressed, return before dispatch.
+
+const MAX = 3;
+const WINDOW_SECONDS = 60;
+const COOLDOWN_SECONDS = 60;
+
+const BASE_FACTS: Omit<ChannelBotLoopProtectionFacts, "nowMs"> = {
+  scopeId: "account-1",
+  conversationId: "channel-1",
+  senderId: "bot-sender",
+  receiverId: "our-bot",
+  config: {
+    enabled: true,
+    maxEventsPerWindow: MAX,
+    windowSeconds: WINDOW_SECONDS,
+    cooldownSeconds: COOLDOWN_SECONDS,
+  },
+  defaultsConfig: undefined,
+  defaultEnabled: true,
+};
+
+describe("botLoopProtection adapter wiring (remoteclaw#2868)", () => {
+  beforeEach(() => {
+    // The guard is a module singleton — isolate every test.
+    clearChannelBotPairLoopGuardForTests();
+  });
+
+  /**
+   * Models an adapter inbound preflight: record the bot-authored event, and if the
+   * guard reports suppression, short-circuit before the dispatch call.
+   */
+  function simulateInboundBotMessage(dispatch: () => void, nowMs: number) {
+    const result = recordChannelBotPairLoopAndCheckSuppression({ ...BASE_FACTS, nowMs });
+    if (result.suppressed) {
+      return result; // adapter drops the message: dispatch is NOT invoked
+    }
+    dispatch();
+    return result;
+  }
+
+  it("dispatches the first N bot events then suppresses the (N+1)th for one pair", () => {
+    const dispatch = vi.fn();
+    const start = 1_000;
+
+    // First N events (all within the window) dispatch normally.
+    for (let i = 0; i < MAX; i++) {
+      const result = simulateInboundBotMessage(dispatch, start + i);
+      expect(result.suppressed).toBe(false);
+    }
+    expect(dispatch).toHaveBeenCalledTimes(MAX);
+
+    // The (N+1)th event within the same window is suppressed and NOT dispatched.
+    const suppressed = simulateInboundBotMessage(dispatch, start + MAX);
+    expect(suppressed.suppressed).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(MAX); // unchanged: no dispatch
+    if (!suppressed.suppressed) {
+      throw new Error("expected suppression");
+    }
+    // cooldownUntilMs = the (N+1)th event time + cooldown window.
+    expect(suppressed.cooldownUntilMs).toBe(start + MAX + COOLDOWN_SECONDS * 1_000);
+  });
+
+  it("keeps suppressing while nowMs is before cooldownUntilMs", () => {
+    const dispatch = vi.fn();
+    const start = 1_000;
+    for (let i = 0; i <= MAX; i++) {
+      simulateInboundBotMessage(dispatch, start + i);
+    }
+    expect(dispatch).toHaveBeenCalledTimes(MAX);
+
+    // A further event still inside the cooldown window stays suppressed.
+    const cooldownUntilMs = start + MAX + COOLDOWN_SECONDS * 1_000;
+    const during = simulateInboundBotMessage(dispatch, cooldownUntilMs - 1);
+    expect(during.suppressed).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(MAX); // still no dispatch
+  });
+
+  it("clears suppression and resumes dispatch once nowMs passes cooldownUntilMs", () => {
+    const dispatch = vi.fn();
+    const start = 1_000;
+    for (let i = 0; i <= MAX; i++) {
+      simulateInboundBotMessage(dispatch, start + i);
+    }
+    expect(dispatch).toHaveBeenCalledTimes(MAX);
+    const cooldownUntilMs = start + MAX + COOLDOWN_SECONDS * 1_000;
+
+    // Advance past cooldownUntilMs (and outside the sliding window): dispatch resumes.
+    const resumed = simulateInboundBotMessage(dispatch, cooldownUntilMs + 1);
+    expect(resumed.suppressed).toBe(false);
+    expect(dispatch).toHaveBeenCalledTimes(MAX + 1); // dispatched again
+  });
+
+  it("never suppresses (always dispatches) when protection is disabled", () => {
+    const dispatch = vi.fn();
+    const disabledFacts: ChannelBotLoopProtectionFacts = {
+      ...BASE_FACTS,
+      config: { ...BASE_FACTS.config, enabled: false },
+    };
+    // Far exceed the budget; a disabled guard must admit every event.
+    for (let i = 0; i < MAX + 5; i++) {
+      const result = recordChannelBotPairLoopAndCheckSuppression({
+        ...disabledFacts,
+        nowMs: 1_000 + i,
+      });
+      expect(result.suppressed).toBe(false);
+      if (!result.suppressed) {
+        dispatch();
+      }
+    }
+    expect(dispatch).toHaveBeenCalledTimes(MAX + 5);
+  });
+
+  it("scopes the budget per pair — a different sender is tracked independently", () => {
+    const dispatch = vi.fn();
+    const start = 1_000;
+    // Trip suppression for bot-sender.
+    for (let i = 0; i <= MAX; i++) {
+      simulateInboundBotMessage(dispatch, start + i);
+    }
+    const other = recordChannelBotPairLoopAndCheckSuppression({
+      ...BASE_FACTS,
+      senderId: "different-bot",
+      nowMs: start + MAX,
+    });
+    // A distinct sender pair is not affected by the tripped pair.
+    expect(other.suppressed).toBe(false);
+  });
+});

--- a/src/config/types.channels.ts
+++ b/src/config/types.channels.ts
@@ -1,4 +1,5 @@
 import type { GroupPolicy } from "./types.base.js";
+import type { ChannelBotLoopProtectionConfig } from "./types.bot-loop-protection.js";
 
 export type ChannelHeartbeatVisibilityConfig = {
   /** Show HEARTBEAT_OK acknowledgments in chat (default: false). */
@@ -21,6 +22,8 @@ export type ChannelDefaultsConfig = {
   groupPolicy?: GroupPolicy;
   /** Default heartbeat visibility for all channels. */
   heartbeat?: ChannelHeartbeatVisibilityConfig;
+  /** Default bot-to-bot loop protection for channels that support it. */
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
 };
 
 export type ChannelModelByChannelConfig = Record<string, Record<string, string>>;

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -7,6 +7,7 @@ import type {
   OutboundRetryConfig,
   ReplyToMode,
 } from "./types.base.js";
+import type { ChannelBotLoopProtectionConfig } from "./types.bot-loop-protection.js";
 import type {
   ChannelHealthMonitorConfig,
   ChannelHeartbeatVisibilityConfig,
@@ -270,6 +271,8 @@ export type DiscordAccountConfig = {
   gatewayRuntimeReadyTimeoutMs?: number;
   /** Allow bot-authored messages to trigger replies (default: false). Set "mentions" to gate on mentions. */
   allowBots?: boolean | "mentions";
+  /** Bot-to-bot loop protection applied when allowBots admits bot-authored messages. */
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
   /**
    * Break-glass override: allow mutable identity matching (names/tags/slugs) in allowlists.
    * Default behavior is ID-only matching.

--- a/src/config/types.googlechat.ts
+++ b/src/config/types.googlechat.ts
@@ -4,6 +4,7 @@ import type {
   GroupPolicy,
   ReplyToMode,
 } from "./types.base.js";
+import type { ChannelBotLoopProtectionConfig } from "./types.bot-loop-protection.js";
 import type { ChannelHealthMonitorConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
 import type { SecretRef } from "./types.secrets.js";
@@ -43,6 +44,8 @@ export type GoogleChatAccountConfig = {
   enabled?: boolean;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;
+  /** Bot-to-bot loop protection applied when allowBots admits bot-authored messages. */
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
   /**
    * Break-glass override: allow mutable principal matching (raw email entries) in allowlists.
    * Default behavior is ID-only matching.

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -5,6 +5,7 @@ import type {
   MarkdownConfig,
   ReplyToMode,
 } from "./types.base.js";
+import type { ChannelBotLoopProtectionConfig } from "./types.bot-loop-protection.js";
 import type {
   ChannelHealthMonitorConfig,
   ChannelHeartbeatVisibilityConfig,
@@ -39,6 +40,8 @@ export type SlackChannelConfig = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;
+  /** Bot-to-bot loop protection applied when allowBots admits bot-authored messages. */
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
   /** Allowlist of users that can invoke the bot in this channel. */
   users?: Array<string | number>;
   /** Optional skill filter for this channel. */
@@ -139,6 +142,8 @@ export type SlackAccountConfig = {
   userTokenReadOnly?: boolean;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;
+  /** Bot-to-bot loop protection applied when allowBots admits bot-authored messages. */
+  botLoopProtection?: ChannelBotLoopProtectionConfig;
   /**
    * Break-glass override: allow mutable identity matching (name/slug) in allowlists.
    * Default behavior is ID-only matching.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -45,6 +45,15 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+export const BotLoopProtectionSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    maxEventsPerWindow: z.number().int().positive().optional(),
+    windowSeconds: z.number().int().positive().optional(),
+    cooldownSeconds: z.number().int().positive().optional(),
+  })
+  .strict();
+
 const DiscordIdSchema = z
   .union([z.string(), z.number()])
   .transform((value, ctx) => {
@@ -567,6 +576,7 @@ export const DiscordAccountSchema = z
     gatewayReadyTimeoutMs: z.number().int().positive().max(120_000).optional(),
     gatewayRuntimeReadyTimeoutMs: z.number().int().positive().max(120_000).optional(),
     allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
+    botLoopProtection: BotLoopProtectionSchema.optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     mentionAliases: z.record(z.string(), DiscordSnowflakeStringSchema).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
@@ -848,6 +858,7 @@ export const GoogleChatAccountSchema = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     allowBots: z.boolean().optional(),
+    botLoopProtection: BotLoopProtectionSchema.optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     requireMention: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
@@ -913,6 +924,7 @@ export const SlackChannelSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
+    botLoopProtection: BotLoopProtectionSchema.optional(),
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
@@ -971,6 +983,7 @@ export const SlackAccountSchema = z
     userToken: SecretInputSchema.optional().register(sensitive),
     userTokenReadOnly: z.boolean().optional().default(true),
     allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
+    botLoopProtection: BotLoopProtectionSchema.optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     requireMention: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional(),

--- a/src/config/zod-schema.providers.ts
+++ b/src/config/zod-schema.providers.ts
@@ -3,6 +3,7 @@ import { ChannelHeartbeatVisibilitySchema } from "./zod-schema.channels.js";
 import { GroupPolicySchema } from "./zod-schema.core.js";
 import {
   BlueBubblesConfigSchema,
+  BotLoopProtectionSchema,
   DiscordConfigSchema,
   GoogleChatConfigSchema,
   IMessageConfigSchema,
@@ -24,6 +25,7 @@ export const ChannelsSchema = z
       .object({
         groupPolicy: GroupPolicySchema.optional(),
         heartbeat: ChannelHeartbeatVisibilitySchema,
+        botLoopProtection: BotLoopProtectionSchema.optional(),
       })
       .strict()
       .optional(),

--- a/src/plugin-sdk/googlechat.ts
+++ b/src/plugin-sdk/googlechat.ts
@@ -56,6 +56,10 @@ export type {
 export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export { getChatChannelMeta } from "../channels/registry.js";
 export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
+export {
+  recordChannelBotPairLoopAndCheckSuppression,
+  type ChannelBotLoopProtectionFacts,
+} from "../channels/turn/bot-loop-protection.js";
 export type { RemoteClawConfig } from "../config/config.js";
 export { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
 export {


### PR DESCRIPTION
## What

Wires the `botLoopProtection` channel setting end-to-end. It was previously **advertised but inert** (#2868): the strict config schema rejected the key (setting it threw a validation error), and no adapter consumed the guard — `recordChannelBotPairLoopAndCheckSuppression` had zero importers. This restores the bot-loop suppression guard the fork already shipped but never connected.

## Why

Bot-loop protection suppresses runaway bot-to-bot message loops (two bots replying to each other → unbounded amplification / cost blow-up). The guard implementation (`src/channels/turn/bot-loop-protection.ts` + `src/plugin-sdk/pair-loop-guard-runtime.ts`) was sound but dead — a config that lies (documented, but rejected at parse time and enforced nowhere).

## Changes

**Config schema (additive, all-optional):**
- `BotLoopProtectionSchema` (`zod-schema.providers-core.ts`) — `.strict()`, `.int().positive()` bounds — added next to each `allowBots` site (discord/googlechat/slack account + slack channel) and to `channels.defaults`.
- Matching optional fields on `ChannelDefaultsConfig` + per-provider config types. Existing configs without the key still parse.

**Adapter wiring (guard runs before dispatch, short-circuits on suppression):**
- **Discord** — fact assembly in `message-handler.preflight.ts`, guard check + early return in `message-handler.process.ts` (before dispatch).
- **Google Chat** — `monitor.ts` (before route/envelope build).
- **Slack** — `message-handler/dispatch.ts` (`resolveSlackBotLoopProtection`, checked at the top of `dispatchPreparedSlackMessage` before all dispatch). Also populates the Slack context `botId` from `auth.test().bot_id` so the own-bot self-exclusion keys on the correct (bot-id) namespace.

**Guard param mapping** per adapter: `scopeId=accountId`, `conversationId=channel/space id`, `senderId=inbound bot id`, `receiverId=our own bot id`; config resolves channel > account > `channels.defaults` > built-in default.

**Test:** `bot-loop-protection.test.ts` — budget trip at N+1, cooldown persistence/expiry, disabled-bypass, per-pair scoping.

## Behavior change (see CHANGELOG)

The guard defaults **on** (`maxEventsPerWindow: 20`, `windowSeconds: 60`, `cooldownSeconds: 60`). An existing `allowBots: true` setup with no `botLoopProtection` block now suppresses a bot pair after 20 messages in 60s where it previously dispatched unconditionally. Opt out with `botLoopProtection.enabled: false` or a higher `maxEventsPerWindow`.

## Not included (deliberate)

- **Matrix** — its inbound path is fully diverged and lacks the configured-bot-sender machinery (`configuredBotUserIds`, allowBots-mode resolution) and a `dispatchInboundMessage`-equivalent. Wiring it requires porting that surface first; no matrix config key was added (avoids re-introducing the exact parse-but-ignore anti-pattern this PR fixes). Tracked as a follow-up.
- No dependency on gutted subsystems (turn/kernel, message inbound-reply-dispatch, plugin-sdk channel-inbound) — the guard is called directly from each adapter's kept inbound path.

Closes #2868
