### PR TITLE
fix(logging): redact quote/backtick-adjacent lowercase credential keys (#2852)

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -276,4 +276,59 @@ describe("redactSensitiveText", () => {
     });
     expect(output).toBe(input);
   });
+
+  it("redacts quote/backtick-adjacent lowercase credential keys in key=value form (#2852)", () => {
+    // A lowercase key touching a quote/backtick fell through both the ENV pattern
+    // (uppercase-only) and the standalone pattern (leading boundary excluded quote chars),
+    // leaking the value. The broadened boundary now redacts these.
+    const secret = "abcdef1234567890ghij";
+    const cases = [
+      `"token=${secret}"`,
+      `{"cmd":"token=${secret}"}`,
+      `\`token=${secret}\``,
+      `'password=${secret}'`,
+    ];
+    for (const input of cases) {
+      const output = redactSensitiveText(input, {
+        mode: "tools",
+        patterns: defaults,
+      });
+      expect(output).not.toContain("1234567890");
+    }
+  });
+
+  it("keeps existing credential-assignment forms redacted after boundary broadening (#2852)", () => {
+    const bare = redactSensitiveText("token=abcdef1234567890ghij", {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(bare).toBe("token=abcdef…ghij");
+    const quotedValue = redactSensitiveText('token="abcdef1234567890ghij"', {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(quotedValue).not.toContain("1234567890");
+    const jsonColon = redactSensitiveText('{"token":"abcdef1234567890ghij"}', {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(jsonColon).not.toContain("1234567890");
+  });
+
+  it("does not over-mask quoted credential-key references without an assignment (#2852)", () => {
+    const diagnostic = 'Unrecognized key: "token"';
+    expect(
+      redactSensitiveText(diagnostic, {
+        mode: "tools",
+        patterns: defaults,
+      }),
+    ).toBe(diagnostic);
+    const fieldRef = 'the "token" field is required';
+    expect(
+      redactSensitiveText(fieldRef, {
+        mode: "tools",
+        patterns: defaults,
+      }),
+    ).toBe(fieldRef);
+  });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -32,7 +32,12 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   // secrets (e.g. `?access_token=…`) stay redacted without hiding config-key diagnostics.
   String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)`,
   // Standalone credential assignments outside URLs (e.g. `token=…` in a log line).
-  String.raw`(^|[\s,;])(?:access_token|refresh_token|api[-_]?key|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#]+)`,
+  // Leading boundary broadened to accept quote/backtick delimiters (`"`, `'`, and `\x60`
+  // for backtick, which keeps the String.raw template intact) so a lowercase key touching
+  // a quote in key=value form — `"token=…"`, `{"cmd":"token=…"}` — is redacted rather than
+  // leaking. Upstream shares this text-level gap and relies on structured tool-output
+  // redaction the fork does not carry. (Fork-side, #2852.)
+  String.raw`(^|[\s,;"'\x60])(?:access_token|refresh_token|api[-_]?key|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#]+)`,
   // JSON fields.
   String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|${PAYMENT_CREDENTIAL_JSON_KEYS})"\s*:\s*"([^"]+)"`,
   // CLI flags.


### PR DESCRIPTION
## Problem

`src/logging/redact.ts` leaks a **lowercase** credential key when the key is **immediately preceded by a quote or backtick** in `key=value` form. Empirically confirmed cleartext leaks through log / tool-output redaction:

- `"token=SECRET"` (double-quote-adjacent)
- `{"cmd":"token=SECRET"}` (JSON-embedded)
- a backtick-delimited `token=SECRET`

**Root cause:** the standalone credential-assignment pattern's leading boundary was `(^|[\s,;])`, which excludes quote/backtick characters, and the ENV-style pattern only matches uppercase keys. A lowercase key touching a quote therefore falls through both patterns and is logged verbatim.

## Fix

Broaden **only** the leading boundary character class of the standalone pattern to also accept `"`, `'`, and backtick. The backtick is written `\x60` (a hex escape) so a literal backtick cannot terminate the `String.raw` template literal. The key list and the value class `([^\s&#]+)` are left untouched, which preserves existing behavior:

- Quoted-value (`token="SECRET"`) and JSON-colon (`{"token":"SECRET"}`) forms still redact via their existing patterns.
- Quoted key *references* with no assignment — `Unrecognized key: "token"`, `the "token" field is required` — are **not** over-masked, so config-key diagnostics stay intact.

Every log / tool-output detail funnels through `redactSensitiveText`, so this single boundary fix closes all confirmed leak shapes.

## Tests (`src/logging/redact.test.ts`)

- **Leak-close** (previously leaked → now redacted): the double-quote, JSON-embedded, backtick, and single-quote `key=value` shapes.
- **No-regression**: bare `token=…` still redacts to `token=abcdef…ghij` (value class untouched); quoted-value and JSON-colon forms still redact.
- **No over-mask**: quoted key references without an assignment stay unchanged.

`redact.test.ts`: 30 passed (30). `pnpm check` (oxfmt + tsgo typecheck + oxlint `--type-aware` + repo lint gates): green.

Closes #2852
