### PR TITLE
fix(logging): defuse Array-subclass prototype toJSON in log redaction

### DIFF
--- a/src/logging/logger-redaction.test.ts
+++ b/src/logging/logger-redaction.test.ts
@@ -330,4 +330,47 @@ describe("redactLogArgLeaves hardening (#2853)", () => {
     }
     fs.rmSync(file, { force: true });
   });
+
+  it("strips an Array-subclass prototype toJSON so a secret cannot re-materialize (#2881)", () => {
+    // Array.prototype.map uses ArraySpeciesCreate, so mapping an Array subclass
+    // returns a same-subclass instance whose prototype toJSON JSON.stringify would
+    // later invoke — re-emitting the secret raw past redaction. The array branch
+    // must normalize to a plain array first, mirroring the object-branch rebuild.
+    class TaggedList extends Array {
+      toJSON() {
+        return "token=supersecretvalue1234567890";
+      }
+    }
+    const arg = new TaggedList();
+    arg.push("visible-element");
+    const serialized = JSON.stringify(redact(arg));
+    expect(serialized).not.toContain("supersecretvalue1234567890");
+    expect(serialized).toContain("visible-element");
+    expect(() => JSON.parse(serialized)).not.toThrow();
+  });
+
+  it("masks an Array-subclass prototype toJSON secret written to the on-disk log (#2881)", () => {
+    // End-to-end at the file sink: the residual array-branch leak, proven masked.
+    const file = tmpLogPath("array-subclass-tojson");
+    fs.rmSync(file, { force: true });
+    setLoggerOverride({ level: "info", file, consoleLevel: "silent" });
+
+    class TaggedList extends Array {
+      toJSON() {
+        return "token=supersecretvalue1234567890";
+      }
+    }
+    const arg = new TaggedList();
+    arg.push("visible-element");
+    getChildLogger({ subsystem: "gateway" }).error("array serialize failed", arg);
+
+    const content = readLog(file);
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).not.toContain("supersecretvalue1234567890");
+    expect(content).toContain("array serialize failed");
+    for (const rawLine of content.split("\n").filter(Boolean)) {
+      expect(() => JSON.parse(rawLine)).not.toThrow();
+    }
+    fs.rmSync(file, { force: true });
+  });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -205,7 +205,12 @@ function redactLogArgLeaf(value: unknown, depth: number, seen: WeakSet<object>):
   seen.add(value);
   try {
     if (Array.isArray(value)) {
-      return value.map((entry) => redactLogArgLeaf(entry, depth + 1, seen));
+      // Normalize to a plain array first: Array.prototype.map uses
+      // ArraySpeciesCreate, so mapping an Array *subclass* returns a same-subclass
+      // instance — preserving a prototype `toJSON` that JSON.stringify would later
+      // invoke, re-materializing a secret raw past redaction (#2881). The spread
+      // strips the subclass prototype, mirroring the plain-`{}` object rebuild below.
+      return [...value].map((entry) => redactLogArgLeaf(entry, depth + 1, seen));
     }
     // An own-enumerable `toJSON` survives the property copy below and is invoked
     // by JSON.stringify after redaction, re-materializing its (possibly


### PR DESCRIPTION
## Summary

`redactLogArgLeaf` in `src/logging/logger.ts` redacts secrets from structured log
arguments *before* serialization. The object branch rebuilds a fresh plain `{}`
(stripping any prototype, so a `toJSON` cannot re-materialize a secret at
`JSON.stringify` time), but the **array branch** did not get equivalent protection:

```ts
return value.map((entry) => redactLogArgLeaf(entry, depth + 1, seen));
```

`Array.prototype.map` uses ArraySpeciesCreate, so mapping an **`Array` subclass**
returns an instance of that subclass — preserving its prototype, including a
prototype `toJSON`. `JSON.stringify` then invokes that `toJSON` on the mapped
result, re-materializing its (possibly secret-bearing) return value **raw, past
redaction**.

## Fix

Normalize the array branch to a plain array before mapping, mirroring the object
branch's prototype-stripping rebuild:

```ts
return [...value].map((entry) => redactLogArgLeaf(entry, depth + 1, seen));
```

`[...value]` produces a plain `Array`, so no subclass prototype survives to the
serializer.

## Severity

LOW (confidentiality), **pre-existing** — the prior code already had the same
species-preserving `.map` behavior; not introduced by any recent change. No known
in-tree caller logs an `Array`-subclass-carrying-a-`toJSON`, so it is not believed
reachable in practice today, but it is a real redaction bypass.

## Tests

Two cases added to `src/logging/logger-redaction.test.ts` (in the existing
`redactLogArgLeaves hardening` block):

- a deterministic unit test that redacts an `Array` subclass whose `toJSON()`
  returns a secret, then `JSON.stringify`s the result and asserts the secret is
  absent (and a visible element preserved);
- an end-to-end test that logs such a value through the file sink and asserts the
  emitted line masks the secret and stays valid JSON.

Both tests **fail against the pre-fix code** (verified by reverting the one-line
change): the pre-fix array branch leaks `token=…` raw into both the stringified
result and the on-disk log line.

## Verification

- `logger-redaction.test.ts`: 21/21 pass (19 existing + 2 new)
- `oxlint --type-aware` + `oxfmt --check`: clean
- `tsgo`: no type errors

Closes #2881
