### PR TITLE
refactor(gateway): centralize node-pairing nodeId derivation (Closes #2854)

### DIFF
--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { normalizeDeclaredNodeCommands } from "./node-command-policy.js";
+import { normalizeDeclaredNodeCommands, resolveNodeIdFromConnect } from "./node-command-policy.js";
+import type { ConnectParams } from "./protocol/index.js";
+
+function makeConnectParams(overrides: {
+  clientId?: ConnectParams["client"]["id"];
+  deviceId?: string;
+}): ConnectParams {
+  return {
+    minProtocol: 1,
+    maxProtocol: 1,
+    client: {
+      id: overrides.clientId ?? "remoteclaw-macos",
+      version: "1.0.0",
+      platform: "darwin",
+      mode: "node",
+    },
+    ...(overrides.deviceId !== undefined
+      ? {
+          device: {
+            id: overrides.deviceId,
+            publicKey: "public-key",
+            signature: "signature",
+            signedAt: 1,
+            nonce: "nonce",
+          },
+        }
+      : {}),
+  };
+}
 
 describe("gateway/node-command-policy", () => {
   it("normalizes declared node commands against the allowlist", () => {
@@ -10,5 +38,31 @@ describe("gateway/node-command-policy", () => {
         allowlist,
       }),
     ).toEqual(["canvas.snapshot", "system.run"]);
+  });
+
+  describe("resolveNodeIdFromConnect", () => {
+    it("uses the device id as the pairing key when a device identity is present", () => {
+      expect(
+        resolveNodeIdFromConnect(
+          makeConnectParams({ clientId: "remoteclaw-macos", deviceId: "device-abc" }),
+        ),
+      ).toBe("device-abc");
+    });
+
+    it("falls back to the client id when no device identity is present", () => {
+      expect(resolveNodeIdFromConnect(makeConnectParams({ clientId: "remoteclaw-macos" }))).toBe(
+        "remoteclaw-macos",
+      );
+    });
+
+    // Locks the nullish-coalescing (`??`) semantics of this security-relevant key against a
+    // future `??` → `||` regression: a present-but-empty device id is non-nullish, so it wins
+    // over the client id. Empty ids are `NonEmptyString`-rejected at the connect boundary, so
+    // this input is unreachable at runtime — the assertion is defense-in-depth for the operator.
+    it("keeps a present device id under nullish-coalescing even when it is empty", () => {
+      expect(
+        resolveNodeIdFromConnect(makeConnectParams({ clientId: "remoteclaw-macos", deviceId: "" })),
+      ).toBe("");
+    });
   });
 });

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -9,6 +9,24 @@ import {
 // oxlint-disable-next-line typescript/no-explicit-any
 const normalizeDeviceMetadataForPolicy = (value?: string) => (value ?? "").toLowerCase().trim();
 import type { NodeSession } from "./node-registry.js";
+import type { ConnectParams } from "./protocol/index.js";
+
+/**
+ * Canonical node-identity derivation for the node-pairing key.
+ *
+ * A connecting node is registered, paired, and `node.invoke`-authorized under a
+ * single id: its device id when a device identity is present, otherwise its
+ * client id. This is a security-relevant key — it selects the paired-node
+ * record, the pending-pairing entry, and the identity a node is authorized
+ * under — so every pairing site MUST derive it identically. Centralizing the
+ * formula here replaces the former comment-enforced "must stay in sync"
+ * invariant across the pairing sites (`NodeRegistry.register`,
+ * `reconcileNodePairingOnConnect`, and the node connect handler) with sameness
+ * by construction.
+ */
+export function resolveNodeIdFromConnect(connect: ConnectParams): string {
+  return connect.device?.id ?? connect.client.id;
+}
 
 const CANVAS_COMMANDS = [
   "canvas.present",

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -7,6 +7,7 @@ import type {
 import {
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
+  resolveNodeIdFromConnect,
 } from "./node-command-policy.js";
 import type { ConnectParams } from "./protocol/index.js";
 
@@ -58,7 +59,7 @@ export async function reconcileNodePairingOnConnect(params: {
   reportedClientIp?: string;
   requestPairing: (input: NodePairingRequestInput) => Promise<PendingNodePairingResult>;
 }): Promise<NodeConnectPairingReconcileResult> {
-  const nodeId = params.connectParams.device?.id ?? params.connectParams.client.id;
+  const nodeId = resolveNodeIdFromConnect(params.connectParams);
   const allowlist = resolveNodeCommandAllowlist(params.cfg, {
     platform: params.connectParams.client.platform,
     deviceFamily: params.connectParams.client.deviceFamily,

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
+import { resolveNodeIdFromConnect } from "./node-command-policy.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
@@ -158,7 +159,7 @@ export class NodeRegistry {
 
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
     const connect = client.connect;
-    const nodeId = connect.device?.id ?? connect.client.id;
+    const nodeId = resolveNodeIdFromConnect(connect);
     const caps = Array.isArray(connect.caps) ? connect.caps : [];
     const declaredCaps = Array.isArray((connect as { declaredCaps?: string[] }).declaredCaps)
       ? ((connect as { declaredCaps?: string[] }).declaredCaps ?? [])

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -48,6 +48,7 @@ import {
   isTrustedProxyAddress,
   resolveClientIp,
 } from "../../net.js";
+import { resolveNodeIdFromConnect } from "../../node-command-policy.js";
 import { reconcileNodePairingOnConnect } from "../../node-connect-reconcile.js";
 import { checkBrowserOrigin } from "../../origin-check.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
@@ -1107,9 +1108,7 @@ export function attachGatewayWsMessageHandler(params: {
               return;
             }
           }
-          // Must stay in sync with NodeRegistry.register, so the pending pairing entry
-          // is keyed by the same id the node is registered and invoked under.
-          const nodeIdForPairing = connectParams.device?.id ?? connectParams.client.id;
+          const nodeIdForPairing = resolveNodeIdFromConnect(connectParams);
           const reconciled = await reconcileNodePairingOnConnect({
             cfg: loadConfig(),
             connectParams,


### PR DESCRIPTION
> **Note — kept security surface.** This touches the node-pairing auth-key derivation. It is a deliberately behavior-preserving refactor (byte-identical value), but the applied diff warrants an independent security review before merge.

## What

Extracts the node-pairing `nodeId` derivation `connect.device?.id ?? connect.client.id` into a single shared helper `resolveNodeIdFromConnect(connect: ConnectParams)` in `src/gateway/node-command-policy.ts`, and calls it from the three pairing sites that previously inlined the formula under a comment-enforced "must stay in sync" invariant:

1. `src/gateway/node-registry.ts` — `NodeRegistry.register`
2. `src/gateway/node-connect-reconcile.ts` — `reconcileNodePairingOnConnect`
3. `src/gateway/server/ws-connection/message-handler.ts` — the `role === "node"` connect block (`nodeIdForPairing`)

The manual "must stay in sync" comment at the message-handler site is removed — sameness is now guaranteed by construction.

## Why

This id is a **security-relevant key**: it selects the paired-node record, the pending-pairing entry, and the identity a node is `node.invoke`-authorized under. Three independent copies of the formula, kept aligned only by a comment, is a latent drift/authorization hazard. Centralizing replaces the comment-enforced invariant with a single source of truth.

## Behavior-preserving

The derived value is **byte-identical** at all three sites — the formula is centralized, not changed (nullish-coalescing preserved). A focused unit test (`node-command-policy.test.ts`) locks the `device.id`-wins / `client.id`-fallback branches and the `??` operator against a future `??` → `||` regression.

## Scope guard (intentionally NOT folded in)

The similarly-shaped derivations elsewhere are **different** and left untouched:

- `server-methods/{nodes,nodes-pending,nodes.handlers.invoke-result}.ts` — caller-node id via the `client?.connect?.…` wrapper with `?? ""` / `?? "node"` fallbacks.
- `message-handler.ts` presence/instance id — `device?.id ?? instanceId ?? connId`.

Different accessor shape, fallbacks, and semantics.

## Verification

- `pnpm check` green (format + typecheck + lint + fork-integrity gates).
- Gateway unit tests for the helper: 4/4 (`device.id` wins / `client.id` fallback / empty-`device.id` operator lock).

Closes #2854
