### PR TITLE
Part of #2812: durable node-pairing store (infra; removePairedNode deferred)

### DIFF
--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -9,6 +9,7 @@ import {
   requestNodePairing,
   verifyNodeToken,
 } from "./node-pairing.js";
+import { resolvePairingPaths } from "./pairing-files.js";
 
 async function setupPairedNode(baseDir: string): Promise<string> {
   const request = await requestNodePairing(
@@ -239,5 +240,23 @@ describe("node pairing tokens", () => {
       ],
       paired: [],
     });
+  });
+
+  test("refuses to overwrite corrupt paired node state when requesting pairing", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const { dir, pairedPath } = resolvePairingPaths(baseDir, "nodes");
+    await mkdir(dir, { recursive: true });
+    await writeFile(pairedPath, "{not-json}", "utf8");
+
+    await expect(
+      requestNodePairing(
+        {
+          nodeId: "node-1",
+          platform: "darwin",
+        },
+        baseDir,
+      ),
+    ).rejects.toThrow(/paired\.json/);
+    await expect(readFile(pairedPath, "utf8")).resolves.toBe("{not-json}");
   });
 });

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -4,7 +4,7 @@ import { type NodeApprovalScope, resolveNodePairApprovalScopes } from "./node-pa
 import {
   createAsyncLock,
   pruneExpiredPending,
-  readJsonFile,
+  readDurableJsonFile,
   reconcilePendingPairingRequests,
   resolvePairingPaths,
   writeJsonAtomic,
@@ -141,8 +141,8 @@ type ApproveNodePairingResult = ApprovedNodePairingResult | ForbiddenNodePairing
 async function loadState(baseDir?: string): Promise<NodePairingStateFile> {
   const { pendingPath, pairedPath } = resolvePairingPaths(baseDir, "nodes");
   const [pending, paired] = await Promise.all([
-    readJsonFile<Record<string, NodePairingPendingRequest>>(pendingPath),
-    readJsonFile<Record<string, NodePairingPairedNode>>(pairedPath),
+    readDurableJsonFile<Record<string, NodePairingPendingRequest>>(pendingPath),
+    readDurableJsonFile<Record<string, NodePairingPairedNode>>(pairedPath),
   ]);
   const state: NodePairingStateFile = {
     pendingById: pending ?? {},

--- a/src/infra/pairing-files.ts
+++ b/src/infra/pairing-files.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 
-export { createAsyncLock, readJsonFile, writeJsonAtomic } from "./json-files.js";
+export {
+  createAsyncLock,
+  readDurableJsonFile,
+  readJsonFile,
+  writeJsonAtomic,
+} from "./json-files.js";
 
 export function resolvePairingPaths(baseDir: string | undefined, subdir: string) {
   const root = baseDir ?? resolveStateDir();


### PR DESCRIPTION
Part of #2812 (Wave-4 sub-item 2812-b) — keep-layer port of deferred upstream node-pairing **infra** deltas from the v2026.4.26 sync.

## What this ports
**Durable pairing-store read** (upstream `ec56dd31162`). `loadState` in `src/infra/node-pairing.ts` now reads the pending/paired stores via `readDurableJsonFile` instead of `readJsonFile`:

- **Before**: `readJsonFile` swallows *all* errors → a corrupt `paired.json` is silently read as empty (`{}`), and the subsequent `persistState` **overwrites and destroys** the corrupt-but-present paired-node data.
- **After**: `readDurableJsonFile` returns `null` only on `ENOENT` (legitimately missing) and **throws `JsonFileReadError`** on a read/parse failure → the operation rejects and the corrupt store is **preserved**, not clobbered.

`src/infra/pairing-files.ts` re-exports `readDurableJsonFile` (the consuming import); `readJsonFile` stays re-exported (still used by other modules, e.g. `server.auth.control-ui.suite.ts`).

## 🔒 Security note (this is a hardening, not a weakening)
The caller flagged pairing as a security-relevant surface — verifying the port does **not** weaken durability/identity handling:
- **Durability**: strengthened — eliminates the silent corrupt-store data-loss clobber.
- **Identity handling**: untouched — `verifyNodeToken` still uses constant-time `verifyPairingToken`; token generation unchanged. A corrupt store now surfaces an error instead of silently resetting every node to "unpaired."
- **No new DoS**: writes are atomic (temp + rename), so a reader never observes partial JSON; `withLock` serializes ops.

## ⚠️ Scope decision — `removePairedNode` DEFERRED (ratification-pending)
The caller listed `removePairedNode` (upstream `7fb2a356e8f`) as a target, **with a STOP-and-ask escape** if it becomes dead code. That condition is met and **forces deferral**:
- Its **only** production caller upstream is a new gateway `nodes/remove` method (`server-methods/nodes.ts`) that depends on `method-scopes.ts` + `protocol/schema/nodes.ts` + `server-methods-list.ts` + CLI `register.pairing.ts` — **all explicitly out of scope** for this infra port.
- The caller's two hard constraints jointly force the outcome: *"do not silently pull the whole feature in"* (forbids wiring it) **and** *"do not add dead code"* (forbids the unwired infra fn).
- **→ Deferred** to the gateway node-command-wiring wave, where it gets a real caller. Trivially reversible if you'd rather land the unwired infra primitive now.

## Out of scope (not touched)
CLI/gateway feature-wiring (`register.pairing.ts`, `register.ts`, `method-scopes.ts`, `protocol/**`, `program.nodes-basic.e2e.test.ts`), device-pairing surface (`device-pairing.ts`, `doctor-device-pairing.ts`), and the recently-refactored gateway files (`node-command-policy.ts` / `node-registry.ts` / `node-connect-reconcile.ts`, #2854). The `readDurableJsonFile` helper (`json-files.ts`) was already present in the fork — no helper port needed.

## Tests
Adds `refuses to overwrite corrupt paired node state when requesting pairing` to `node-pairing.test.ts` (adapted to the fork's inline-`mkdtemp` / `remoteclaw-` style): writes `{not-json}` to `paired.json`, asserts `requestNodePairing` rejects with `/paired\.json/`, and asserts the corrupt file is preserved byte-for-byte. **10/10 node-pairing tests pass.**

## Gates
- `pnpm check` (format + tsgo typecheck + oxlint type-aware + lobster-leak + css-drift + fork gates) — green
- `pnpm build` — green
- No `openclaw`/`OpenClaw`/`OPENCLAW_`/lobster leaks in additions

Do not merge — held for the orchestrator's independent security spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)