### PR TITLE
fix(gateway): prevent concurrent stale-writeback of session metadata — Closes #2858

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -697,4 +697,73 @@ describe("gateway agent handler", () => {
       }),
     );
   });
+
+  it("does not clobber a concurrently-committed metadata field with the stale pre-lock snapshot (#2858)", async () => {
+    // Op A's pre-lock snapshot was loaded BEFORE op B committed — it lacks the
+    // verboseLevel op B set.
+    mockMainSessionEntry({ sessionId: "existing-session-id" });
+
+    // Inside the write lock, op B has already committed verboseLevel=3 to the
+    // canonical entry (older updatedAt, so op A's own write still advances it).
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": {
+          sessionId: "existing-session-id",
+          updatedAt: 10,
+          verboseLevel: 3,
+        },
+      };
+      const result = await updater(store);
+      capturedEntry = store["agent:main:main"] as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await runMainAgent("concurrent op A", "test-idem-2858-noclobber");
+
+    expect(mocks.updateSessionStore).toHaveBeenCalled();
+    expect(capturedEntry).toBeDefined();
+    // Before #2858 the patch was built from the stale pre-lock entry
+    // (verboseLevel undefined), and the object-spread merge overwrote op B's
+    // committed value with undefined. The fix sources the patch from the fresh
+    // in-lock entry, so op B's field survives...
+    expect(capturedEntry?.verboseLevel).toBe(3);
+    // ...and op A's own write still lands (updatedAt advances past op B's).
+    expect(capturedEntry?.updatedAt as number).toBeGreaterThan(10);
+  });
+
+  it("adopts a concurrently-rotated sessionId instead of forcing the stale one back (#2858)", async () => {
+    // Op A's pre-lock snapshot holds the stale identity.
+    mockMainSessionEntry({ sessionId: "stale-session-id" });
+
+    // Inside the write lock, op B has already rotated the identity.
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": {
+          sessionId: "rotated-session-id",
+          updatedAt: 10,
+        },
+      };
+      const result = await updater(store);
+      capturedEntry = store["agent:main:main"] as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await runMainAgent("op A after rotation", "test-idem-2858-rotation");
+
+    // The persisted entry keeps the fresh identity rather than the stale one...
+    expect(capturedEntry?.sessionId).toBe("rotated-session-id");
+    // ...and the dispatched run uses it (resolvedSessionId reflects the persist).
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(readLastAgentCommandCall()?.sessionId).toBe("rotated-session-id");
+  });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -56,6 +56,7 @@ import {
   canonicalizeSpawnedByForAgent,
   loadSessionEntry,
   pruneLegacyStoreKeys,
+  resolveFreshestSessionStoreMatchFromStoreKeys,
   resolveGatewaySessionStoreTarget,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -492,33 +493,52 @@ export const agentHandlers: GatewayRequestHandlers = {
       resolvedGroupId = resolvedGroupId || inheritedGroup?.groupId;
       resolvedGroupChannel = resolvedGroupChannel || inheritedGroup?.groupChannel;
       resolvedGroupSpace = resolvedGroupSpace || inheritedGroup?.groupSpace;
-      const deliveryFields = normalizeSessionDeliveryFields(entry);
-      const nextEntryPatch: SessionEntry = {
-        sessionId,
-        updatedAt: now,
-        verboseLevel: entry?.verboseLevel,
-        reasoningLevel: entry?.reasoningLevel,
-        systemSent: entry?.systemSent,
-        sendPolicy: entry?.sendPolicy,
-        skillsSnapshot: entry?.skillsSnapshot,
-        deliveryContext: deliveryFields.deliveryContext,
-        lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
-        lastTo: deliveryFields.lastTo ?? entry?.lastTo,
-        lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
-        modelOverride: entry?.modelOverride,
-        providerOverride: entry?.providerOverride,
-        label: labelValue,
-        spawnedBy: spawnedByValue,
-        spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
-        spawnDepth: entry?.spawnDepth,
-        channel: entry?.channel ?? request.channel?.trim(),
-        groupId: resolvedGroupId ?? entry?.groupId,
-        groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
-        space: resolvedGroupSpace ?? entry?.space,
-        cliSessionIds: entry?.cliSessionIds,
-        claudeCliSessionId: entry?.claudeCliSessionId,
+      // Build the session-store patch from a supplied source entry so the
+      // persisted merge (below) can source every carried-forward / fallback
+      // field from the FRESH in-lock entry rather than the pre-lock snapshot.
+      // Request-resolved intent (label, spawnedBy, resolved group ids, now) is
+      // captured as-is; only the fields sourced from / falling back to this
+      // session's own entry read from `sourceEntry`. This prevents concurrent
+      // same-session ops from clobbering each other's committed metadata (#2858).
+      const buildNextEntryPatch = (sourceEntry: SessionEntry | undefined): SessionEntry => {
+        const deliveryFields = normalizeSessionDeliveryFields(sourceEntry);
+        return {
+          // Prefer the fresh entry's identity when a concurrent op rotated it
+          // since the pre-lock load; otherwise fall back to the pre-lock
+          // sessionId (a fresh randomUUID for first-time sessions).
+          sessionId: sourceEntry?.sessionId ?? sessionId,
+          updatedAt: now,
+          verboseLevel: sourceEntry?.verboseLevel,
+          reasoningLevel: sourceEntry?.reasoningLevel,
+          systemSent: sourceEntry?.systemSent,
+          sendPolicy: sourceEntry?.sendPolicy,
+          skillsSnapshot: sourceEntry?.skillsSnapshot,
+          deliveryContext: deliveryFields.deliveryContext,
+          lastChannel: deliveryFields.lastChannel ?? sourceEntry?.lastChannel,
+          lastTo: deliveryFields.lastTo ?? sourceEntry?.lastTo,
+          lastAccountId: deliveryFields.lastAccountId ?? sourceEntry?.lastAccountId,
+          modelOverride: sourceEntry?.modelOverride,
+          providerOverride: sourceEntry?.providerOverride,
+          // label / spawnedBy carry this op's request-resolved intent (scoped
+          // out of the fresh-source switch per #2858; low concurrent-write risk).
+          label: labelValue,
+          spawnedBy: spawnedByValue,
+          spawnedWorkspaceDir: sourceEntry?.spawnedWorkspaceDir,
+          spawnDepth: sourceEntry?.spawnDepth,
+          channel: sourceEntry?.channel ?? request.channel?.trim(),
+          groupId: resolvedGroupId ?? sourceEntry?.groupId,
+          groupChannel: resolvedGroupChannel ?? sourceEntry?.groupChannel,
+          space: resolvedGroupSpace ?? sourceEntry?.space,
+          cliSessionIds: sourceEntry?.cliSessionIds,
+          claudeCliSessionId: sourceEntry?.claudeCliSessionId,
+        };
       };
-      sessionEntry = mergeSessionEntry(entry, nextEntryPatch);
+      // Provisional entry for the no-store path / pre-persist use. Built from the
+      // pre-lock `entry`; behavior is unchanged when `storePath` is falsy.
+      sessionEntry = mergeSessionEntry(entry, buildNextEntryPatch(entry));
+      // Per-op ALLOW/DENY gate, intentionally evaluated against the pre-lock
+      // `entry`: it is a decision about THIS request, not persisted metadata, so
+      // it is out of scope for the stale-writeback fix (#2858) and unchanged.
       const sendPolicy = resolveSendPolicy({
         cfg,
         entry,
@@ -546,16 +566,38 @@ export const agentHandlers: GatewayRequestHandlers = {
             key: requestedSessionKey,
             store,
           });
+          // Re-derive the freshest committed entry the same way loadSessionEntry
+          // does (freshest match across candidate keys), inside the lock and
+          // BEFORE pruning — prune deletes the legacy keys the freshest match may
+          // live under. Building the patch from THIS fresh entry, rather than the
+          // pre-lock snapshot, is what prevents a concurrent same-session
+          // writer's just-committed metadata from being clobbered. In the
+          // non-racing case this equals the pre-lock `entry`, so the single-op
+          // path is byte-identical. Fall back to the pre-lock `entry` only when
+          // the session is absent from the in-lock store (nothing committed to
+          // clobber — a concurrent writer always lands under a candidate key, so
+          // this fallback never reintroduces the race). See #2858.
+          const freshEntry =
+            resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys)?.entry ?? entry;
           pruneLegacyStoreKeys({
             store,
             canonicalKey: target.canonicalKey,
             candidates: target.storeKeys,
           });
-          const merged = mergeSessionEntry(store[canonicalSessionKey], nextEntryPatch);
+          // Base stays `store[canonicalSessionKey]` (unchanged from the original);
+          // only the patch source moves from the stale pre-lock `entry` to
+          // `freshEntry`.
+          const merged = mergeSessionEntry(
+            store[canonicalSessionKey],
+            buildNextEntryPatch(freshEntry),
+          );
           store[canonicalSessionKey] = merged;
           return merged;
         });
         sessionEntry = persisted;
+        // Reflect the persisted (possibly concurrently-rotated) identity so the
+        // dispatched run and abort controller use the committed sessionId.
+        resolvedSessionId = persisted?.sessionId ?? resolvedSessionId;
       }
       if (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") {
         context.addChatRun(idem, {


### PR DESCRIPTION
Closes #2858.

## Problem

The gateway `agent` handler's `if (requestedSessionKey) { … }` block
(`src/gateway/server-methods/agent.ts`) builds the session-store patch
(`nextEntryPatch`) from the **pre-lock** `entry` snapshot — an unlocked
`loadSessionEntry` read at `agent.ts:466` — then merges it **inside** the
`updateSessionStore` write lock.

`updateSessionStore` serializes only the write callback and re-reads the store
fresh inside the lock; it does **not** cover the pre-lock read. A second
same-session op scheduled during the `await updateSessionStore` yield reads the
still-uncommitted store at its own pre-lock point, queues behind op A on the
write lock, then its patch — built from the pre-A snapshot — clobbers op A's
committed fields. `mergeSessionEntryWithPolicy` does `{ ...existing, ...patch }`,
so every key present in the patch (many sourced from `entry?.*`, some literally
`undefined`) overwrites the fresh base. **`sendPolicy` is among the clobbered
fields** — this is a kept high-sensitivity gateway surface.

Reachable, not latent: the `466 → 554` path yields at real file I/O and there is
no per-session end-to-end run serialization (only the narrow store-write lock).

## Fix

- Factor the patch construction into `buildNextEntryPatch(sourceEntry)`; every
  field sourced from / falling back to the session's own entry now reads from
  `sourceEntry` (incl. `sendPolicy`, `verboseLevel`, `reasoningLevel`,
  `systemSent`, `skillsSnapshot`, `modelOverride`, `providerOverride`,
  delivery/`last*`, `channel`, `group*`, `cliSessionIds`, `claudeCliSessionId`,
  `spawnDepth`, `spawnedWorkspaceDir`, `sessionId`).
- Inside the write lock, derive the freshest committed entry the **same way
  `loadSessionEntry` does** —
  `resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys)`,
  computed **before** `pruneLegacyStoreKeys` (which deletes the legacy keys the
  freshest match may live under) — and build the patch from it. Fall back to the
  pre-lock `entry` only when the session is absent from the in-lock store
  (nothing committed to clobber; a concurrent writer always lands under a
  candidate key, so the fallback never reintroduces the race).
- **Base is unchanged** (`store[canonicalSessionKey]`), so the single-op path is
  byte-identical.
- **sessionId rotation guard**: if a concurrent op rotated the identity, the
  fresh entry wins (`sourceEntry?.sessionId ?? sessionId`) and
  `resolvedSessionId` is reflected from the persisted entry so the downstream
  dispatch + abort-controller registration use the committed id.

## Scope

- The pre-lock `resolveSendPolicy` **DENY gate** (a per-request ALLOW/DENY
  decision, not persisted metadata) and the **parent-group inheritance block**
  (reads a *different* session) are intentionally unchanged.
- `label` / `spawnedBy` deliberately retain their request-resolved values
  (documented in-code). **Flagged for review:** an op with no `request.label`
  racing a concurrent label change could still carry a stale `label` — a narrow,
  non-regressive residual (pre-fix these were also written from the pre-lock
  snapshot), symmetric with `spawnedBy`, and low-churn. Extendable if the
  reviewer wants `label` on the fresh-source switch too.
- Diverged from the original literal recommendation (`store[canonicalSessionKey]`
  as the fresh source): that reads a **post-prune** slot and would lose metadata
  in the legacy-key migration case, breaking the byte-identical guarantee. Using
  the pre-prune freshest match + `?? entry` fallback honors the guarantee in all
  single-op cases (incl. legacy keys).

## Tests

Two regression tests added (`agent.test.ts`), corpse-verified fail-before /
pass-after:
- concurrent-metadata no-clobber (op B's `verboseLevel` survives; op A's write
  still lands) — pre-fix: `expected undefined to be 3`.
- `sessionId` rotation guard (persisted entry **and** dispatched run use the
  rotated id) — pre-fix: `expected 'stale-session-id' to be 'rotated-session-id'`.

`pnpm check` (format + `tsgo` + `oxlint` + fork gates): green.
Gateway suite slice (agent + session-utils + sessions-patch + broader
session/agent): 143 passing, 0 failing. Independent fresh-context adversarial
validation: **CLEAN** (7/7 claims). LIVE smoke not required (touches
`src/gateway/`, not `src/middleware/`).

## ⚠ HELD — do not merge yet

Per the dispatch, this PR is **held for an independent security-architect Polish**
of the applied diff before merge (kept high-sensitivity gateway surface;
`sendPolicy` among the previously-clobbered fields). Auto-merge intentionally
**not** enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
