### PR TITLE
fix(logging): redact AWS AKIA access-key-ids (part of #2852)

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -249,4 +249,31 @@ describe("redactSensitiveText", () => {
     });
     expect(output).toBe("r8_ABC…stuv");
   });
+
+  it("masks AWS long-term access-key IDs (AKIA prefix)", () => {
+    const input = "AccessKeyId is AKIAIOSFODNN7EXAMPLE";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe("AccessKeyId is AKIAIO…MPLE");
+  });
+
+  it("does not over-mask an AKIA sequence that appears mid-word", () => {
+    const input = "prefixAKIAIOSFODNN7EXAMPLE stays visible";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe(input);
+  });
+
+  it("does not mask a lowercase akia-prefixed token (case-sensitive form)", () => {
+    const input = "value akiaiosfodnn7example stays";
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe(input);
+  });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -52,6 +52,10 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   String.raw`\b(AIza[0-9A-Za-z\-_]{20,})\b`,
   String.raw`\b(pplx-[A-Za-z0-9_-]{10,})\b`,
   String.raw`\b(npm_[A-Za-z0-9]{10,})\b`,
+  // AWS long-term access-key IDs (literal AKIA + 16 upper-alphanumerics, 20 total).
+  // Case-sensitive `/…/g` form (not the bare `gi` fallback form) since AWS key IDs are
+  // uppercase — avoids over-masking mixed-case words that merely start "akia". (Fork-side, #2852.)
+  String.raw`/\b(AKIA[0-9A-Z]{16})\b/g`,
   // Additional access-key and token-style prefixes (Tencent AKID, Alibaba LTAI,
   // HuggingFace hf_, Replicate r8_). Ported from upstream #58162.
   String.raw`\b(AKID[A-Za-z0-9]{10,})\b`,


### PR DESCRIPTION
## Summary

Adds one log-redaction pattern that masks **AWS long-term access-key IDs** (`AKIA` + 16 uppercase-alphanumerics, 20 chars total) in tool logs. The fork's `src/logging/redact.ts` already redacts Tencent (`AKID`), Alibaba (`LTAI`), HuggingFace (`hf_`), and Replicate (`r8_`) credential IDs but had **no AWS pattern** — AWS access-key IDs currently leak in redacted output.

**Part of #2852.** This PR implements only the AWS-AKIA half. The other half — quoted `key="value"` credential redaction (a structured field-value redaction helper port) — is deferred to a separate tracked follow-up; **#2852 stays open**, re-scoped to that work. (Not `Closes`/`Fixes`.)

## Change

`src/logging/redact.ts` — new entry in `DEFAULT_REDACT_PATTERNS`, grouped with the other credential-ID patterns (immediately above the `AKID` block):

```ts
String.raw`/\b(AKIA[0-9A-Z]{16})\b/g`,
```

- **Case-sensitive** (`/…/g`, i.e. only the `g` flag — unlike the bare sibling patterns, which `parsePattern` compiles with `gi`): AWS key IDs are uppercase, so this avoids over-masking ordinary mixed-case words that merely begin "akia".
- **Word-boundary anchored** + **fixed `{16}` quantifier**: linear (no ReDoS), no mid-word over-match.
- Masks via the file's existing capture-group → `maskToken` convention (`AKIAIOSFODNN7EXAMPLE` → `AKIAIO…MPLE`).
- Its own comment; not filed under the adjacent "Ported from upstream #58162" block (this is a fork-side addition).

## Tests

`src/logging/redact.test.ts` — three cases:
1. Masks `AKIAIOSFODNN7EXAMPLE` (positive).
2. Leaves a mid-word `AKIA…` sequence visible (word-boundary guard).
3. Leaves a lowercase `akia…` token visible (case-sensitivity guard — this case fails if the pattern is reverted to a bare `gi` form, locking in the deliberate case-sensitive choice).

## Verification

- `redact` unit suite: **27/27 pass**.
- `pnpm check`: green (format + `tsgo` typecheck + type-aware lint + all fork-integrity gates).
- Change touches `src/logging/` only (not `src/middleware/`), so LIVE middleware smoke tests are N/A.

## Notes for reviewers

Scoped intentionally to the additive AKIA pattern; no changes to existing patterns or their ordering. Pending an independent security review before merge.
