### PR TITLE
fix(logging): harden redactLogArgLeaves — toJSON post-redaction leak + cycle/depth guard (Closes #2853)

### DIFF
--- a/src/logging/logger-redaction.test.ts
+++ b/src/logging/logger-redaction.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getChildLogger, resetLogger, setLoggerOverride } from "./logger.js";
+import { __test__, getChildLogger, resetLogger, setLoggerOverride } from "./logger.js";
 import { createSubsystemLogger } from "./subsystem.js";
 
 // Regression coverage for issue #2848 (redaction-coverage audit): the file log
@@ -188,6 +188,143 @@ describe("file log write-path redaction", () => {
 
     const content = readLog(file).trim();
     expect(content).toContain("service ready on port 8080");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
+});
+
+// Hardening coverage for issue #2853: two residual gaps in redactLogArgLeaves.
+// (1) an own-enumerable toJSON() re-materializes secrets AFTER the leaf pass
+// because JSON.stringify invokes it later; (2) no intrinsic cycle/depth guard, so
+// a cyclic or pathologically deep graph could overflow the stack (the transport
+// try/catch would then drop the whole line — observability loss). The function is
+// exposed via `__test__` so the depth cap can be asserted deterministically —
+// tslog pre-truncates very deep args on the end-to-end path, which would mask it.
+describe("redactLogArgLeaves hardening (#2853)", () => {
+  const redact = __test__.redactLogArgLeaves;
+
+  afterEach(() => {
+    setLoggerOverride(null);
+    resetLogger();
+  });
+
+  it("materializes and redacts an own-enumerable toJSON returning a secret string", () => {
+    // JSON.stringify would call this toJSON *after* redaction, re-emitting the raw
+    // secret; the pass must invoke it now and redact its output instead.
+    const out = redact({
+      toJSON: () => "connect failed token=supersecretvalue1234567890",
+    }) as string;
+    expect(typeof out).toBe("string");
+    expect(out).not.toContain("supersecretvalue1234567890");
+    expect(out).toContain("connect failed");
+  });
+
+  it("redacts secrets inside a toJSON that returns an object", () => {
+    const serialized = JSON.stringify(
+      redact({ toJSON: () => ({ detail: "token=supersecretvalue1234567890" }) }),
+    );
+    expect(serialized).not.toContain("supersecretvalue1234567890");
+    expect(() => JSON.parse(serialized)).not.toThrow();
+  });
+
+  it("emits [unserializable] when an own-enumerable toJSON throws (line not dropped)", () => {
+    // A throwing toJSON must not propagate out of the redactor — the transport's
+    // try/catch would otherwise drop the whole line. Materialization is caught here
+    // and replaced with a marker so the record still serializes.
+    const out = redact({
+      toJSON: () => {
+        throw new Error("cannot serialize");
+      },
+    });
+    expect(out).toBe("[unserializable]");
+  });
+
+  it("does not invoke a prototype (non-own) toJSON — class instances stay untouched", () => {
+    // A prototype toJSON is not copied onto the rebuilt plain object, so it never
+    // reaches JSON.stringify; the own fields are redacted instead. Guards that the
+    // own-enumerable scoping does not newly invoke an inherited toJSON.
+    class Sneaky {
+      readonly label = "safe-field";
+      toJSON() {
+        return "token=supersecretvalue1234567890";
+      }
+    }
+    const out = redact(new Sneaky()) as Record<string, unknown>;
+    expect(JSON.stringify(out)).not.toContain("supersecretvalue1234567890");
+    expect(out.label).toBe("safe-field");
+  });
+
+  it("leaves a non-function own toJSON as a redacted leaf (not invoked)", () => {
+    const out = redact({ toJSON: "token=supersecretvalue1234567890", other: 1 }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.other).toBe(1);
+    expect(String(out.toJSON)).not.toContain("supersecretvalue1234567890");
+  });
+
+  it("breaks reference cycles with a [cyclic] marker instead of overflowing", () => {
+    const node: Record<string, unknown> = { name: "root" };
+    node.self = node;
+    const out = redact(node) as Record<string, unknown>;
+    expect(out.name).toBe("root");
+    expect(out.self).toBe("[cyclic]");
+    expect(() => JSON.stringify(out)).not.toThrow();
+  });
+
+  it("breaks cycles that route through arrays", () => {
+    const arr: unknown[] = ["head"];
+    arr.push(arr);
+    const out = redact(arr) as unknown[];
+    expect(out[0]).toBe("head");
+    expect(out[1]).toBe("[cyclic]");
+  });
+
+  it("does not flag shared (non-cyclic) references as cyclic", () => {
+    const shared = { k: "v" };
+    const out = redact({ a: shared, b: shared }) as Record<string, Record<string, unknown>>;
+    expect(out.a).toEqual({ k: "v" });
+    expect(out.b).toEqual({ k: "v" });
+  });
+
+  it("bounds pathologically deep graphs with a [maxDepth] marker", () => {
+    const top: Record<string, unknown> = {};
+    let cursor = top;
+    for (let i = 0; i < 100; i++) {
+      const child: Record<string, unknown> = {};
+      cursor.child = child;
+      cursor = child;
+    }
+    const serialized = JSON.stringify(redact(top));
+    expect(serialized).toContain("[maxDepth]");
+    expect(() => JSON.parse(serialized)).not.toThrow();
+  });
+
+  it("still redacts ordinary nested string leaves and preserves non-strings", () => {
+    const out = redact({ detail: "token=supersecretvalue1234567890", port: 8080 }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.port).toBe(8080);
+    expect(String(out.detail)).not.toContain("supersecretvalue1234567890");
+  });
+
+  it("masks an own-enumerable toJSON secret written to the on-disk log", () => {
+    // End-to-end: the residual leak the unit tests guard, proven at the file sink.
+    const file = tmpLogPath("tojson");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    getChildLogger({ subsystem: "gateway" }).error("serialize failed", {
+      toJSON: () => "token=supersecretvalue1234567890",
+    });
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("supersecretvalue1234567890");
+    expect(content).toContain("serialize failed");
     for (const rawLine of content.split("\n").filter(Boolean)) {
       expect(() => JSON.parse(rawLine)).not.toThrow();
     }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -168,26 +168,76 @@ export function isFileLogLevelEnabled(level: LogLevel): boolean {
 // through. See the file transport in `buildLogger` for why redaction must run
 // here, pre-serialization, rather than over the serialized JSON string.
 //
-// Known limitation: a value that materializes its string only at serialization
-// time via an own-enumerable `toJSON()` returning a secret-bearing string is not
-// reached (the recursion sees the object's fields, not the string JSON.stringify
-// later emits). This is non-regressive — the previous serialized-string pass had
-// the same blind spot — and no in-tree caller logs such a shape.
+// An own-enumerable `toJSON()` is intercepted (#2853): JSON.stringify would call
+// it AFTER this pass and re-materialize whatever it returns unredacted, so the
+// method is invoked here and its output redacted before serialization. A
+// prototype / non-enumerable `toJSON` is not copied onto the rebuilt plain object
+// (Object.entries below only copies own-enumerable props), so it never reaches
+// the serializer — class instances stay safe and are left untouched. Recursion is
+// bounded by a visited-set cycle break and a max-depth cap (#2853): a cyclic or
+// deeply-nested graph yields a "[cyclic]" / "[maxDepth]" marker instead of
+// overflowing the stack (the cap bounds recursion depth, not total node count) —
+// which the transport's try/catch would otherwise turn into a silently dropped
+// line.
+const MAX_LOG_ARG_DEPTH = 32;
+
 function redactLogArgLeaves(value: unknown): unknown {
+  return redactLogArgLeaf(value, 0, new WeakSet<object>());
+}
+
+function redactLogArgLeaf(value: unknown, depth: number, seen: WeakSet<object>): unknown {
   if (typeof value === "string") {
     return redactSensitiveText(value);
   }
-  if (Array.isArray(value)) {
-    return value.map(redactLogArgLeaves);
+  // Only arrays and plain (non-Date) objects recurse; everything else — numbers,
+  // booleans, null, undefined, functions, Date — is a leaf and passes through.
+  if (value === null || typeof value !== "object" || value instanceof Date) {
+    return value;
   }
-  if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+  // Depth/cycle guard, shared by both container kinds (see the header comment
+  // for the stack-overflow / dropped-line rationale).
+  if (depth >= MAX_LOG_ARG_DEPTH) {
+    return "[maxDepth]";
+  }
+  if (seen.has(value)) {
+    return "[cyclic]";
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => redactLogArgLeaf(entry, depth + 1, seen));
+    }
+    // An own-enumerable `toJSON` survives the property copy below and is invoked
+    // by JSON.stringify after redaction, re-materializing its (possibly
+    // secret-bearing) return value raw. Intercept it: materialize now and redact
+    // the result — or emit "[unserializable]" if it throws, rather than letting the
+    // exception propagate out and drop the line. Scoped to own-enumerable (via
+    // propertyIsEnumerable) because a prototype / non-enumerable `toJSON` is not
+    // copied onto `out` and so never reaches the serializer — leaving it uninvoked
+    // preserves existing behavior.
+    const maybeToJSON = (value as { toJSON?: unknown }).toJSON;
+    if (
+      typeof maybeToJSON === "function" &&
+      Object.prototype.propertyIsEnumerable.call(value, "toJSON")
+    ) {
+      let materialized: unknown;
+      try {
+        materialized = (maybeToJSON as () => unknown).call(value);
+      } catch {
+        return "[unserializable]";
+      }
+      return redactLogArgLeaf(materialized, depth + 1, seen);
+    }
     const out: Record<string, unknown> = {};
     for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-      out[key] = redactLogArgLeaves(nested);
+      out[key] = redactLogArgLeaf(nested, depth + 1, seen);
     }
     return out;
+  } finally {
+    // Backtrack so a shared (non-cyclic) reference in a sibling position is not
+    // mistaken for a cycle — only an ancestor still on the stack counts.
+    seen.delete(value);
   }
-  return value;
 }
 
 // tslog's `_meta` is framework-generated — runtime info, timestamp, source path,
@@ -414,6 +464,7 @@ export function registerLogTransport(transport: LogTransport): () => void {
 
 export const __test__ = {
   shouldSkipLoadConfigFallback,
+  redactLogArgLeaves,
 };
 
 function formatLocalDate(date: Date): string {


### PR DESCRIPTION
## Summary

Closes #2853. Two **defense-in-depth** hardening items in the file-log write-path
redactor `redactLogArgLeaves` (`src/logging/logger.ts`), both residual to the #2851
`logs.tail` redaction fix. Neither is a live exploit — the demonstrated #2851
exposure stays fully closed for ordinary string/object logging.

### 1. Own-enumerable `toJSON()` re-materialized secrets after leaf redaction
`redactLogArgLeaves` rebuilds objects via `Object.entries`, which copies an
own-enumerable `toJSON` onto the reconstructed object; `JSON.stringify` then
invoked it **after** redaction had already run, emitting the raw return value to
the on-disk log. Now an own-enumerable `toJSON` (scoped via `propertyIsEnumerable`)
is **materialized and recursively redacted** before serialization — matching
`JSON.stringify` semantics (it would use `toJSON`'s output and ignore siblings). A
prototype / non-enumerable `toJSON` is not copied onto the rebuilt plain object, so
class instances stay safe and are left uninvoked (unchanged behavior). A throwing
`toJSON` yields `[unserializable]` rather than propagating out and dropping the line.

### 2. Intrinsic cycle + depth guard
Safety was previously *compositional* (tslog pre-truncates deep args; the transport
`try/catch` drops a line that stack-overflows on a cycle → observability loss). The
redactor is now self-contained: a `WeakSet` cycle break emits `[cyclic]` (with
`finally`-backtracking so shared/diamond references are **not** false-flagged) and a
`MAX_LOG_ARG_DEPTH = 32` cap emits `[maxDepth]` — a marker instead of a lost line or
a blown stack.

## Changes
- `src/logging/logger.ts` — rewrote `redactLogArgLeaves` as a thin seed + inner
  `redactLogArgLeaf(value, depth, seen)`; obsoleted "Known limitation" comment
  replaced with accurate prose; exposed via `__test__` for deterministic depth-cap
  testing (tslog pre-truncation masks it on the end-to-end path).
- `src/logging/logger-redaction.test.ts` — +11 tests: toJSON string/object/
  prototype-safe/non-fn/throwing, cycle (object + array), shared-ref-not-cyclic,
  deep-bound, nested-leaf preservation, and an on-disk end-to-end toJSON masking test.

## Verification
- `pnpm check` (format + typecheck + oxlint + fork-integrity gates) → **0 warnings / 0 errors**.
- Full logging suite → **177 passed / 5 skipped** (pre-existing skips); redaction file **19/19**.
- Adversarially validated in fresh context (12 hostile inputs + pre/post head-to-head):
  both hardening items PASS, ordinary inputs (string/object/Error/Date) unchanged, input never mutated.

## Out-of-scope findings surfaced during adversarial review (pre-existing, non-blocking)
Neither is introduced or worsened by this PR (verified), and both are outside #2853's
scope (which is `toJSON` + cycle/depth). Recommend tracked follow-up:
- **[low] Secret in an object *key* leaks.** `{"token=…":"v"}` is written raw — redaction
  masks string values/leaves, never keys (identical pre/post-fix). Same unredacted file
  sink; uncommon shape (secrets are usually values). Distinct from #2852 (pattern coverage).
- **[info] Shared "doubling" DAG heap-OOM.** A ~31-object DAG (depth ~30, each node
  pointing twice at the same child) expands to ~2³⁰ nodes → heap OOM. The depth cap bounds
  *depth*, not shared *width*; proven identical call counts pre/post-fix. A total-node budget
  would be the fix, deferred as its own robustness item.

## Merge posture
🔒 **Do not auto-merge.** Held for an independent security-architect review of the applied
diff before merge (per dispatch). Auto-merge intentionally not armed.

> CI note: a red `test-ui-smoke` (browser/Vite) lane is a known chronic non-blocking flake,
> unrelated to this change (logging-only).
