### PR TITLE
Part of #2812: Windows restart-helper (.cmd+PS wrapper, bounded task stop)

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -75,36 +75,44 @@ exit 0
   }
 
   function expectWindowsRestartWaitOrdering(content: string, port = 18789) {
-    const endCommand = 'schtasks /End /TN "';
-    const pollAttemptsInit = "set /a attempts=0";
-    const pollLabel = ":wait_for_port_release";
-    const pollAttemptIncrement = "set /a attempts+=1";
-    const pollNetstatCheck = `netstat -ano | findstr /R /C:":${port} .*LISTENING" >nul`;
-    const forceKillLabel = ":force_kill_listener";
-    const forceKillCommand = "taskkill /F /PID %%P >>";
-    const portReleasedLabel = ":port_released";
-    const runCommand = 'schtasks /Run /TN "';
-    const endIndex = content.indexOf(endCommand);
-    const attemptsInitIndex = content.indexOf(pollAttemptsInit, endIndex);
-    const pollLabelIndex = content.indexOf(pollLabel, attemptsInitIndex);
-    const pollAttemptIncrementIndex = content.indexOf(pollAttemptIncrement, pollLabelIndex);
-    const pollNetstatCheckIndex = content.indexOf(pollNetstatCheck, pollAttemptIncrementIndex);
-    const forceKillLabelIndex = content.indexOf(forceKillLabel, pollNetstatCheckIndex);
-    const forceKillCommandIndex = content.indexOf(forceKillCommand, forceKillLabelIndex);
-    const portReleasedLabelIndex = content.indexOf(portReleasedLabel, forceKillCommandIndex);
-    const runIndex = content.indexOf(runCommand, portReleasedLabelIndex);
+    const stateCheck = "$taskState = Get-RemoteClawScheduledTaskState -TaskName $taskName";
+    const runningGuard = 'if ($taskState -eq "Running")';
+    const endCommand =
+      'Invoke-RemoteClawSchtasksWithTimeout -Arguments @("/End", "/TN", $taskName) -TimeoutSeconds 10';
+    const skipEndLog = "remoteclaw restart skipped schtasks end";
+    const pollLoop = "for ($attempt = 1; $attempt -le 10; $attempt++)";
+    const pollCall = `Get-RemoteClawListenerPids -Port $port`;
+    const forceKillBranch = "if ($attempt -eq 10)";
+    const forceKillCommand = "Stop-Process -Id $listenerPid -Force";
+    const runCommand =
+      'Invoke-RemoteClawSchtasksWithTimeout -Arguments @("/Run", "/TN", $taskName) -TimeoutSeconds 30';
+    const portAssignment = `$port = ${port}`;
+    const stateCheckIndex = content.indexOf(stateCheck);
+    const runningGuardIndex = content.indexOf(runningGuard, stateCheckIndex);
+    const endIndex = content.indexOf(endCommand, runningGuardIndex);
+    const skipEndLogIndex = content.indexOf(skipEndLog, endIndex);
+    const portAssignmentIndex = content.indexOf(portAssignment);
+    const pollLoopIndex = content.indexOf(pollLoop, skipEndLogIndex);
+    const pollCallIndex = content.indexOf(pollCall, pollLoopIndex);
+    const forceKillBranchIndex = content.indexOf(forceKillBranch, pollCallIndex);
+    const forceKillCommandIndex = content.indexOf(forceKillCommand, forceKillBranchIndex);
+    const runIndex = content.indexOf(runCommand, forceKillCommandIndex);
 
-    expect(endIndex).toBeGreaterThanOrEqual(0);
-    expect(attemptsInitIndex).toBeGreaterThan(endIndex);
-    expect(pollLabelIndex).toBeGreaterThan(attemptsInitIndex);
-    expect(pollAttemptIncrementIndex).toBeGreaterThan(pollLabelIndex);
-    expect(pollNetstatCheckIndex).toBeGreaterThan(pollAttemptIncrementIndex);
-    expect(forceKillLabelIndex).toBeGreaterThan(pollNetstatCheckIndex);
-    expect(forceKillCommandIndex).toBeGreaterThan(forceKillLabelIndex);
-    expect(portReleasedLabelIndex).toBeGreaterThan(forceKillCommandIndex);
-    expect(runIndex).toBeGreaterThan(portReleasedLabelIndex);
+    expect(stateCheckIndex).toBeGreaterThanOrEqual(0);
+    expect(runningGuardIndex).toBeGreaterThan(stateCheckIndex);
+    expect(endIndex).toBeGreaterThan(runningGuardIndex);
+    expect(skipEndLogIndex).toBeGreaterThan(endIndex);
+    expect(portAssignmentIndex).toBeGreaterThanOrEqual(0);
+    expect(pollLoopIndex).toBeGreaterThan(skipEndLogIndex);
+    expect(pollCallIndex).toBeGreaterThan(pollLoopIndex);
+    expect(forceKillBranchIndex).toBeGreaterThan(pollCallIndex);
+    expect(forceKillCommandIndex).toBeGreaterThan(forceKillBranchIndex);
+    expect(runIndex).toBeGreaterThan(forceKillCommandIndex);
 
     expect(content).not.toContain("timeout /t 3 /nobreak >nul");
+    expect(content).not.toContain("findstr");
+    expect(content).not.toContain("netstat -ano |");
+    expect(content).not.toContain("schtasks /End /TN");
   }
 
   beforeEach(() => {
@@ -351,23 +359,30 @@ exit 0
       await cleanupScript(scriptPath);
     });
 
-    it("creates a schtasks restart script on Windows", async () => {
+    it("creates a guarded schtasks restart script on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
 
       const { scriptPath, content } = await prepareAndReadScript({
         REMOTECLAW_PROFILE: "default",
       });
-      expect(scriptPath.endsWith(".bat")).toBe(true);
+      expect(scriptPath.endsWith(".cmd")).toBe(true);
       expect(content).toContain("@echo off");
+      expect(content).toContain("powershell -NoProfile -ExecutionPolicy Bypass -Command");
+      expect(content).not.toContain("powershell -NoProfile -ExecutionPolicy Bypass -File");
+      expect(content).toContain('$ErrorActionPreference = "Continue"');
       expect(content).toContain("gateway-restart.log");
+      expect(content).toContain("$taskName = 'RemoteClaw Gateway'");
+      expect(content).toContain("function Invoke-RemoteClawSchtasksWithTimeout");
+      expect(content).toContain("function Get-RemoteClawScheduledTaskState");
+      expect(content).toContain("function Invoke-RemoteClawStartupLauncher");
+      expect(content).toContain("Get-ScheduledTask -TaskName $TaskName");
+      expect(content).toContain("remoteclaw restart skipped schtasks end");
       expect(content).toContain(
-        "remoteclaw restart attempt source=update target=RemoteClaw Gateway",
+        '$launcherPath = Join-Path $env:USERPROFILE ".remoteclaw\\gateway.cmd"',
       );
-      expect(content).toContain('schtasks /End /TN "RemoteClaw Gateway"');
-      expect(content).toContain('schtasks /Run /TN "RemoteClaw Gateway" >>');
+      expect(content).toContain("remoteclaw restart launched startup fallback");
       expectWindowsRestartWaitOrdering(content);
-      // Batch self-cleanup
-      expect(content).toContain('del "%~f0"');
+      expect(content).toContain('del "%~f0" >nul 2>&1');
       await cleanupScript(scriptPath);
     });
 
@@ -378,8 +393,12 @@ exit 0
         REMOTECLAW_PROFILE: "default",
         REMOTECLAW_WINDOWS_TASK_NAME: "RemoteClaw Gateway (custom)",
       });
-      expect(content).toContain('schtasks /End /TN "RemoteClaw Gateway (custom)"');
-      expect(content).toContain('schtasks /Run /TN "RemoteClaw Gateway (custom)"');
+      expect(content).toContain("$taskName = 'RemoteClaw Gateway (custom)'");
+      expect(content).toContain("Get-RemoteClawScheduledTaskState -TaskName $taskName");
+      expect(content).toContain(
+        'Invoke-RemoteClawSchtasksWithTimeout -Arguments @("/End", "/TN", $taskName) -TimeoutSeconds 10',
+      );
+      expect(content).toContain("$status = Invoke-RemoteClawStartupLauncher");
       expectWindowsRestartWaitOrdering(content);
       await cleanupScript(scriptPath);
     });
@@ -394,10 +413,10 @@ exit 0
         },
         customPort,
       );
-      expect(content).toContain(`netstat -ano | findstr /R /C:":${customPort} .*LISTENING" >nul`);
-      expect(content).toContain(
-        `for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":${customPort} .*LISTENING"') do (`,
-      );
+      expect(content).toContain(`$port = ${customPort}`);
+      expect(content).toContain("Get-NetTCPConnection -LocalPort $Port -State Listen");
+      expect(content).toContain("& netstat.exe -ano -p tcp");
+      expect(content).not.toContain("findstr");
       expectWindowsRestartWaitOrdering(content, customPort);
       await cleanupScript(scriptPath);
     });
@@ -428,7 +447,7 @@ exit 0
       const { scriptPath, content } = await prepareAndReadScript({
         REMOTECLAW_PROFILE: "production",
       });
-      expect(content).toContain('schtasks /End /TN "RemoteClaw Gateway (production)"');
+      expect(content).toContain("$taskName = 'RemoteClaw Gateway (production)'");
       expectWindowsRestartWaitOrdering(content);
       await cleanupScript(scriptPath);
     });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -10,8 +10,8 @@ import {
   resolveGatewayWindowsTaskName,
 } from "../../daemon/constants.js";
 import {
-  renderCmdRestartLogSetup,
   renderPosixRestartLogSetup,
+  resolveGatewayRestartLogPath,
   shellEscapeRestartLogValue,
 } from "../../daemon/restart-logs.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -25,10 +25,13 @@ function shellEscape(value: string): string {
   return value.replace(/'/g, "'\\''");
 }
 
-/** Validates a string is safe for embedding in a batch (cmd.exe) script. */
-function isBatchSafe(value: string): boolean {
-  // Reject characters that have special meaning in batch: & | < > ^ % " ` $
+/** Validates a task name is safe for embedding in Windows restart scripts. */
+function isWindowsTaskNameSafe(value: string): boolean {
   return /^[A-Za-z0-9 _\-().]+$/.test(value);
+}
+
+function powerShellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 function resolveSystemdUnit(env: NodeJS.ProcessEnv): string {
@@ -159,45 +162,209 @@ exit "$status"
 `;
     } else if (platform === "win32") {
       const taskName = resolveWindowsTaskName(env);
-      if (!isBatchSafe(taskName)) {
+      if (!isWindowsTaskNameSafe(taskName)) {
         return null;
       }
       const port =
         Number.isFinite(gatewayPort) && gatewayPort > 0 ? gatewayPort : DEFAULT_GATEWAY_PORT;
-      const restartLog = renderCmdRestartLogSetup({ ...process.env, ...env });
-      filename = `remoteclaw-restart-${timestamp}.bat`;
+      const restartLogPath = resolveGatewayRestartLogPath({ ...process.env, ...env });
+      const quotedLogPath = powerShellSingleQuote(restartLogPath);
+      const quotedTaskName = powerShellSingleQuote(taskName);
+      filename = `remoteclaw-restart-${timestamp}.cmd`;
       scriptContent = `@echo off
-REM Standalone restart script — survives parent process termination.
-REM Wait briefly to ensure file locks are released after update.
-timeout /t 2 /nobreak >nul
-${restartLog.lines.join("\r\n")}
->> ${restartLog.quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart attempt source=update target=${taskName}
-schtasks /End /TN "${taskName}" >> ${restartLog.quotedLogPath} 2>&1
-REM Poll for gateway port release before rerun; force-kill listener if stuck.
-set /a attempts=0
-:wait_for_port_release
-set /a attempts+=1
-netstat -ano | findstr /R /C:":${port} .*LISTENING" >nul
-if errorlevel 1 goto port_released
-if %attempts% GEQ 10 goto force_kill_listener
-timeout /t 1 /nobreak >nul
-goto wait_for_port_release
-:force_kill_listener
-for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":${port} .*LISTENING"') do (
-  taskkill /F /PID %%P >> ${restartLog.quotedLogPath} 2>&1
-  goto port_released
-)
-:port_released
-schtasks /Run /TN "${taskName}" >> ${restartLog.quotedLogPath} 2>&1
+REM Standalone restart script - survives parent process termination.
+REM Keep this as a cmd wrapper so Group Policy script execution policies
+REM cannot block the update restart handoff before schtasks.exe runs.
+setlocal
+set "REMOTECLAW_RESTART_SCRIPT=%~f0"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$p=$env:REMOTECLAW_RESTART_SCRIPT; $s=Get-Content -Raw -LiteralPath $p; $m='# POWERSHELL'; $i=$s.IndexOf($m); if ($i -lt 0) { exit 1 }; Invoke-Expression $s.Substring($i)"
 set "status=%ERRORLEVEL%"
-if not "%status%"=="0" (
-  >> ${restartLog.quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart failed source=update status=%status%
-) else (
-  >> ${restartLog.quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart done source=update
-)
-REM Self-cleanup
-del "%~f0"
+del "%~f0" >nul 2>&1
 exit /b %status%
+# POWERSHELL
+# Wait briefly to ensure file locks are released after update.
+$ErrorActionPreference = "Continue"
+Start-Sleep -Seconds 2
+
+$logPath = ${quotedLogPath}
+try {
+  $logDir = Split-Path -Parent $logPath
+  New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+  Add-Content -LiteralPath $logPath -Value "[$(Get-Date -Format o)] remoteclaw restart log initialized"
+} catch {
+  # Restart should still run if log setup is unavailable.
+}
+
+function Write-RestartLog {
+  param([string]$Message)
+  try {
+    Add-Content -LiteralPath $logPath -Value "[$(Get-Date -Format o)] $Message"
+  } catch {
+  }
+}
+
+function Join-RemoteClawProcessArguments {
+  param([string[]]$Arguments)
+  ($Arguments | ForEach-Object {
+    if ($_ -match "\\s") {
+      '"' + $_ + '"'
+    } else {
+      $_
+    }
+  }) -join " "
+}
+
+function Invoke-RemoteClawSchtasksWithTimeout {
+  param(
+    [string[]]$Arguments,
+    [int]$TimeoutSeconds
+  )
+  $process = $null
+  try {
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = "schtasks.exe"
+    $startInfo.Arguments = Join-RemoteClawProcessArguments -Arguments $Arguments
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $process = [System.Diagnostics.Process]::Start($startInfo)
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+      try {
+        $process.Kill()
+      } catch {
+      }
+      Write-RestartLog "remoteclaw restart schtasks timeout source=update args=$($Arguments -join ' ')"
+      return 124
+    }
+    $stdout = $process.StandardOutput.ReadToEnd()
+    $stderr = $process.StandardError.ReadToEnd()
+    if ($stdout) {
+      Write-RestartLog $stdout.Trim()
+    }
+    if ($stderr) {
+      Write-RestartLog $stderr.Trim()
+    }
+    return $process.ExitCode
+  } catch {
+    Write-RestartLog "remoteclaw restart schtasks failed source=update args=$($Arguments -join ' ') error=$($_.Exception.Message)"
+    return 1
+  }
+}
+
+function Get-RemoteClawScheduledTaskState {
+  param([string]$TaskName)
+  try {
+    $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+    if ($task -and $task.State) {
+      return [string]$task.State
+    }
+  } catch {
+  }
+
+  try {
+    $queryOutput = & schtasks.exe /Query /TN $TaskName /FO LIST 2>$null
+    foreach ($line in $queryOutput) {
+      if ($line -match "^\\s*Status:\\s*(.+?)\\s*$") {
+        return $Matches[1]
+      }
+    }
+  } catch {
+  }
+
+  return "Unknown"
+}
+
+function Get-RemoteClawListenerPids {
+  param([int]$Port)
+  $listenerPids = @()
+
+  try {
+    if (Get-Command Get-NetTCPConnection -ErrorAction SilentlyContinue) {
+      $listenerPids += Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
+        ForEach-Object { [int]$_.OwningProcess }
+    }
+  } catch {
+  }
+
+  if ($listenerPids.Count -eq 0) {
+    try {
+      $portPattern = [regex]::Escape(":$Port")
+      $linePattern = "^\\s*TCP\\s+\\S+$portPattern\\s+\\S+\\s+LISTENING\\s+(\\d+)\\s*$"
+      & netstat.exe -ano -p tcp 2>$null | ForEach-Object {
+        if ($_ -match $linePattern) {
+          $listenerPids += [int]$Matches[1]
+        }
+      }
+    } catch {
+    }
+  }
+
+  $listenerPids | Sort-Object -Unique
+}
+
+function Invoke-RemoteClawStartupLauncher {
+  $launcherPath = Join-Path $env:USERPROFILE ".remoteclaw\\gateway.cmd"
+  if (-not (Test-Path -LiteralPath $launcherPath)) {
+    Write-RestartLog "remoteclaw restart startup launcher missing source=update path=$launcherPath"
+    return 1
+  }
+
+  try {
+    Start-Process -FilePath $launcherPath -WindowStyle Hidden | Out-Null
+    Write-RestartLog "remoteclaw restart launched startup fallback source=update path=$launcherPath"
+    return 0
+  } catch {
+    Write-RestartLog "remoteclaw restart startup fallback failed source=update error=$($_.Exception.Message)"
+    return 1
+  }
+}
+
+$taskName = ${quotedTaskName}
+$port = ${port}
+Write-RestartLog "remoteclaw restart attempt source=update target=$taskName"
+
+$taskState = Get-RemoteClawScheduledTaskState -TaskName $taskName
+if ($taskState -eq "Running") {
+  $endStatus = Invoke-RemoteClawSchtasksWithTimeout -Arguments @("/End", "/TN", $taskName) -TimeoutSeconds 10
+  if ($endStatus -ne 0) {
+    Write-RestartLog "remoteclaw restart schtasks end did not complete cleanly source=update status=$endStatus"
+  }
+} else {
+  Write-RestartLog "remoteclaw restart skipped schtasks end source=update state=$taskState"
+}
+
+for ($attempt = 1; $attempt -le 10; $attempt++) {
+  $listeners = @(Get-RemoteClawListenerPids -Port $port)
+  if ($listeners.Count -eq 0) {
+    break
+  }
+
+  if ($attempt -eq 10) {
+    foreach ($listenerPid in $listeners) {
+      try {
+        Stop-Process -Id $listenerPid -Force -ErrorAction Stop
+        Write-RestartLog "remoteclaw restart killed stale listener source=update pid=$listenerPid"
+      } catch {
+        Write-RestartLog "remoteclaw restart failed to kill stale listener source=update pid=$listenerPid error=$($_.Exception.Message)"
+      }
+    }
+    break
+  }
+
+  Start-Sleep -Seconds 1
+}
+
+$status = Invoke-RemoteClawSchtasksWithTimeout -Arguments @("/Run", "/TN", $taskName) -TimeoutSeconds 30
+if ($status -ne 0) {
+  $status = Invoke-RemoteClawStartupLauncher
+}
+if ($status -eq 0) {
+  Write-RestartLog "remoteclaw restart done source=update"
+} else {
+  Write-RestartLog "remoteclaw restart failed source=update status=$status"
+}
+
+exit $status
 `;
     } else {
       return null;


### PR DESCRIPTION
Part of #2812 (Wave-4 sub-item 2812-d).

Keep-layer port of two deferred upstream deltas for the Windows update-restart
path, reconciled onto the fork's already-rebranded code:

- `17596fc484e` — restart the Windows startup gateway after update.
- `d1e5f4bd3c6` — bound the Windows scheduled-task stop; rewrite the restart
  script from `.bat` to a `.cmd` + PowerShell wrapper so Group-Policy script
  execution policies can't block the post-update restart before `schtasks.exe`
  runs.

## Changes (`src/cli/update-cli/restart-helper.ts` + test only)

- **`.cmd` + inline PowerShell wrapper** replaces the batch script. The `.cmd`
  stub invokes `powershell -NoProfile -ExecutionPolicy Bypass` against an inline
  `# POWERSHELL` body, so GPO execution policies can't block the restart handoff.
- **Bounded schtasks stop/run** — `/End` and `/Run` run via a timeout-guarded
  `System.Diagnostics.Process` launch (10s / 30s); `/End` is skipped unless the
  task state is `Running`.
- **Port-release polling** switches from `netstat | findstr` to
  `Get-NetTCPConnection` (with a `netstat.exe -ano` fallback), force-killing
  stale listeners only on the final attempt.
- **Startup-launcher fallback** (`~/.remoteclaw/gateway.cmd`) when
  `schtasks /Run` fails.
- Helper rename `isBatchSafe` → `isWindowsTaskNameSafe`; add
  `powerShellSingleQuote`; swap `renderCmdRestartLogSetup` →
  `resolveGatewayRestartLogPath` (the former keeps a live caller in
  `src/infra/windows-task-restart.ts`, so it is not orphaned).

All OpenClaw brand strings introduced by the port (PowerShell helper names, log
lines, `REMOTECLAW_RESTART_SCRIPT` env var, `.remoteclaw\gateway.cmd` launcher
path) are rebranded to RemoteClaw. Linux/macOS branches untouched.

## Verification

- `restart-helper.test.ts`: **28/28 pass** (companion test ported + adapted).
- `pnpm check` (format + typecheck + lint + rebrand/lobster/css gates): **green**.
- `pnpm build`: **green**.
- No `openclaw`/`OpenClaw` leak in the ported files.

> Note: the Windows script paths are covered by text assertions on the generated
> script (the suite executes only the Linux/macOS scripts). This matches upstream's
> test design; the port is faithful to upstream logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
