### PR TITLE
fix(channels): inherit shared policy defaults onto named accounts on promotion (#2097)

### DIFF
--- a/src/commands/doctor-legacy-config.test.ts
+++ b/src/commands/doctor-legacy-config.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../config/config.js";
+import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
+
+// Regression coverage for remoteclaw/remoteclaw#2097 (security): the single→multi-account
+// promotion (`seedMissingDefaultAccountsFromSingleAccountBase`) moved channel-top-level access
+// policy into `accounts.default` but silently STRIPPED those shared defaults from existing named
+// accounts. Because the top-level keys acted as inherited defaults, a stripped named account could
+// flip from allowlist-gated to OPEN. The fix inherits the moved policy keys onto every named
+// account that does not already define its own value. Adapted from upstream commit 7b461676072.
+//
+// NOTE: `src/commands/**` is currently excluded from every CI vitest lane (`vitest.unit.config.ts`
+// excludes it, and no other config includes it), so this suite is verified locally rather than in
+// CI. Colocated per repo convention; run it with:
+//   node ./node_modules/vitest/vitest.mjs run --config vitest.config.ts src/commands/doctor-legacy-config.test.ts
+
+type AccountsByChannel = Record<string, { accounts?: Record<string, unknown> }>;
+
+const accountsOf = (
+  config: RemoteClawConfig,
+  channelId: string,
+): Record<string, unknown> | undefined =>
+  (config.channels as AccountsByChannel | undefined)?.[channelId]?.accounts;
+
+describe("normalizeCompatibilityConfigValues — single-account promotion policy inheritance (#2097)", () => {
+  it.each(["slack", "discord", "telegram", "signal"])(
+    "preserves inherited %s access policy on existing named accounts when seeding accounts.default",
+    (channelId) => {
+      const res = normalizeCompatibilityConfigValues({
+        channels: {
+          [channelId]: {
+            dmPolicy: "allowlist",
+            allowFrom: ["sender-1"],
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["group-sender-1"],
+            accounts: {
+              work: { enabled: true },
+            },
+          },
+        },
+      } as unknown as RemoteClawConfig);
+
+      const accounts = accountsOf(res.config, channelId);
+
+      // accounts.default still receives the moved values (existing behavior, unchanged).
+      expect(accounts?.default).toEqual({
+        dmPolicy: "allowlist",
+        allowFrom: ["sender-1"],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["group-sender-1"],
+      });
+      // The regression: the existing named account must RETAIN the inherited policy, not lose it.
+      expect(accounts?.work).toEqual({
+        enabled: true,
+        dmPolicy: "allowlist",
+        allowFrom: ["sender-1"],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["group-sender-1"],
+      });
+      expect(res.changes).toContain(
+        `Moved channels.${channelId} single-account top-level values into channels.${channelId}.accounts.default.`,
+      );
+    },
+  );
+
+  it("keeps a named account's own policy overrides while inheriting only the rest", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        discord: {
+          dmPolicy: "allowlist",
+          allowFrom: ["top-dm"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["top-group"],
+          accounts: {
+            work: {
+              token: "work-token",
+              allowFrom: ["work-dm"],
+              groupPolicy: "disabled",
+            },
+          },
+        },
+      },
+    } as unknown as RemoteClawConfig);
+
+    // allowFrom + groupPolicy are the account's own values (never clobbered); dmPolicy +
+    // groupAllowFrom are inherited because the account did not define them.
+    expect(accountsOf(res.config, "discord")?.work).toEqual({
+      token: "work-token",
+      dmPolicy: "allowlist",
+      allowFrom: ["work-dm"],
+      groupPolicy: "disabled",
+      groupAllowFrom: ["top-group"],
+    });
+  });
+
+  it("moves defaultTo into accounts.default but does NOT inherit it onto named accounts", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        slack: {
+          defaultTo: "work",
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["group-sender-1"],
+          accounts: {
+            work: { token: "work-token" },
+          },
+        },
+      },
+    } as unknown as RemoteClawConfig);
+
+    const accounts = accountsOf(res.config, "slack");
+    // accounts.default receives every moved key, including the routing default `defaultTo`.
+    expect(accounts?.default).toEqual({
+      defaultTo: "work",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["group-sender-1"],
+    });
+    // The named account inherits access-policy keys only — `defaultTo` is a routing default,
+    // not an access policy, and must not be duplicated onto each account (caller-confirmed).
+    expect(accounts?.work).toEqual({
+      token: "work-token",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["group-sender-1"],
+    });
+  });
+
+  it("preserves inherited policy across multiple named accounts, cloning object values independently", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        discord: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["group-sender-1"],
+          accounts: {
+            work: { token: "work-token" },
+            research: { token: "research-token" },
+          },
+        },
+      },
+    } as unknown as RemoteClawConfig);
+
+    const accounts = accountsOf(res.config, "discord");
+    expect(accounts?.work).toEqual({
+      token: "work-token",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["group-sender-1"],
+    });
+    expect(accounts?.research).toEqual({
+      token: "research-token",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["group-sender-1"],
+    });
+    // Inherited array values must be independent clones, not shared references across accounts.
+    const work = accounts?.work as { groupAllowFrom: string[] };
+    const research = accounts?.research as { groupAllowFrom: string[] };
+    expect(work.groupAllowFrom).not.toBe(research.groupAllowFrom);
+  });
+});

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -10,6 +10,13 @@ import {
 } from "../config/discord-preview-streaming.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 
+// Account-scoped access-policy keys that act as shared channel-level defaults. During the
+// single→multi-account promotion (seedMissingDefaultAccountsFromSingleAccountBase) these must be
+// inherited onto existing named accounts, not silently stripped when the channel-top-level values
+// are moved into accounts.default — otherwise an allowlist-gated channel can flip OPEN.
+// See remoteclaw/remoteclaw#2097 (adapted from upstream commit 7b461676072).
+const INHERITED_ACCOUNT_POLICY_KEYS = ["dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"];
+
 export function normalizeCompatibilityConfigValues(cfg: RemoteClawConfig): {
   config: RemoteClawConfig;
   changes: string[];
@@ -19,6 +26,9 @@ export function normalizeCompatibilityConfigValues(cfg: RemoteClawConfig): {
 
   const isRecord = (value: unknown): value is Record<string, unknown> =>
     Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+  const cloneIfObject = (value: unknown): unknown =>
+    value && typeof value === "object" ? structuredClone(value) : value;
 
   const normalizeDmAliases = (params: {
     provider: "slack" | "discord";
@@ -331,8 +341,7 @@ export function normalizeCompatibilityConfigValues(cfg: RemoteClawConfig): {
 
       const defaultAccount: Record<string, unknown> = {};
       for (const key of keysToMove) {
-        const value = rawChannel[key];
-        defaultAccount[key] = value && typeof value === "object" ? structuredClone(value) : value;
+        defaultAccount[key] = cloneIfObject(rawChannel[key]);
       }
       const nextChannel: Record<string, unknown> = {
         ...rawChannel,
@@ -340,10 +349,37 @@ export function normalizeCompatibilityConfigValues(cfg: RemoteClawConfig): {
       for (const key of keysToMove) {
         delete nextChannel[key];
       }
-      nextChannel.accounts = {
+      const inheritedPolicyKeys = INHERITED_ACCOUNT_POLICY_KEYS.filter((key) =>
+        keysToMove.includes(key),
+      );
+      const nextAccounts: Record<string, unknown> = {
         ...rawAccounts,
         [DEFAULT_ACCOUNT_ID]: defaultAccount,
       };
+      // The moved keys previously acted as shared defaults for every existing named account
+      // (they were resolved from the channel top level). Preserve that inheritance: copy each
+      // moved policy key down onto every named account that does not already define its own
+      // value. Never clobber an account's own override, and only inherit keys actually moved.
+      if (inheritedPolicyKeys.length > 0) {
+        for (const [accountId, rawAccount] of Object.entries(rawAccounts)) {
+          if (!isRecord(rawAccount)) {
+            continue;
+          }
+          const nextAccount = { ...rawAccount };
+          let accountChanged = false;
+          for (const key of inheritedPolicyKeys) {
+            if (Object.prototype.hasOwnProperty.call(nextAccount, key)) {
+              continue;
+            }
+            nextAccount[key] = cloneIfObject(rawChannel[key]);
+            accountChanged = true;
+          }
+          if (accountChanged) {
+            nextAccounts[accountId] = nextAccount;
+          }
+        }
+      }
+      nextChannel.accounts = nextAccounts;
 
       nextChannels[channelId] = nextChannel;
       channelsChanged = true;


### PR DESCRIPTION
## Summary

Security-regression fix. The doctor single→multi-account promotion
(`seedMissingDefaultAccountsFromSingleAccountBase` in `src/commands/doctor-legacy-config.ts`) moved
channel-top-level access-policy keys (`dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`) into
`accounts.default` when named accounts existed but `default` did not — **but silently stripped those
keys from the existing named accounts**. Because the top-level keys acted as inherited shared
defaults, a stripped named account could flip from allowlist-gated to **OPEN**. Slack, Discord,
WhatsApp, Signal, iMessage, and IRC were all affected (only Telegram/Matrix had the move-guard).

**Fix**: copy each *moved* policy key down onto every existing named account that does not already
define its own value — never clobbering an account's own override, and only for keys actually in
`keysToMove`. `accounts.default` seeding is unchanged.

Adapted port of upstream openclaw `7b461676072` ("preserve migrated account policies"), fitted to the
fork's consolidated doctor code. `defaultTo` is intentionally **not** inherited (it's a routing
default, not an access policy — matches upstream's constant).

Closes #2097.

> The issue's Options 2 (`namedAccountPromotionKeys`) & 3 were not viable for the fork: the promotion
> logic here is inlined in the doctor normalizer, not the upstream symbols. The other promotion path
> (`channels add` → `moveSingleAccountChannelSectionToDefaultAccount` in `setup-helpers.ts`)
> early-returns unchanged for non-matrix channels that already have named accounts, so it is **not**
> vulnerable and is left untouched — matching upstream, which fixed only the doctor normalizer.

## Changes

- `src/commands/doctor-legacy-config.ts` — new module const `INHERITED_ACCOUNT_POLICY_KEYS` (4 flat
  keys) + the inheritance loop; extracted a local `cloneIfObject` helper (DRYs the existing
  clone-ternary; matches the `cloneIfObject` idiom already in `setup-helpers.ts`).
- `src/commands/doctor-legacy-config.test.ts` *(new)* — 7 regression assertions.

## Test evidence

- **Red → green** proven: with the source fix stashed, all **7 tests fail**
  (`expected { enabled: true } to deeply equal { enabled: true, …(4) }` — the named account stripped);
  with the fix, **7 pass**.
- Coverage: cross-channel inheritance (slack/discord/telegram/signal, parametrized), never-clobber
  partial inheritance, `defaultTo`-exclusion guard, and independent per-account clones.
- `pnpm check` green (oxfmt + tsgo strict + oxlint + fork-integrity gates).
- Independently re-verified by a fresh-context adversarial validation pass (all 8 completion claims
  PASS; the 6 non-matrix channels' newly-reachable state is CLEAN — resolvers use replace-semantics
  and empty allowlists fail closed).

> ⚠️ **CI-coverage note**: `src/commands/**` is currently excluded from **every** CI vitest lane
> (`vitest.unit.config.ts` excludes it; no other config includes it — the existing isolated
> `src/commands/doctor.*` entries in `scripts/test-parallel.mjs` are silently skipped for the same
> reason). This suite is therefore **verified locally, not in CI**. I deliberately did **not** wire it
> into the isolated list (that would imply CI coverage that does not exist). Giving `src/commands/` a
> real CI lane is out of scope here (the excluded suites likely carry pre-existing failures) — flagging
> for a follow-up.

## ⚠️ Security residual — reviewer action needed (matrix)

The adversarial validation surfaced one **empirically-confirmed** same-class residual that this fix
does **not** cover, and in one idiom **locally worsens** — deliberately routed here for your call:

- **What**: the doctor path lacks the matrix move-guard that `setup-helpers.ts` already has, so for a
  matrix multi-account config it moves matrix's *own* gating keys (`allowlistOnly`, nested `dm`) into
  `accounts.default`. `INHERITED_ACCOUNT_POLICY_KEYS` covers only the 4 flat keys, so siblings do not
  re-inherit `allowlistOnly`/`dm`.
- **Worsening idiom**: `matrix: { allowlistOnly: true, groupPolicy: "open", dm: {…}, accounts: { ≥2 named, no default } }`.
  Pre-fix, a stripped sibling fell to the fail-closed `"allowlist"` default (gated). Post-fix it
  inherits `groupPolicy: "open"` **without** the `allowlistOnly` that would re-tighten it → effective
  groups gating **"open"**.
- **Provenance**: this is an **upstream-parity gap** — upstream `7b461676072` inherits the same 4 flat
  keys and is equally affected; it is **not** introduced by this fork adaptation. (The fork does have an
  internal inconsistency: its `setup-helpers` path already guards matrix while its doctor path does not.)
- **Recommended fix** (deferred to your decision, in-PR or as a tracked follow-up): give the doctor
  path the same matrix guard `setup-helpers` carries (`MATRIX_NAMED_ACCOUNT_PROMOTION_KEYS`) so matrix
  gating keys stay top-level as shared defaults rather than being moved-then-partially-inherited — plus
  a matrix multi-account regression test.

Scope was held to the caller-prescribed faithful upstream port (the 6 non-matrix channels); the matrix
call is surfaced for the security review rather than resolved unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
