### PR TITLE
Part of #2812: harden bundled plugin install/uninstall sweep

### DIFF
--- a/src/plugins/bundled-sources.test.ts
+++ b/src/plugins/bundled-sources.test.ts
@@ -74,6 +74,7 @@ describe("bundled plugin sources", () => {
       pluginId: "feishu",
       localPath: "/app/extensions/feishu",
       npmSpec: "@remoteclaw/feishu",
+      requiresConfig: false,
     });
   });
 
@@ -127,6 +128,41 @@ describe("bundled plugin sources", () => {
     expect(resolved?.pluginId).toBe("diffs");
     expect(resolved?.localPath).toBe("/app/extensions/diffs");
     expect(missing).toBeUndefined();
+  });
+
+  it("marks bundled sources that require plugin config before activation", () => {
+    discoverRemoteClawPluginsMock.mockReturnValue({
+      candidates: [
+        {
+          origin: "bundled",
+          rootDir: "/app/extensions/memory-lancedb",
+          packageName: "@remoteclaw/memory-lancedb",
+          packageManifest: { install: { npmSpec: "@remoteclaw/memory-lancedb" } },
+        },
+      ],
+      diagnostics: [],
+    });
+    loadPluginManifestMock.mockReturnValue({
+      ok: true,
+      manifest: {
+        id: "memory-lancedb",
+        configSchema: {
+          type: "object",
+          required: ["embedding"],
+        },
+      },
+    });
+
+    expect(resolveBundledPluginSources({}).get("memory-lancedb")).toEqual({
+      pluginId: "memory-lancedb",
+      localPath: "/app/extensions/memory-lancedb",
+      npmSpec: "@remoteclaw/memory-lancedb",
+      configSchema: {
+        type: "object",
+        required: ["embedding"],
+      },
+      requiresConfig: true,
+    });
   });
 
   it("reuses a pre-resolved bundled map for repeated lookups", () => {

--- a/src/plugins/bundled-sources.ts
+++ b/src/plugins/bundled-sources.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { isRecord } from "../utils.js";
 import { discoverRemoteClawPlugins } from "./discovery.js";
 import { loadPluginManifest } from "./manifest.js";
 
@@ -6,6 +7,8 @@ export type BundledPluginSource = {
   pluginId: string;
   localPath: string;
   npmSpec?: string;
+  configSchema?: Record<string, unknown>;
+  requiresConfig?: boolean;
 };
 
 export type BundledPluginLookup =
@@ -59,10 +62,22 @@ export function resolveBundledPluginSources(params: {
       pluginId,
       localPath: candidate.rootDir,
       npmSpec,
+      ...(isRecord(manifest.manifest.configSchema)
+        ? { configSchema: manifest.manifest.configSchema }
+        : {}),
+      requiresConfig: pluginConfigSchemaHasRequiredFields(manifest.manifest.configSchema),
     });
   }
 
   return bundled;
+}
+
+function pluginConfigSchemaHasRequiredFields(schema: unknown): boolean {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  const required = schema.required;
+  return Array.isArray(required) && required.some((entry) => typeof entry === "string");
 }
 
 export function findBundledPluginSource(params: {


### PR DESCRIPTION
## What

Keep-layer port of upstream `caba05b94a2`, scoped to the bundled-plugin sweep only. `resolveBundledPluginSources` now surfaces two new (optional) fields on every `BundledPluginSource`:

- `configSchema` — the plugin manifest's config schema, when present.
- `requiresConfig` — `true` when that schema declares one or more `required` string fields.

This lets the bundled plugin install/uninstall sweep distinguish plugins that need configuration before activation from those that are safe to activate as-is.

## Upstream delta

Net diff of `v2026.4.24..v2026.4.26` restricted to the two in-scope files:

```
git -C <openclaw> diff v2026.4.24..v2026.4.26 -- \
  src/plugins/bundled-sources.ts src/plugins/bundled-sources.test.ts
```

## Fork reconciliation

- **`isRecord`**: upstream added a *local* copy; the fork already exports a semantically-identical `isRecord` from `../utils.js` (the sibling `manifest.ts` imports it from there), so this reuses the shared one rather than duplicating it.
- **`configSchema` is required in the fork's `PluginManifest` type** (loader rejects manifests without it), but the defensive conditional spread is preserved as-authored upstream — it also keeps the existing tests (whose mocks omit `configSchema`) correct.
- **Companion test**: the fork's `bundled-sources.test.ts` has diverged from upstream's helper-based harness (`setBundled*` / `createResolvedBundledSource`), so the new "requires config before activation" case is written in the fork's inline-mock style. One pre-existing full-shape assertion gains `requiresConfig: false` (the resolver now always emits the flag).

## Scope guard

Limited to `src/plugins/bundled-sources.ts` + its test, per #2812's file table. `caba05b94a2` also touches `src/cli/plugins-install-*.ts`, `src/plugins/enable.ts`, the docker e2e scripts, `package.json`, and `CHANGELOG.md` — those belong to the broader install-flow change and are **not** ported here. The bundled-sources delta references no symbol from those files.

## Blast radius

Both new fields are optional; all `BundledPluginSource` type consumers (`plugins-cli.ts`, `plugin-install-plan.ts`) compile unchanged. `update.test.ts` mocks `resolveBundledPluginSources`; the onboarding `plugin-install.test.ts` only exercises unrelated path-safety helpers. No consumer asserts the exact resolved-source shape except `bundled-sources.test.ts` itself (updated here).

## Verification

- `src/plugins/bundled-sources.test.ts` — 5/5 pass (4 existing + 1 new)
- `src/plugins/update.test.ts` — 6/6 pass (primary real consumer)
- `pnpm check` — clean (format + tsgo + oxlint + fork gates: lobster-leak, css-class-drift, rebrand)
- `pnpm build` — success

No brand leaks (rebrand: `@remoteclaw/*` in the new test).

Part of #2812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
