### PR TITLE
chore(test): drop vestigial transport field from APNs node-wake test

### DIFF
--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -76,13 +76,11 @@ type WakeResultOverrides = Partial<{
   tokenSuffix: string;
   topic: string;
   environment: "sandbox" | "production";
-  transport: "direct";
 }>;
 
 function directRegistration(nodeId: string) {
   return {
     nodeId,
-    transport: "direct" as const,
     token: "abcd1234abcd1234abcd1234abcd1234",
     topic: "org.remoteclaw.ios",
     environment: "sandbox" as const,
@@ -106,7 +104,6 @@ function mockDirectWakeConfig(nodeId: string, overrides: WakeResultOverrides = {
     tokenSuffix: "1234abcd",
     topic: "org.remoteclaw.ios",
     environment: "sandbox",
-    transport: "direct",
     ...overrides,
   });
 }


### PR DESCRIPTION
Removes a vestigial `transport: "direct"` field from `nodes.invoke-wake.test.ts` — the `WakeResultOverrides` type field, the `directRegistration` mock, and the `sendApnsBackgroundWake` mock result. The `transport` field no longer exists anywhere in production (the APNs direct-token path is transport-less), so these three occurrences were dead test scaffolding with no readers or assertions.

Test-only change; the gateway test lane still passes (10/10 locally).