### PR TITLE
gut(agents): remove dead owner-only tool-visibility apparatus — Closes #2857

### DIFF
--- a/src/agents/remoteclaw-gateway-tool.test.ts
+++ b/src/agents/remoteclaw-gateway-tool.test.ts
@@ -87,11 +87,6 @@ describe("gateway tool", () => {
     await loadFreshRemoteClawToolsModuleForTest();
   });
 
-  it("marks gateway as owner-only", async () => {
-    const tool = requireGatewayTool();
-    expect(tool.ownerOnly).toBe(true);
-  });
-
   it("schedules SIGUSR1 restart", async () => {
     vi.useFakeTimers();
     const kill = vi.spyOn(process, "kill").mockImplementation(() => true);

--- a/src/agents/remoteclaw-tools.ts
+++ b/src/agents/remoteclaw-tools.ts
@@ -68,8 +68,6 @@ export function createRemoteClawTools(options?: {
   disableMessageTool?: boolean;
   /** Trusted sender id from inbound context (not tool args). */
   requesterSenderId?: string | null;
-  /** Whether the requesting sender is an owner. */
-  senderIsOwner?: boolean;
   /** HTTP callers consume tool output directly; preserve raw media invoke payloads. */
   allowMediaInvokeCommands?: boolean;
 }): AnyAgentTool[] {

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -1,46 +1,11 @@
 // Sandbox infrastructure removed (#68) — sandbox tool policy tests removed
 import { describe, expect, it } from "vitest";
 import {
-  applyOwnerOnlyToolPolicy,
   expandToolGroups,
-  isOwnerOnlyToolName,
   normalizeToolName,
   resolveToolProfilePolicy,
   TOOL_GROUPS,
 } from "./tool-policy.js";
-import type { AnyAgentTool } from "./tools/common.js";
-
-function createOwnerPolicyTools() {
-  return [
-    {
-      name: "read",
-      // oxlint-disable-next-line typescript/no-explicit-any
-      execute: async () => ({ content: [], details: {} }) as unknown,
-    },
-    {
-      name: "cron",
-      ownerOnly: true,
-      // oxlint-disable-next-line typescript/no-explicit-any
-      execute: async () => ({ content: [], details: {} }) as unknown,
-    },
-    {
-      name: "gateway",
-      ownerOnly: true,
-      // oxlint-disable-next-line typescript/no-explicit-any
-      execute: async () => ({ content: [], details: {} }) as unknown,
-    },
-    {
-      name: "whatsapp_login",
-      // oxlint-disable-next-line typescript/no-explicit-any
-      execute: async () => ({ content: [], details: {} }) as unknown,
-    },
-    {
-      name: "nodes",
-      ownerOnly: true,
-      execute: async () => ({ content: [], details: {} }) as unknown,
-    },
-  ] as unknown as AnyAgentTool[];
-}
 
 describe("tool-policy", () => {
   it("expands groups and normalizes names", () => {
@@ -69,72 +34,6 @@ describe("tool-policy", () => {
   it("normalizes tool names", () => {
     expect(normalizeToolName(" BASH ")).toBe("bash");
     expect(normalizeToolName("READ")).toBe("read");
-  });
-
-  it("identifies owner-only tools", () => {
-    expect(isOwnerOnlyToolName("cron")).toBe(true);
-    expect(isOwnerOnlyToolName("gateway")).toBe(true);
-    expect(isOwnerOnlyToolName("nodes")).toBe(true);
-    expect(isOwnerOnlyToolName("read")).toBe(false);
-  });
-
-  it("strips owner-only tools for non-owner senders", async () => {
-    const tools = createOwnerPolicyTools();
-    const filtered = applyOwnerOnlyToolPolicy(tools, false);
-    expect(filtered.map((t) => t.name)).toEqual(["read"]);
-  });
-
-  it("keeps owner-only tools for the owner sender", () => {
-    const tools = createOwnerPolicyTools();
-    const filtered = applyOwnerOnlyToolPolicy(tools, true);
-    expect(filtered.map((t) => t.name)).toEqual(["read", "cron", "gateway", "nodes"]);
-  });
-
-  it("keeps only explicitly authorized owner-only tools for non-owner senders", async () => {
-    const tools = createOwnerPolicyTools();
-    const filtered = applyOwnerOnlyToolPolicy(tools, false, ["cron"]);
-    expect(filtered.map((t) => t.name)).toEqual(["read", "cron"]);
-
-    await expect(
-      filtered.find((tool) => tool.name === "cron")?.execute?.("call_1", {}),
-    ).resolves.toEqual({
-      content: [],
-      details: {},
-    });
-  });
-
-  it("honors ownerOnly metadata for custom tool names", () => {
-    const tools = [
-      {
-        name: "custom_admin_tool",
-        ownerOnly: true,
-        // oxlint-disable-next-line typescript/no-explicit-any
-        execute: async () => ({ content: [], details: {} }) as unknown,
-      },
-    ] as unknown as AnyAgentTool[];
-    expect(applyOwnerOnlyToolPolicy(tools, false)).toStrictEqual([]);
-    expect(applyOwnerOnlyToolPolicy(tools, true)).toHaveLength(1);
-  });
-
-  it("strips nodes for non-owner senders via fallback policy", () => {
-    const tools = [
-      {
-        name: "read",
-        // oxlint-disable-next-line typescript/no-explicit-any
-        execute: async () => ({ content: [], details: {} }) as unknown,
-      },
-      {
-        name: "nodes",
-        // oxlint-disable-next-line typescript/no-explicit-any
-        execute: async () => ({ content: [], details: {} }) as unknown,
-      },
-    ] as unknown as AnyAgentTool[];
-
-    expect(applyOwnerOnlyToolPolicy(tools, false).map((tool) => tool.name)).toEqual(["read"]);
-    expect(applyOwnerOnlyToolPolicy(tools, true).map((tool) => tool.name)).toEqual([
-      "read",
-      "nodes",
-    ]);
   });
 });
 

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -6,7 +6,6 @@ import {
   resolveToolProfilePolicy,
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
-import type { AnyAgentTool } from "./tools/common.js";
 
 /**
  * Runtime attestation (ADR 0005 H9). Declares the implementation status
@@ -15,9 +14,6 @@ import type { AnyAgentTool } from "./tools/common.js";
  * updating these when sync or rebrand changes the surface.
  */
 export const MODULE_ATTESTATIONS = {
-  resolveOwnerOnlyToolApprovalClass: "live",
-  isOwnerOnlyToolName: "live",
-  applyOwnerOnlyToolPolicy: "live",
   collectExplicitAllowlist: "live",
   buildPluginToolGroups: "live",
   expandPluginGroups: "live",
@@ -33,67 +29,6 @@ export {
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
 export type { ToolProfileId } from "./tool-policy-shared.js";
-
-export type OwnerOnlyToolApprovalClass = "control_plane" | "exec_capable" | "interactive";
-
-// Keep tool-policy browser-safe: do not import tools/common at runtime.
-function wrapOwnerOnlyToolExecution(tool: AnyAgentTool, authorized: boolean): AnyAgentTool {
-  if (tool.ownerOnly !== true || authorized || !tool.execute) {
-    return tool;
-  }
-  return {
-    ...tool,
-    execute: async () => {
-      throw new Error("Tool restricted to owner senders.");
-    },
-  };
-}
-
-const OWNER_ONLY_TOOL_APPROVAL_CLASS_FALLBACKS = new Map<string, OwnerOnlyToolApprovalClass>([
-  ["cron", "control_plane"],
-  ["gateway", "control_plane"],
-  ["nodes", "exec_capable"],
-]);
-
-export function resolveOwnerOnlyToolApprovalClass(
-  name: string,
-): OwnerOnlyToolApprovalClass | undefined {
-  return OWNER_ONLY_TOOL_APPROVAL_CLASS_FALLBACKS.get(normalizeToolName(name));
-}
-
-export function isOwnerOnlyToolName(name: string) {
-  return resolveOwnerOnlyToolApprovalClass(name) !== undefined;
-}
-
-function isOwnerOnlyTool(tool: AnyAgentTool) {
-  return tool.ownerOnly === true || isOwnerOnlyToolName(tool.name);
-}
-
-/**
- * Filters owner-only tools unless the sender is an owner or a server-side
- * runtime grant authorizes a specific owner-only tool for this run.
- */
-export function applyOwnerOnlyToolPolicy(
-  tools: AnyAgentTool[],
-  senderIsOwner: boolean,
-  ownerOnlyToolAllowlist?: string[],
-) {
-  const allowedOwnerOnlyTools = new Set(
-    ownerOnlyToolAllowlist?.map((name) => normalizeToolName(name)) ?? [],
-  );
-  const isAuthorized = (tool: AnyAgentTool) =>
-    senderIsOwner || allowedOwnerOnlyTools.has(normalizeToolName(tool.name));
-  const withGuard = tools.map((tool) => {
-    if (!isOwnerOnlyTool(tool)) {
-      return tool;
-    }
-    return wrapOwnerOnlyToolExecution(tool, isAuthorized(tool));
-  });
-  if (senderIsOwner) {
-    return withGuard;
-  }
-  return withGuard.filter((tool) => !isOwnerOnlyTool(tool) || isAuthorized(tool));
-}
 
 export type ToolPolicyLike = {
   allow?: string[];

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -5,7 +5,6 @@ import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import { sanitizeToolResultImages } from "../tool-images.js";
 
 export type AnyAgentTool = AgentTool & {
-  ownerOnly?: boolean;
   // oxlint-disable-next-line typescript/no-explicit-any
   execute: (...args: any[]) => Promise<AgentToolResult<any>>;
 };
@@ -21,8 +20,6 @@ export type ActionGate<T extends Record<string, boolean | undefined>> = (
   key: keyof T,
   defaultValue?: boolean,
 ) => boolean;
-
-export const OWNER_ONLY_TOOL_ERROR = "Tool restricted to owner senders.";
 
 export class ToolInputError extends Error {
   readonly status: number = 400;
@@ -254,21 +251,6 @@ export function jsonResult(payload: unknown): AgentToolResult {
       },
     ],
     details: payload,
-  };
-}
-
-export function wrapOwnerOnlyToolExecution(
-  tool: AnyAgentTool,
-  senderIsOwner: boolean,
-): AnyAgentTool {
-  if (tool.ownerOnly !== true || senderIsOwner || !tool.execute) {
-    return tool;
-  }
-  return {
-    ...tool,
-    execute: async () => {
-      throw new Error(OWNER_ONLY_TOOL_ERROR);
-    },
   };
 }
 

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -116,11 +116,6 @@ describe("cron tool", () => {
     callGatewayMock.mockResolvedValue({ ok: true });
   });
 
-  it("marks cron as owner-only", () => {
-    const tool = createTestCronTool();
-    expect(tool.ownerOnly).toBe(true);
-  });
-
   it("documents deferred follow-up guidance in the tool description", () => {
     const tool = createTestCronTool();
     expect(tool.description).toContain(

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -216,7 +216,6 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
   return {
     label: "Cron",
     name: "cron",
-    ownerOnly: true,
     description: `Manage Gateway cron jobs (status/list/add/update/remove/run/runs) and send wake events.
 
 Main-session cron jobs enqueue system events for heartbeat handling. Isolated cron jobs create background task runs that appear in \`remoteclaw tasks\`.

--- a/src/agents/tools/owner-only-tools.ts
+++ b/src/agents/tools/owner-only-tools.ts
@@ -1,9 +1,0 @@
-export const REMOTECLAW_OWNER_ONLY_CORE_TOOL_NAMES = ["cron", "gateway", "nodes"] as const;
-
-const REMOTECLAW_OWNER_ONLY_CORE_TOOL_NAME_SET: ReadonlySet<string> = new Set(
-  REMOTECLAW_OWNER_ONLY_CORE_TOOL_NAMES,
-);
-
-export function isRemoteClawOwnerOnlyCoreToolName(toolName: string): boolean {
-  return REMOTECLAW_OWNER_ONLY_CORE_TOOL_NAME_SET.has(toolName);
-}

--- a/src/channels/plugins/agent-tools/whatsapp-login.ts
+++ b/src/channels/plugins/agent-tools/whatsapp-login.ts
@@ -5,7 +5,6 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
   return {
     label: "WhatsApp Login",
     name: "whatsapp_login",
-    ownerOnly: true,
     description: "Generate a WhatsApp QR code for linking, or wait for the scan to complete.",
     // NOTE: Using Type.Unsafe for action enum instead of Type.Union([Type.Literal(...)]
     // because Claude API on Vertex AI rejects nested anyOf schemas as invalid JSON Schema.


### PR DESCRIPTION
Closes #2857.

## Decision: REMOVE (not wire)

Issue #2857 asked whether to wire or remove the dead owner-only tool-visibility apparatus. A security adjudication concluded **REMOVE**, and this PR applies it. The apparatus in `src/agents/` was a **self-referential dead island with zero live consumers**; the CWE-862 precondition it nominally guarded (a non-owner chat sender reaching an owner-scoped `cron`/`gateway`/`nodes` tool) is architecturally absent.

## Why it's dead (grounded against the code)

- **`applyOwnerOnlyToolPolicy` had zero live callers** — only its own definition, its `MODULE_ATTESTATIONS` entry, and tests. The whole cluster (`isOwnerOnlyTool` → `isOwnerOnlyToolName` → `resolveOwnerOnlyToolApprovalClass` → local `wrapOwnerOnlyToolExecution`) was a closed loop.
- **`owner-only-tools.ts` had no importers** anywhere in the repo.
- **The `.ownerOnly` field was read only by that dead apparatus.** Its two writers (`cron-tool.ts`, `whatsapp-login.ts`) fed only dead readers.
- **`createRemoteClawTools`'s `senderIsOwner?` param was never passed.** Its one live caller, `src/gateway/tools-invoke-http.ts` (`POST /tools/invoke`), omits it and enforces via `DEFAULT_GATEWAY_HTTP_TOOL_DENY` + `applyToolPolicyPipeline` + the gateway deny-list.
- The `"live"` `MODULE_ATTESTATIONS` entry on `applyOwnerOnlyToolPolicy` was a **false-signal hazard** — it claimed an enforcement that never ran.

## The live enforcement is a *separate* mechanism — untouched

Owner-gating that actually runs is **not** this apparatus. It is:

1. **`src/middleware/mcp-tools.ts`** — `registerAllTools` gates the owner-scoped families on `if (ctx.senderIsOwner) { registerCronTools / registerGatewayTools / registerNodeTools / registerCanvasTools / registerBrowserTools / registerTtsTools }`, fed by `senderIsOwner` computed in `src/auto-reply/command-auth.ts` and propagated via `REMOTECLAW_SENDER_IS_OWNER`. Byte-identical before/after.
2. **Gateway HTTP `POST /tools/invoke`** — bearer auth + name-based `DEFAULT_GATEWAY_HTTP_TOOL_DENY` (`src/security/dangerous-tools.ts`). Byte-identical before/after.

`senderIsOwner` therefore survives everywhere it matters; only the dead `src/agents/` apparatus is removed.

## What changed

- **Deleted** `src/agents/tools/owner-only-tools.ts` (whole file).
- **`tool-policy.ts`** — removed the owner-only cluster (`applyOwnerOnlyToolPolicy` + helpers + approval-class map + local `wrapOwnerOnlyToolExecution` + `OwnerOnlyToolApprovalClass`) and its 3 `MODULE_ATTESTATIONS` entries. The file's live plugin-policy functions (allowlist/plugin-group helpers) are untouched.
- **`common.ts`** — removed `ownerOnly?` field on `AnyAgentTool`, `wrapOwnerOnlyToolExecution`, `OWNER_ONLY_TOOL_ERROR`.
- Removed inert `ownerOnly: true` markers (`cron-tool.ts`, `whatsapp-login.ts`) and the unused `senderIsOwner?` param (`remoteclaw-tools.ts`).
- Removed stale, never-run owner-only tests (`src/agents/**` is excluded from CI per `vitest.unit.config.ts`).

Pure deletion: **9 files, 207 deletions, 0 insertions.**

## Verification

- **Apparatus-specific after-grep → zero** (`applyOwnerOnlyToolPolicy`, `wrapOwnerOnlyToolExecution`, `isRemoteClawOwnerOnlyCoreToolName`, `REMOTECLAW_OWNER_ONLY_CORE_TOOL_NAMES`, `resolveOwnerOnlyToolApprovalClass`, `isOwnerOnlyToolName`, `OWNER_ONLY_TOOL_ERROR`, `OwnerOnlyToolApprovalClass`). Surviving `senderIsOwner` hits are all the separate live mechanism above.
- **`pnpm check` passes** (oxfmt + tsgo + oxlint 0/0 + fork-integrity gates).
- **Independent fresh-context security review: PASS** — no non-owner → owner-tool path becomes reachable; both live enforcement paths byte-identical before/after; no dangling live residue.

## Scope notes for review

- **Retained** the public plugin-SDK field `ChannelAgentTool.ownerOnly?` (`src/channels/plugins/types.core.ts:18`, re-exported via `src/plugin-sdk/index.ts`). It is now **inert** (no readers) but removing it would be an unrequested plugin-SDK breaking change, so it is intentionally kept in scope-limited fashion. **Maintainer follow-up options:** (a) keep as-is, (b) remove it (provably dead) in a plugin-SDK-breaking window, or (c) mark it `@deprecated` as inert.
- **Pre-existing, not introduced:** the HTTP `POST /tools/invoke` deny-list does not list `nodes`/`canvas`/`browser`/`tts`, so an authenticated operator-bearer caller can invoke those there. This posture predates #2857 (that path never applied owner-only filtering) and is out of scope here; `nodes` remains covered by its exec-approval gate.

## ⚠️ Do not auto-merge

This PR is **held for an independent security-architect Polish** of the applied diff before merge (per the dispatch that produced it). Auto-merge is intentionally not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
