### PR TITLE
fix(apns): evict stale device-token registration on permanent wake-push failure (Closes #2874)

### DIFF
--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../protocol/index.js";
-import { nodeHandlers } from "./nodes.js";
+import { maybeSendNodeWakeNudge, maybeWakeNodeWithApns, nodeHandlers } from "./nodes.js";
 
 type MockNodeCommandPolicyParams = {
   command: string;
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   resolveApnsAuthConfigFromEnv: vi.fn(),
   sendApnsBackgroundWake: vi.fn(),
   sendApnsAlert: vi.fn(),
+  clearApnsRegistrationIfCurrent: vi.fn(),
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -37,12 +38,19 @@ vi.mock("../node-invoke-sanitize.js", () => ({
   sanitizeNodeInvokeParamsForForwarding: mocks.sanitizeNodeInvokeParamsForForwarding,
 }));
 
-vi.mock("../../infra/push-apns.js", () => ({
-  loadApnsRegistration: mocks.loadApnsRegistration,
-  resolveApnsAuthConfigFromEnv: mocks.resolveApnsAuthConfigFromEnv,
-  sendApnsBackgroundWake: mocks.sendApnsBackgroundWake,
-  sendApnsAlert: mocks.sendApnsAlert,
-}));
+vi.mock("../../infra/push-apns.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/push-apns.js")>();
+  return {
+    loadApnsRegistration: mocks.loadApnsRegistration,
+    resolveApnsAuthConfigFromEnv: mocks.resolveApnsAuthConfigFromEnv,
+    sendApnsBackgroundWake: mocks.sendApnsBackgroundWake,
+    sendApnsAlert: mocks.sendApnsAlert,
+    clearApnsRegistrationIfCurrent: mocks.clearApnsRegistrationIfCurrent,
+    // Use the REAL predicate so eviction wiring is exercised against the actual
+    // 410 / 400-BadDeviceToken decision, not a mock's canned boolean.
+    isApnsTokenPermanentlyInvalid: actual.isApnsTokenPermanentlyInvalid,
+  };
+});
 
 type RespondCall = [
   boolean,
@@ -214,6 +222,8 @@ describe("node.invoke APNs wake path", () => {
     mocks.resolveApnsAuthConfigFromEnv.mockClear();
     mocks.sendApnsBackgroundWake.mockClear();
     mocks.sendApnsAlert.mockClear();
+    mocks.clearApnsRegistrationIfCurrent.mockClear();
+    mocks.clearApnsRegistrationIfCurrent.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -501,5 +511,103 @@ describe("node.invoke APNs wake path", () => {
     });
     const actions = (pullCall?.[1] as { actions?: unknown[] } | undefined)?.actions ?? [];
     expect(actions).toHaveLength(1);
+  });
+});
+
+describe("APNs registration eviction on permanent-invalid wake failures", () => {
+  // The stored token is the normalized form of directRegistration()'s token; the wiring must
+  // forward exactly this (the token that failed) so the store-side guard can no-op on a race.
+  const STORED_TOKEN = "abcd1234abcd1234abcd1234abcd1234";
+
+  beforeEach(() => {
+    mocks.loadApnsRegistration.mockReset();
+    mocks.resolveApnsAuthConfigFromEnv.mockReset();
+    mocks.sendApnsBackgroundWake.mockReset();
+    mocks.sendApnsAlert.mockReset();
+    mocks.clearApnsRegistrationIfCurrent.mockReset();
+    mocks.clearApnsRegistrationIfCurrent.mockResolvedValue(true);
+  });
+
+  it("evicts the stored registration when the background wake returns 410 Unregistered", async () => {
+    mockDirectWakeConfig("evict-410", { ok: false, status: 410, reason: "Unregistered" });
+
+    const attempt = await maybeWakeNodeWithApns("evict-410");
+
+    expect(attempt.path).toBe("send-error");
+    expect(attempt.apnsStatus).toBe(410);
+    expect(mocks.clearApnsRegistrationIfCurrent).toHaveBeenCalledTimes(1);
+    expect(mocks.clearApnsRegistrationIfCurrent).toHaveBeenCalledWith({
+      nodeId: "evict-410",
+      token: STORED_TOKEN,
+    });
+  });
+
+  it("evicts the stored registration when the background wake returns 400 BadDeviceToken", async () => {
+    mockDirectWakeConfig("evict-400", { ok: false, status: 400, reason: "BadDeviceToken" });
+
+    const attempt = await maybeWakeNodeWithApns("evict-400");
+
+    expect(attempt.path).toBe("send-error");
+    expect(attempt.apnsStatus).toBe(400);
+    expect(mocks.clearApnsRegistrationIfCurrent).toHaveBeenCalledTimes(1);
+    expect(mocks.clearApnsRegistrationIfCurrent).toHaveBeenCalledWith({
+      nodeId: "evict-400",
+      token: STORED_TOKEN,
+    });
+  });
+
+  it("retains the registration on transient or non-permanent wake failures", async () => {
+    mockDirectWakeConfig("keep-429", { ok: false, status: 429, reason: "TooManyRequests" });
+    const rateLimited = await maybeWakeNodeWithApns("keep-429");
+    expect(rateLimited.apnsStatus).toBe(429);
+
+    mockDirectWakeConfig("keep-503", { ok: false, status: 503, reason: "ServiceUnavailable" });
+    const serverError = await maybeWakeNodeWithApns("keep-503");
+    expect(serverError.apnsStatus).toBe(503);
+
+    // 400 with a reason other than BadDeviceToken is NOT a dead token — must not evict.
+    mockDirectWakeConfig("keep-400-other", { ok: false, status: 400, reason: "BadCollapseId" });
+    const otherBadRequest = await maybeWakeNodeWithApns("keep-400-other");
+    expect(otherBadRequest.apnsStatus).toBe(400);
+
+    expect(mocks.clearApnsRegistrationIfCurrent).not.toHaveBeenCalled();
+  });
+
+  it("evicts a permanently-invalid nudge target but retains a transient one", async () => {
+    // maybeSendNodeWakeNudge uses sendApnsAlert; wire the same permanent/transient guard.
+    mockDirectWakeConfig("nudge-410");
+    mocks.sendApnsAlert.mockResolvedValue({
+      ok: false,
+      status: 410,
+      reason: "Unregistered",
+      tokenSuffix: "1234abcd",
+      topic: "org.remoteclaw.ios",
+      environment: "sandbox",
+    });
+
+    const permanent = await maybeSendNodeWakeNudge("nudge-410");
+    expect(permanent.reason).toBe("apns-not-ok");
+    expect(permanent.apnsStatus).toBe(410);
+    expect(mocks.clearApnsRegistrationIfCurrent).toHaveBeenCalledTimes(1);
+    expect(mocks.clearApnsRegistrationIfCurrent).toHaveBeenCalledWith({
+      nodeId: "nudge-410",
+      token: STORED_TOKEN,
+    });
+
+    mocks.clearApnsRegistrationIfCurrent.mockClear();
+    mockDirectWakeConfig("nudge-503");
+    mocks.sendApnsAlert.mockResolvedValue({
+      ok: false,
+      status: 503,
+      reason: "ServiceUnavailable",
+      tokenSuffix: "1234abcd",
+      topic: "org.remoteclaw.ios",
+      environment: "sandbox",
+    });
+
+    const transient = await maybeSendNodeWakeNudge("nudge-503");
+    expect(transient.reason).toBe("apns-not-ok");
+    expect(transient.apnsStatus).toBe(503);
+    expect(mocks.clearApnsRegistrationIfCurrent).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -11,6 +11,8 @@ import {
   verifyNodeToken,
 } from "../../infra/node-pairing.js";
 import {
+  clearApnsRegistrationIfCurrent,
+  isApnsTokenPermanentlyInvalid,
   loadApnsRegistration,
   resolveApnsAuthConfigFromEnv,
   sendApnsAlert,
@@ -297,6 +299,11 @@ export async function maybeWakeNodeWithApns(
         wakeReason: opts?.wakeReason ?? "node.invoke",
       });
       if (!wakeResult.ok) {
+        if (isApnsTokenPermanentlyInvalid(wakeResult)) {
+          // Best-effort eviction of a token Apple reports as permanently invalid, so we
+          // stop firing doomed wakes and let the registration table shed dead entries.
+          await clearApnsRegistrationIfCurrent({ nodeId, token: registration.token });
+        }
         return withDuration({
           available: true,
           throttled: false,
@@ -376,6 +383,11 @@ export async function maybeSendNodeWakeNudge(nodeId: string): Promise<NodeWakeNu
       body: "Tap to reopen RemoteClaw and restore the node connection.",
     });
     if (!result.ok) {
+      if (isApnsTokenPermanentlyInvalid(result)) {
+        // Best-effort eviction on a permanently-invalid nudge target (same guard as the
+        // background-wake path) — keep transient failures (429/5xx) registered for retry.
+        await clearApnsRegistrationIfCurrent({ nodeId, token: registration.token });
+      }
       return withDuration({
         sent: false,
         throttled: false,

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  clearApnsRegistrationIfCurrent,
+  isApnsTokenPermanentlyInvalid,
   loadApnsRegistration,
   normalizeApnsEnvironment,
   registerApnsToken,
@@ -223,5 +225,95 @@ describe("push APNs send semantics", () => {
         nodeId: "ios-node-wake-default-reason",
       },
     });
+  });
+});
+
+describe("push APNs registration eviction", () => {
+  it("removes the registration when the stored token matches the failed token", async () => {
+    const baseDir = await makeTempDir();
+    await registerApnsToken({
+      nodeId: "ios-node-evict",
+      token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+      topic: "org.remoteclaw.ios",
+      environment: "sandbox",
+      baseDir,
+    });
+
+    const cleared = await clearApnsRegistrationIfCurrent({
+      nodeId: "ios-node-evict",
+      token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+      baseDir,
+    });
+
+    expect(cleared).toBe(true);
+    expect(await loadApnsRegistration("ios-node-evict", baseDir)).toBeNull();
+  });
+
+  it("retains the registration when the stored token differs (race guard)", async () => {
+    const baseDir = await makeTempDir();
+    await registerApnsToken({
+      nodeId: "ios-node-race",
+      token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+      topic: "org.remoteclaw.ios",
+      environment: "sandbox",
+      baseDir,
+    });
+
+    // Simulate a fresh re-registration having replaced the token between the doomed push and
+    // this eviction attempt: the failed (now-stale) token no longer matches what is stored.
+    const cleared = await clearApnsRegistrationIfCurrent({
+      nodeId: "ios-node-race",
+      token: "ffff0000ffff0000ffff0000ffff0000",
+      baseDir,
+    });
+
+    expect(cleared).toBe(false);
+    const retained = await loadApnsRegistration("ios-node-race", baseDir);
+    expect(retained).not.toBeNull();
+    expect(retained?.token).toBe("abcd1234abcd1234abcd1234abcd1234");
+  });
+
+  it("matches tokens through normalization (case and angle-bracket/space formatting)", async () => {
+    const baseDir = await makeTempDir();
+    await registerApnsToken({
+      nodeId: "ios-node-normalize",
+      token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+      topic: "org.remoteclaw.ios",
+      environment: "sandbox",
+      baseDir,
+    });
+
+    // The failed token arriving in a raw APNs formatting variant must still match the
+    // normalized stored form, or the guard would wrongly refuse to evict a dead token.
+    const cleared = await clearApnsRegistrationIfCurrent({
+      nodeId: "ios-node-normalize",
+      token: "<ABCD1234 ABCD1234 ABCD1234 ABCD1234>",
+      baseDir,
+    });
+
+    expect(cleared).toBe(true);
+    expect(await loadApnsRegistration("ios-node-normalize", baseDir)).toBeNull();
+  });
+
+  it("returns false when the node has no registration", async () => {
+    const baseDir = await makeTempDir();
+    const cleared = await clearApnsRegistrationIfCurrent({
+      nodeId: "ios-node-missing",
+      token: "ABCD1234ABCD1234ABCD1234ABCD1234",
+      baseDir,
+    });
+    expect(cleared).toBe(false);
+  });
+});
+
+describe("isApnsTokenPermanentlyInvalid", () => {
+  it("treats only 410 and 400 BadDeviceToken as permanent; everything else is retryable", () => {
+    expect(isApnsTokenPermanentlyInvalid({ status: 410, reason: "Unregistered" })).toBe(true);
+    expect(isApnsTokenPermanentlyInvalid({ status: 400, reason: "BadDeviceToken" })).toBe(true);
+    expect(isApnsTokenPermanentlyInvalid({ status: 400, reason: "BadCollapseId" })).toBe(false);
+    expect(isApnsTokenPermanentlyInvalid({ status: 400 })).toBe(false);
+    expect(isApnsTokenPermanentlyInvalid({ status: 429, reason: "TooManyRequests" })).toBe(false);
+    expect(isApnsTokenPermanentlyInvalid({ status: 503 })).toBe(false);
+    expect(isApnsTokenPermanentlyInvalid({ status: 200 })).toBe(false);
   });
 });

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -244,6 +244,48 @@ export async function loadApnsRegistration(
   return state.registrationsByNodeId[normalizedNodeId] ?? null;
 }
 
+// Remove a node's stored registration, but only if the currently-persisted token still
+// matches the token that failed. The match guard avoids racing a fresh re-registration:
+// if the device re-registered a new token between the doomed push and this eviction, the
+// stored (valid) token differs and we leave it untouched.
+export async function clearApnsRegistrationIfCurrent(params: {
+  nodeId: string;
+  token: string;
+  baseDir?: string;
+}): Promise<boolean> {
+  const nodeId = normalizeNodeId(params.nodeId);
+  const token = normalizeApnsToken(params.token);
+  if (!nodeId || !token) {
+    return false;
+  }
+  return await withLock(async () => {
+    const state = await loadRegistrationsState(params.baseDir);
+    const current = state.registrationsByNodeId[nodeId];
+    if (!current || normalizeApnsToken(current.token) !== token) {
+      return false;
+    }
+    delete state.registrationsByNodeId[nodeId];
+    await persistRegistrationsState(state, params.baseDir);
+    return true;
+  });
+}
+
+// A permanently-invalid APNs response means the token can never deliver again: HTTP 410
+// (Unregistered) or HTTP 400 with reason BadDeviceToken. Transient failures (429 rate-limit,
+// 5xx server errors) must NOT evict — the token is still valid, retry later.
+export function isApnsTokenPermanentlyInvalid(result: {
+  status: number;
+  reason?: string;
+}): boolean {
+  if (result.status === 410) {
+    return true;
+  }
+  if (result.status === 400 && result.reason === "BadDeviceToken") {
+    return true;
+  }
+  return false;
+}
+
 export async function resolveApnsAuthConfigFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<ApnsAuthConfigResolution> {


### PR DESCRIPTION
Closes #2874

## What & why

A dead APNs device token (Apple reports **HTTP 410 `Unregistered`**, or **HTTP 400 `BadDeviceToken`**) previously persisted indefinitely. Every `node.invoke` against that node fired another doomed background wake, and `push/apns-registrations.json` accumulated entries that can never deliver. **Reliability / hygiene only — a dead token cannot deliver, so there is no security impact** (no escalation, no disclosure). Priority: low.

## Change

**`src/infra/push-apns.ts`** — two new exports, reusing the existing `normalizeNodeId` / `normalizeApnsToken` / `withLock` / `loadRegistrationsState` / `persistRegistrationsState` helpers:

- `clearApnsRegistrationIfCurrent({ nodeId, token, baseDir? })` — removes the stored registration **only if the currently-persisted token still matches the token that failed**. This is the load-bearing **race guard**: it no-ops when a concurrent re-registration has already replaced the token (the match is re-checked inside `withLock`, so a fresh token is never deleted under interleaving). No `transport` field — the fork's registration model is direct-token-only by design.
- `isApnsTokenPermanentlyInvalid({ status, reason? })` — `true` only for **410** or **400 + `BadDeviceToken`**; transient failures (429, 5xx, other 400 reasons) never evict.

**`src/gateway/server-methods/nodes.ts`** — eviction wired into the failure branches of `maybeWakeNodeWithApns` (`!wakeResult.ok`) and `maybeSendNodeWakeNudge` (`!result.ok`), guarded by `isApnsTokenPermanentlyInvalid`, best-effort inside the existing `try/catch`.

## Acceptance criteria

- [x] `clearApnsRegistrationIfCurrent` + `isApnsTokenPermanentlyInvalid` exported; no `transport` field reintroduced.
- [x] `maybeWakeNodeWithApns` **and** `maybeSendNodeWakeNudge` evict only on permanent-invalid, never transient.
- [x] Eviction is token-matched.
- [x] New tests pass; existing wake tests unaffected.

## Tests

- **Gateway wiring** (`nodes.invoke-wake.test.ts`, +4 cases): evict on 410 / 400-BadDeviceToken, retain on 429 / 503 / 400-other, plus the nudge path — exercising the **real** predicate via `importOriginal` (not a canned mock boolean). → `10 passed`.
- **Direct real-function** (`push-apns.test.ts`, +5 cases): token-match → evict; **mismatch → retain (race guard)**; normalization-match; missing → false; predicate truth table. → `13 passed`.
- `pnpm tsgo` clean · `oxlint --type-aware` 0/0 · `oxfmt` no churn.

## Adversarial validation — CLEAN

Independently validated in fresh context (all 4 ACs PASS; race guard holds under concurrent interleaving; reachable-state expansion confirmed the post-eviction "no registration" state collapses onto the already-handled *never-registered* path across all three consumers). Non-blocking notes:

- **Accepted edge**: if `clearApnsRegistrationIfCurrent` itself throws (disk-write failure), the outer `try/catch` swallows it and the returned attempt degrades to a generic `send-error` (loses `apnsStatus:410`) — observability-only on a double-failure path; control flow is unchanged. Left bare per the issue spec (best-effort).
- **Out-of-scope discovery (for reviewers)**: the pre-existing `src/gateway/server-methods/nodes.wake-leak.test.ts` (not in this diff) is effectively vacuous and its mock factory references `resolveApnsRelayConfigFromEnv` / `shouldClearStoredApnsRegistration` — symbols that exist nowhere in source (zombie refs to the abandoned upstream *relay* design the fork rejected). Green, non-blocking; suggested as a follow-up cleanup, intentionally left untouched here.

## Notes

- Not a middleware change (`src/gateway/` + `src/infra/` only), so the `LIVE=1 pnpm test:live` middleware smoke gate does not apply.
- **Held for review**: auto-merge intentionally **not** enabled — this PR is held for an independent security-architect review of the applied diff before merge.
