### PR TITLE
fix(gateway): wire node.pair.remove server handler + removePairedNode store (#2898)

### DIFF
--- a/src/gateway/server-methods/nodes.pair-remove.test.ts
+++ b/src/gateway/server-methods/nodes.pair-remove.test.ts
@@ -1,0 +1,146 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { approveNodePairing, getPairedNode, requestNodePairing } from "../../infra/node-pairing.js";
+import { handleGatewayRequest } from "../server-methods.js";
+
+const noWebchat = () => false;
+
+type DispatchResult = {
+  respond: ReturnType<typeof vi.fn>;
+  logInfo: ReturnType<typeof vi.fn>;
+};
+
+// These tests dispatch through the real `handleGatewayRequest`, so they exercise
+// the actual authorization gate AND the real (non-mocked) `node.pair.remove`
+// handler against a durable on-disk store rooted at a per-test temp directory.
+describe("gateway node.pair.remove handler", () => {
+  let previousStateDir: string | undefined;
+
+  beforeEach(async () => {
+    previousStateDir = process.env.REMOTECLAW_STATE_DIR;
+    const dir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pair-remove-"));
+    process.env.REMOTECLAW_STATE_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (previousStateDir === undefined) {
+      delete process.env.REMOTECLAW_STATE_DIR;
+    } else {
+      process.env.REMOTECLAW_STATE_DIR = previousStateDir;
+    }
+    vi.restoreAllMocks();
+  });
+
+  async function seedPairedNode(nodeId: string): Promise<void> {
+    const pending = await requestNodePairing({
+      nodeId,
+      platform: "darwin",
+      commands: ["system.run"],
+    });
+    await approveNodePairing(pending.request.requestId, {
+      callerScopes: ["operator.pairing", "operator.admin"],
+    });
+    expect(await getPairedNode(nodeId)).not.toBeNull();
+  }
+
+  async function dispatchRemove(params: {
+    nodeId: string;
+    scopes: string[];
+  }): Promise<DispatchResult> {
+    const respond = vi.fn();
+    const logInfo = vi.fn();
+    await handleGatewayRequest({
+      req: {
+        type: "req",
+        id: crypto.randomUUID(),
+        method: "node.pair.remove",
+        params: { nodeId: params.nodeId },
+      },
+      respond,
+      client: {
+        connect: {
+          role: "operator",
+          scopes: params.scopes,
+          client: {
+            id: "remoteclaw-control-ui",
+            version: "1.0.0",
+            platform: "darwin",
+            mode: "ui",
+          },
+          minProtocol: 1,
+          maxProtocol: 1,
+        },
+        connId: "conn-1",
+        clientIp: "10.0.0.5",
+      } as Parameters<typeof handleGatewayRequest>[0]["client"],
+      isWebchatConnect: noWebchat,
+      context: {
+        logGateway: { info: logInfo, warn: vi.fn() },
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+    });
+    return { respond, logInfo };
+  }
+
+  it("removes a paired node and clears it from the durable store", async () => {
+    await seedPairedNode("node-1");
+
+    const { respond, logInfo } = await dispatchRemove({
+      nodeId: "node-1",
+      scopes: ["operator.pairing"],
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0];
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+    expect((payload as { nodeId?: string })?.nodeId).toBe("node-1");
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining("node pairing removed node=node-1"),
+    );
+    expect(await getPairedNode("node-1")).toBeNull();
+  });
+
+  it("rejects callers lacking operator.pairing scope and leaves the node paired", async () => {
+    await seedPairedNode("node-2");
+
+    const { respond, logInfo } = await dispatchRemove({
+      nodeId: "node-2",
+      scopes: ["operator.read"],
+    });
+
+    const [ok, payload, error] = respond.mock.calls[0];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect((error as { message?: string })?.message).toContain("operator.pairing");
+    // Authorization is enforced at the dispatch layer before the handler runs, so
+    // an under-scoped caller must not remove the node nor emit the removal log.
+    expect(logInfo).not.toHaveBeenCalled();
+    expect(await getPairedNode("node-2")).not.toBeNull();
+  });
+
+  it("returns a not-found error for an unknown node without throwing", async () => {
+    const { respond } = await dispatchRemove({
+      nodeId: "ghost-node",
+      scopes: ["operator.pairing"],
+    });
+
+    const [ok, payload, error] = respond.mock.calls[0];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect((error as { message?: string })?.message).toContain("unknown nodeId");
+  });
+
+  it("is idempotent: removing an already-removed node reports not-found gracefully", async () => {
+    await seedPairedNode("node-3");
+
+    const first = await dispatchRemove({ nodeId: "node-3", scopes: ["operator.pairing"] });
+    expect(first.respond.mock.calls[0][0]).toBe(true);
+
+    const second = await dispatchRemove({ nodeId: "node-3", scopes: ["operator.pairing"] });
+    const [ok, , error] = second.respond.mock.calls[0];
+    expect(ok).toBe(false);
+    expect((error as { message?: string })?.message).toContain("unknown nodeId");
+  });
+});

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -6,6 +6,7 @@ import {
   approveNodePairing,
   listNodePairing,
   rejectNodePairing,
+  removePairedNode,
   renamePairedNode,
   requestNodePairing,
   verifyNodeToken,
@@ -41,6 +42,7 @@ import {
   validateNodePairApproveParams,
   validateNodePairListParams,
   validateNodePairRejectParams,
+  validateNodePairRemoveParams,
   validateNodePairRequestParams,
   validateNodePairVerifyParams,
   validateNodeRenameParams,
@@ -551,6 +553,26 @@ export const nodeHandlers: GatewayRequestHandlers = {
         { dropIfSlow: true },
       );
       respond(true, rejected, undefined);
+    });
+  },
+  "node.pair.remove": async ({ params, respond, context }) => {
+    if (!validateNodePairRemoveParams(params)) {
+      respondInvalidParams({
+        respond,
+        method: "node.pair.remove",
+        validator: validateNodePairRemoveParams,
+      });
+      return;
+    }
+    const { nodeId } = params as { nodeId: string };
+    await respondUnavailableOnThrow(respond, async () => {
+      const removed = await removePairedNode(nodeId);
+      if (!removed) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
+        return;
+      }
+      context.logGateway.info(`node pairing removed node=${removed.nodeId}`);
+      respond(true, removed, undefined);
     });
   },
   "node.pair.verify": async ({ params, respond }) => {

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -365,3 +365,20 @@ export async function renamePairedNode(
     return next;
   });
 }
+
+export async function removePairedNode(
+  nodeId: string,
+  baseDir?: string,
+): Promise<NodePairingPairedNode | null> {
+  return await withLock(async () => {
+    const state = await loadState(baseDir);
+    const normalized = normalizeNodeId(nodeId);
+    const existing = state.pairedByNodeId[normalized];
+    if (!existing) {
+      return null;
+    }
+    delete state.pairedByNodeId[normalized];
+    await persistState(state, baseDir);
+    return existing;
+  });
+}


### PR DESCRIPTION
## Summary

`node.pair.remove` was declared in every gateway layer — CLI command, method-scope group (`operator.pairing`), methods list, method descriptor, and param schema/validator — **except the server handler**. The dispatcher therefore rejected the method as unknown, so `nodes remove` failed at runtime even though every other layer advertised it.

This wires the missing pieces:

- **Store** — add `removePairedNode(nodeId)` to `src/infra/node-pairing.ts`, mirroring `renamePairedNode`'s durable `withLock` / `loadState` / `persistState` pattern. It is idempotent: removing an unknown or already-removed node returns `null` (not-found) rather than throwing.
- **Handler** — register `node.pair.remove` in `nodeHandlers` (`src/gateway/server-methods/nodes.ts`), matching this file's helper-based style (`respondInvalidParams`, `respondUnavailableOnThrow`) and the removal semantics of the sibling `device.pair.remove`: validate params, remove, return a not-found error for an unknown node, log the removal, respond. No broadcast is emitted — a removal is not a pairing-*request* resolution (there is no `requestId`/`decision`), and the device analogue does not broadcast either.
- **Authorization** — unchanged. The declared `operator.pairing` scope is enforced at the dispatch layer (`authorizeGatewayMethod` → `authorizeOperatorScopesForMethod`), so simply registering the handler makes the method both reachable and correctly gated, with no in-body scope check.

## CLI success-fidelity

`nodes remove` was audited and needs **no change**: `callGatewayCli` → `callGateway` → `client.request` rejects with `GatewayClientRequestError` on any `ok:false` RPC response (`src/gateway/client.ts`), and `runNodesCommand` catches the rejection and exits before the `Removed paired node <id>` success log (`register.pairing.ts:158`). The success log is therefore already conditional on a real success and cannot fire on failure.

## Tests

Adds `src/gateway/server-methods/nodes.pair-remove.test.ts` — a real, non-mocked handler-path test that dispatches through `handleGatewayRequest` against a durable temp-directory store, covering:

1. successful removal (node cleared from the durable store, removal logged),
2. under-scoped caller rejected (`operator.read`) with the node left paired and no removal log — proving dispatch-layer authorization gates the handler,
3. unknown node → graceful not-found without throwing,
4. idempotent already-removed node → graceful not-found.

Verification in a clean worktree:

- `pnpm check` (format + `tsgo` typecheck + `oxlint --type-aware` + repo lint gates) — passes, exit 0.
- New test 4/4; node-pairing store tests 13/13; gateway consistency + sibling handler tests 65/65; `program.nodes-basic.e2e.test.ts` 13/13. No regressions.

Closes #2898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
