### PR TITLE
Part of #2812: auto-update kill switch (update-startup)

### DIFF
--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -69,7 +69,12 @@ describe("update-startup", () => {
     vi.setSystemTime(new Date("2026-01-17T10:00:00Z"));
     tempDir = path.join(suiteRoot, `case-${++suiteCase}`);
     await fs.mkdir(tempDir);
-    envSnapshot = captureEnv(["REMOTECLAW_STATE_DIR", "NODE_ENV", "VITEST"]);
+    envSnapshot = captureEnv([
+      "REMOTECLAW_NO_AUTO_UPDATE",
+      "REMOTECLAW_STATE_DIR",
+      "NODE_ENV",
+      "VITEST",
+    ]);
     process.env.REMOTECLAW_STATE_DIR = tempDir;
 
     process.env.NODE_ENV = "test";
@@ -371,6 +376,30 @@ describe("update-startup", () => {
     });
 
     expect(runAutoUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors REMOTECLAW_NO_AUTO_UPDATE for configured auto-updates", async () => {
+    mockPackageUpdateStatus("beta", "2.0.0-beta.1");
+    process.env.REMOTECLAW_NO_AUTO_UPDATE = "1";
+    const log = { info: vi.fn() };
+    const runAutoUpdate = createAutoUpdateSuccessMock();
+
+    await runGatewayUpdateCheck({
+      cfg: createBetaAutoUpdateConfig(),
+      log,
+      isNixMode: false,
+      allowInTests: true,
+      runAutoUpdate,
+    });
+
+    expect(runAutoUpdate).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      "auto-update disabled by REMOTECLAW_NO_AUTO_UPDATE",
+      expect.objectContaining({
+        version: "2.0.0-beta.1",
+        tag: "beta",
+      }),
+    );
   });
 
   it("uses current runtime + entrypoint for default auto-update command execution", async () => {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -7,6 +7,7 @@ import type { RemoteClawConfig } from "../config/types.remoteclaw.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { VERSION } from "../version.js";
+import { isTruthyEnvValue } from "./env.js";
 import { writeJsonAtomic } from "./json-files.js";
 import { resolveRemoteClawPackageRoot } from "./remoteclaw-root.js";
 import { normalizeUpdateChannel, DEFAULT_PACKAGE_CHANNEL } from "./update-channels.js";
@@ -317,8 +318,10 @@ export async function runGatewayUpdateCheck(params: {
     return;
   }
   const auto = resolveAutoUpdatePolicy(params.cfg);
+  const autoDisabledByEnv = isTruthyEnvValue(process.env.REMOTECLAW_NO_AUTO_UPDATE);
+  const shouldRunAutoUpdate = auto.enabled && !autoDisabledByEnv;
   const shouldRunUpdateHints = params.cfg.update?.checkOnStart !== false;
-  if (!shouldRunUpdateHints && !auto.enabled) {
+  if (!shouldRunUpdateHints && !shouldRunAutoUpdate) {
     return;
   }
 
@@ -338,7 +341,9 @@ export async function runGatewayUpdateCheck(params: {
       onUpdateAvailableChange: params.onUpdateAvailableChange,
     });
   }
-  const checkIntervalMs = resolveCheckIntervalMs(params.cfg);
+  const checkIntervalMs = shouldRunAutoUpdate
+    ? resolveCheckIntervalMs(params.cfg)
+    : UPDATE_CHECK_INTERVAL_MS;
   if (lastCheckedAt && Number.isFinite(lastCheckedAt)) {
     if (now - lastCheckedAt < checkIntervalMs) {
       return;
@@ -407,7 +412,14 @@ export async function runGatewayUpdateCheck(params: {
       nextState.lastNotifiedTag = tag;
     }
 
-    if (auto.enabled && (channel === "stable" || channel === "beta")) {
+    if (auto.enabled && autoDisabledByEnv) {
+      params.log.info("auto-update disabled by REMOTECLAW_NO_AUTO_UPDATE", {
+        version: resolved.version,
+        tag,
+      });
+    }
+
+    if (shouldRunAutoUpdate && (channel === "stable" || channel === "beta")) {
       const runAuto = params.runAutoUpdate ?? runAutoUpdateCommand;
       const attemptIntervalMs =
         channel === "beta"


### PR DESCRIPTION
## What

Ports the auto-update **kill switch** from the deferred upstream OpenClaw
delta (`v2026.4.24..v2026.4.26`, source commit `36a936af661`) onto the fork's
`src/infra/update-startup.ts`.

When `REMOTECLAW_NO_AUTO_UPDATE` is truthy, `runGatewayUpdateCheck`:

- skips configured auto-updates (`shouldRunAutoUpdate = auto.enabled && !autoDisabledByEnv`),
- still surfaces update **hints** (the env var only gates the auto-*apply*, not the notification),
- logs `auto-update disabled by REMOTECLAW_NO_AUTO_UPDATE` when auto-update was otherwise enabled,
- falls back to the default 24h check interval instead of the auto-update cadence.

## Fork adaptations

- **Rebrand**: upstream's `OPENCLAW_NO_AUTO_UPDATE` → `REMOTECLAW_NO_AUTO_UPDATE`.
- Reuses the fork's existing `isTruthyEnvValue` helper (`src/infra/env.ts`) — no new helper.
- The companion test rebrands the env var and adds it to the `captureEnv` isolation list so
  `afterEach` restore deletes it (it was never set before the case).

## Scope

`#2812` is file-scoped; this sub-item ports **only** `src/infra/update-startup.ts` +
`src/infra/update-startup.test.ts`. The source commit's `CHANGELOG.md` /
`docs/install/updating.md` touches are intentionally **not** included, and the fork has no
existing doc mention of this env var to update.

## Verification

- `pnpm test` (targeted): `src/infra/update-startup.test.ts` — **11 passed** (10 existing + 1 new).
- `pnpm check` — green (format, `tsgo`, oxlint 0/0, no-`.ai`, lobster-leak, css-class-drift).
- `pnpm build` — green.

Part of #2812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
