### PR TITLE
fix(redact): close standalone-assignment redaction gaps (#2902, #2903)

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -331,4 +331,229 @@ describe("redactSensitiveText", () => {
       }),
     ).toBe(fieldRef);
   });
+
+  const SECRET = "abcdef1234567890ghij";
+  const redact = (input: string) =>
+    redactSensitiveText(input, { mode: "tools", patterns: defaults });
+
+  it("redacts standalone credential assignments after any non-word delimiter (#2902)", () => {
+    // The previous leading boundary was a delimiter whitelist accepting only
+    // whitespace/comma/semicolon/quote/backtick, so every other delimiter leaked. `\b` is a
+    // strict superset of that whitelist. Confidentiality is what this closes: no case leaks.
+    const cases = [
+      `(token=${SECRET})`,
+      `[token=${SECRET}]`,
+      `{cmd:token=${SECRET}}`,
+      `call:token=${SECRET}`,
+      `opts.token=${SECRET}`,
+      `--token=${SECRET}`,
+      `<token=${SECRET}>`,
+      `/token=${SECRET}`,
+    ];
+    for (const input of cases) {
+      expect(redact(input), `leaked: ${input}`).not.toContain(SECRET);
+    }
+  });
+
+  it("masks to an exact start…end band when no delimiter trails the value (#2902)", () => {
+    // Delimiters outside the value class `[^\s&#]+` do not enter the capture, so the band is
+    // exactly maskToken's image.
+    const cases = [
+      `call:token=${SECRET}`,
+      `opts.token=${SECRET}`,
+      `--token=${SECRET}`,
+      `/token=${SECRET}`,
+    ];
+    for (const input of cases) {
+      expect(redact(input), `wrong band: ${input}`).toBe(input.replace(SECRET, "abcdef…ghij"));
+    }
+  });
+
+  it("borrows the mask tail from a trailing closing delimiter (#2907, pinned as-is)", () => {
+    // The value class admits `)` `]` `}` `>`, so a closing delimiter is captured INTO the value
+    // and supplies the mask's last KEEP_END chars: `(token=<secret>)` -> `(token=abcdef…hij)`.
+    // The secret is still masked — confidentiality holds — but the tail is NOT the token's tail,
+    // so the same token masks differently depending on surrounding punctuation. That breaks the
+    // cross-line correlation the 6+4 shape exists to provide. It lands hardest on exactly the
+    // bracket delimiters #2902 fixes. Value class deliberately byte-identical here; see #2907.
+    expect(redact(`(token=${SECRET})`)).toBe("(token=abcdef…hij)");
+    expect(redact(`[token=${SECRET}]`)).toBe("[token=abcdef…hij]");
+    expect(redact(`<token=${SECRET}>`)).toBe("<token=abcdef…hij>");
+  });
+
+  it("still refuses to fire mid-word after boundary broadening (#2902)", () => {
+    // `\b` is a superset of the old whitelist but is still a word boundary, so a longer word
+    // merely ENDING in a credential key is untouched.
+    for (const input of [`mytoken=${SECRET}`, `xsecret=${SECRET}`]) {
+      expect(redact(input), `over-masked: ${input}`).toBe(input);
+    }
+  });
+
+  it("redacts compound lowercase credential keys at standalone position (#2903)", () => {
+    // `_` is a word character, so `auth_token=` has NO word boundary before `token`: the generic
+    // `token` alternative can never reach it and the #2902 boundary fix alone cannot help. These
+    // keys are enumerated explicitly. Hyphenated spellings need no entry — the hyphen IS a
+    // boundary, so generic `token` already catches `auth-token=`. Both spellings pinned anyway.
+    const keys = [
+      "id_token",
+      "auth_token",
+      "auth-token",
+      "authtoken",
+      "hook_token",
+      "hook-token",
+      "client_secret",
+      "client-secret",
+      "app_secret",
+      "app-secret",
+      "jwt",
+      "credential",
+    ];
+    for (const key of keys) {
+      expect(redact(`connecting with ${key}=${SECRET} now`), `leaked: ${key}`).toBe(
+        `connecting with ${key}=abcdef…ghij now`,
+      );
+    }
+  });
+
+  it("keeps the standalone key set contained in the URL key set (#2903 losslessness)", () => {
+    // The standalone pattern refuses to fire at URL position (its lookbehind blocks `?`/`&`).
+    // That is only lossless because the URL pattern's key set is a superset: every key the
+    // standalone pattern would redact must still be redacted at URL position by the URL pattern.
+    const standaloneKeys = [
+      "access_token",
+      "refresh_token",
+      "id_token",
+      "auth_token",
+      "auth-token",
+      "authtoken",
+      "hook_token",
+      "hook-token",
+      "hooktoken",
+      "api_key",
+      "api-key",
+      "apikey",
+      "client_secret",
+      "client-secret",
+      "clientsecret",
+      "app_secret",
+      "app-secret",
+      "appsecret",
+      "jwt",
+      "token",
+      "secret",
+      "password",
+      "passwd",
+      "credential",
+      "card_number",
+      "card_cvc",
+      "card_cvv",
+      "cvc",
+      "cvv",
+      "security_code",
+      "payment_credential",
+      "shared_payment_token",
+    ];
+    for (const key of standaloneKeys) {
+      expect(redact(`GET /x?${key}=${SECRET}&ok=1`), `URL-position leak: ${key}`).not.toContain(
+        SECRET,
+      );
+    }
+  });
+
+  it("does not collapse the URL-masked band when the standalone pattern re-enters", () => {
+    // `?auth-token=` has a word boundary at `-|token`, so the standalone pattern's `\b` can
+    // re-enter INSIDE the query key. The value there is already masked; re-masking would collapse
+    // the legible 11-char band to `***` (11 < DEFAULT_REDACT_MIN_LENGTH) and destroy the token
+    // correlation the `start…end` shape exists for. The band must survive intact.
+    for (const key of ["auth-token", "access-token", "hook-token", "client-secret", "api-key"]) {
+      const output = redact(`GET /x?${key}=${SECRET}&ok=1`);
+      expect(output, `collapsed: ${key}`).toBe(`GET /x?${key}=abcdef…ghij&ok=1`);
+      expect(output, `collapsed: ${key}`).not.toContain("***");
+    }
+  });
+
+  it("holds ENV-position parity for the keys #2903 adds to the standalone pattern", () => {
+    // These already carry a KEY/TOKEN/SECRET suffix, so the ENV pattern masked them at HEAD and
+    // `_` blocked standalone re-entry. Adding them to the standalone pattern makes it re-match
+    // under `i` — without maskToken's idempotence guard each would REGRESS from `abcdef…ghij` to
+    // `***`. Parity here IS the guard working; this test fails if the guard is removed.
+    for (const key of ["AUTH_TOKEN", "ID_TOKEN", "HOOK_TOKEN", "CLIENT_SECRET", "APP_SECRET"]) {
+      expect(redact(`${key}=${SECRET}`), `regressed: ${key}`).toBe(`${key}=abcdef…ghij`);
+    }
+  });
+
+  it("applies maskToken's stated reveal at ENV position (exposure increase — see PR)", () => {
+    // Each of these is matched by BOTH the case-sensitive ENV pattern and the case-insensitive
+    // standalone pattern, so at HEAD the second pass re-masked the mask and collapsed it to
+    // `***`. The idempotence guard stops that, so each now reveals KEEP_START+KEEP_END chars —
+    // the same as every other position. This INCREASES what appears in logs: 0 bytes -> 10.
+    // Deliberate: the `***` was an accident of 11 < 18, never a policy. Payment keys are
+    // included; an 18-19 digit PAN at CARD_NUMBER= logs as first6…last4.
+    const keys = [
+      "TOKEN",
+      "SECRET",
+      "PASSWORD",
+      "PASSWD",
+      "API_KEY",
+      "APIKEY",
+      "ACCESS_TOKEN",
+      "REFRESH_TOKEN",
+      "CARD_NUMBER",
+      "CARD_CVC",
+      "CARD_CVV",
+      "CVC",
+      "CVV",
+      "SECURITY_CODE",
+      "PAYMENT_CREDENTIAL",
+      "SHARED_PAYMENT_TOKEN",
+    ];
+    for (const key of keys) {
+      expect(redact(`${key}=${SECRET}`), `not applied: ${key}`).toBe(`${key}=abcdef…ghij`);
+    }
+  });
+
+  it("closes the ENV-position cleartext leak for suffix-less credential keys (#2903)", () => {
+    // `JWT`/`CREDENTIAL` carry no KEY/TOKEN/SECRET/PASSWORD suffix for the ENV pattern to match
+    // on, so at HEAD they leaked in FULL at ENV position. Adding them to the standalone pattern
+    // closes that — a leak fix, not an exposure change.
+    for (const key of ["JWT", "CREDENTIAL"]) {
+      expect(redact(`${key}=${SECRET}`), `still leaking: ${key}`).toBe(`${key}=abcdef…ghij`);
+    }
+  });
+
+  it("masks a fresh secret in a run that already contains a mask", () => {
+    // The value class admits `,` and `=`, so a whitespace-delimited run spans adjacent
+    // assignments (#2907). Any guard keyed on "this RUN contains U+2026" is therefore disarmed by
+    // an already-masked NEIGHBOUR and lets the fresh secret through in full. maskToken's guard
+    // keys on the token itself, so the rest of the run is irrelevant to it.
+    expect(redact(`token=${SECRET},other=abcdef…ghij`)).not.toContain(SECRET);
+    expect(redact(`token=abcdef…ghij,other=${SECRET}`)).not.toContain(SECRET);
+  });
+
+  it("skips exactly maskToken's own image and nothing wider (idempotence guard)", () => {
+    // Skip set = exactly maskToken's output shape: length KEEP_START+1+KEEP_END (11) with U+2026
+    // at index KEEP_START (6). That is the tightest guard available — and tightest is not empty:
+    // an 11-char credential of exactly that shape is returned verbatim instead of `***`. No
+    // credential alphabet (base64url, hex, JWT, PEM body) contains U+2026, so the set is empty in
+    // practice, not in principle. Pinned so the trade fails loudly if that ever stops holding.
+    expect(redact("password=abcdef…ghij")).toBe("password=abcdef…ghij");
+
+    // Right length, no U+2026 at index 6 -> not a mask -> masked normally.
+    expect(redact("password=abcdefXghij")).toBe("password=***");
+    // U+2026 present, wrong length -> not a mask -> masked normally.
+    expect(redact("password=ab…cd")).toBe("password=***");
+    // U+2026 present, wrong index -> not a mask -> masked normally.
+    expect(redact("password=abcde…fghij")).toBe("password=***");
+    // Long value that merely contains U+2026 -> not a mask -> masked normally.
+    expect(redact("password=abcdef…ghijklmnopqrstuv")).toBe("password=abcdef…stuv");
+  });
+
+  it("does not redact prefixed URL-query credential keys (known gap, #2905)", () => {
+    // `?csrf-token=` leaks at URL position: the URL pattern does not know the key, and the
+    // standalone pattern is correctly blocked from URL position by its lookbehind. Pre-existing
+    // at HEAD — NOT introduced here. The fix belongs in the URL key set, where it is legible and
+    // covers both separators. This pins current behavior so #2905 flips it deliberately.
+    const input = `GET /x?csrf-token=${SECRET}&ok=1`;
+    expect(redact(input)).toBe(input);
+  });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -30,14 +30,69 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*\\+(["'])([^\s"'\\]+)\\+\1/g`,
   // URL query parameters. Kept separate from ENV-style assignments so lower-case URL
   // secrets (e.g. `?access_token=…`) stay redacted without hiding config-key diagnostics.
-  String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)`,
+  // The key set here is a superset of the standalone pattern's key set below. That is what
+  // makes the two patterns' disjoint domains lossless: every key redacted standalone is
+  // also redacted at URL position, so the standalone pattern can safely refuse to fire
+  // there. `id[-_]?token`, `app[-_]?secret`, `jwt`, and `credential` were added for that
+  // containment (#2903); the first two also closed real leaks at URL position.
+  String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|id[-_]?token|api[-_]?key|client[-_]?secret|app[-_]?secret|jwt|token|key|secret|password|pass|passwd|auth|credential|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)`,
   // Standalone credential assignments outside URLs (e.g. `token=…` in a log line).
-  // Leading boundary broadened to accept quote/backtick delimiters (`"`, `'`, and `\x60`
-  // for backtick, which keeps the String.raw template intact) so a lowercase key touching
-  // a quote in key=value form — `"token=…"`, `{"cmd":"token=…"}` — is redacted rather than
-  // leaking. Upstream shares this text-level gap and relies on structured tool-output
-  // redaction the fork does not carry. (Fork-side, #2852.)
-  String.raw`(^|[\s,;"'\x60])(?:access_token|refresh_token|api[-_]?key|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#]+)`,
+  //
+  // Leading boundary is `\b` (#2902). The previous delimiter whitelist accepted only
+  // whitespace/comma/semicolon/quote/backtick, so every other non-word delimiter leaked:
+  // `(token=…)`, `[token=…]`, `{cmd:token=…}`, `:token=…`, `.token=…`, `--token=…`. `\b` is
+  // a strict superset of that whitelist and still refuses to fire mid-word, so `mytoken=…`
+  // stays untouched. It is zero-width, so it consumes nothing and needs no capture group —
+  // the value is the only group, which is what `redactMatch` takes.
+  //
+  // `(?<![?&][-\w]*)` keeps this pattern's domain disjoint from the URL-query pattern above,
+  // which runs first (patterns apply in array order, each fed the previous one's output).
+  // Without the lookbehind, `\b` re-enters INSIDE a hyphenated query key — `?auth-token=`
+  // has a word boundary at `-|token` — and re-matches the already-masked value. Blocking only
+  // the single char before the key is not enough: a query key spans many chars, hence the
+  // variable-length lookbehind. It is unbounded on purpose — a length cap would only change
+  // behavior for keys longer than the cap, where it reverts to the broken re-entry. Cost is
+  // not measurable: the lookbehind fails fast and prunes the alternation attempt entirely.
+  //
+  // `maskToken`'s idempotence guard now makes that re-entry harmless, so the lookbehind may be
+  // redundant. That is NOT established. The two patterns' value classes differ (`[^\s&#]+` here
+  // vs `[^&\s"'<>]+` above), so a re-entered match need not span the same text as the original,
+  // and nothing exercises that divergence — quotes and `#` are exactly where they part company.
+  // Removing it is a separate question resting on an unproven premise; retained deliberately.
+  //
+  // Compound keys are enumerated explicitly (#2903) because `_` is a word character:
+  // `auth_token=` has NO word boundary before `token`, so the generic `token` alternative
+  // can never reach it and `\b` alone cannot fix that. Hyphenated spellings need no entry —
+  // the hyphen IS a boundary, so generic `token` already catches `auth-token=`. The
+  // boundary fix and the key list are complementary; neither alone closes the gap.
+  //
+  // Deliberately NOT here: `pass` (over-masks `pass=1`/`pass=true` in ordinary prose),
+  // `authorization` and `private_key`. The latter two are ordering-sensitive: this pattern
+  // runs BEFORE the dedicated Bearer and PEM patterns below, and its value class stops at
+  // whitespace, so it would mask the `Bearer`/`-----BEGIN` marker those patterns match on
+  // and let the actual credential through. Tracked in #2904.
+  //
+  // Idempotence — not re-masking a value some earlier pattern already masked — is deliberately
+  // NOT enforced here. It is a property of the redactor (any pattern can re-enter any other's
+  // output), not of this pattern, so the guard lives in `maskToken`; see `isAlreadyMasked`.
+  // Two attempts to encode it in this regex both got the skip set wrong, in the same way: they
+  // keyed on a proxy for "this value is a mask" rather than on the mask itself. Do not retry.
+  //
+  // The value class `[^\s&#]+` is byte-identical to HEAD's on purpose. It admits `,` and `=`,
+  // so a whitespace-delimited run spans adjacent assignments: `token=<secret>,user=alice` masks
+  // as one blob — eating the `user=alice` diagnostic, and making the mask tail (`…lice`) the
+  // tail of `alice` rather than of the token. The 6+4 shape exists to let the same token be
+  // correlated across log lines; a tail borrowed from neighbouring text breaks that. Structural,
+  // not cosmetic, and out of scope here. Tracked in #2907.
+  //
+  // Known gap: a hyphenated key absent from the URL key set above (`?csrf-token=…`) leaks at
+  // URL position — this pattern is correctly blocked there, and the URL pattern does not
+  // know the key. Pre-existing at HEAD, not introduced here. The fix belongs in the URL key
+  // set, where it is legible and works for BOTH separators. Tracked in #2905.
+  //
+  // Upstream shares this text-level gap and relies on structured tool-output redaction the
+  // fork does not carry. (Fork-side, #2852.)
+  String.raw`\b(?<![?&][-\w]*)(?:access_token|refresh_token|id_token|auth[-_]?token|hook[-_]?token|api[-_]?key|client[-_]?secret|app[-_]?secret|jwt|token|secret|password|passwd|credential|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#]+)`,
   // JSON fields.
   String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|${PAYMENT_CREDENTIAL_JSON_KEYS})"\s*:\s*"([^"]+)"`,
   // CLI flags.
@@ -98,7 +153,40 @@ function resolvePatterns(value?: string[]): RegExp[] {
   return source.map(parsePattern).filter((re): re is RegExp => Boolean(re));
 }
 
+const MASKED_TOKEN_LENGTH = DEFAULT_REDACT_KEEP_START + 1 + DEFAULT_REDACT_KEEP_END;
+
+// Idempotence guard: `maskToken` must never mask its own output.
+//
+// Patterns apply in array order, each fed the previous one's output, and their domains overlap.
+// The ENV pattern at index 0 is case-SENSITIVE, while bare `String.raw` entries compile with
+// flags `gi`, so an `AUTH_TOKEN=` masked by index 0 is re-matched by `auth[-_]?token` under `i`.
+// Without this guard the second pass masks a mask \u2014 and since a mask is exactly
+// KEEP_START + 1 + KEEP_END = 11 chars while MIN_LENGTH is 18, `maskToken` would classify it as
+// a short token and collapse the legible `abcdef\u2026ghij` to `***`.
+//
+// That collapse is an accident of two unrelated constants, not a policy. Nobody decided an
+// ENV-assigned secret should reveal 0 bytes where a URL-assigned one reveals 10; it falls out of
+// 11 < 18, and it silently flips if either constant moves. Revealing KEEP_START + KEEP_END chars
+// at or above MIN_LENGTH is the deliberate decision. The guard makes every position obey it.
+//
+// It lives here rather than in a pattern's regex because "don't re-mask a mask" is a property of
+// the redactor, not of any one pattern \u2014 and because keying on `maskToken`'s own constants tracks
+// them instead of restating them. A regex-side guard hardcoding 6/4 would silently disarm the
+// moment either constant changed, which is a worse failure than the one it prevents.
+//
+// The skip set is exactly `maskToken`'s image: 11 chars with U+2026 at index KEEP_START. That is
+// the tightest guard available \u2014 and tightest is not empty. An 11-char credential with U+2026 at
+// exactly index 6 is returned verbatim instead of `***`. No credential alphabet (base64url, hex,
+// JWT, PEM body) contains U+2026, so the set is empty in practice, not in principle. Pinned by
+// test, so the trade fails loudly if it ever stops being acceptable.
+function isAlreadyMasked(token: string): boolean {
+  return token.length === MASKED_TOKEN_LENGTH && token[DEFAULT_REDACT_KEEP_START] === "\u2026";
+}
+
 function maskToken(token: string): string {
+  if (isAlreadyMasked(token)) {
+    return token;
+  }
   if (token.length < DEFAULT_REDACT_MIN_LENGTH) {
     return "***";
   }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — held for independent security review

This change intentionally alters redaction **exposure** and touches the shared masking
path for **every** pattern in `DEFAULT_REDACT_PATTERNS`. Both are called out in their own
sections below and are required review items. Please do not merge until a security review
has signed off on the exposure delta.

---

## Summary

Two text-level redaction gaps on the **standalone credential-assignment** entry of
`DEFAULT_REDACT_PATTERNS` (`src/logging/redact.ts`), plus a redactor-level idempotence
guard that broadening the pattern surfaced.

- **#2902** — the leading-boundary was a small delimiter whitelist, so a credential in
  `key=value` form leaked whenever the character in front of the key was anything outside
  that whitelist (`(`, `[`, `{`, `:`, `.`, `-`, …).
- **#2903** — underscore-compound keys (`auth_token=`, `client_secret=`, `id_token=`, …)
  never matched, because `_` is a word character and the generic `token`/`secret`
  alternatives cannot reach across it.

Closes #2902
Closes #2903

---

## ⚠️ Exposure change — REQUIRED review item

This PR **increases** the number of bytes revealed for credentials assigned at
**ENV position** (`NAME=value` with an uppercase key). A reviewer who considers any part of
this unacceptable should say so here — it is a deliberate, gated decision, not an oversight.

**It is not a new plaintext leak.** The affected keys were already redacted at HEAD; they
showed `***`. That `***` was itself an accident: at ENV position the value is masked twice
(once by the ENV pattern, once by the standalone pattern re-entering the output), and a mask
is exactly `KEEP_START + 1 + KEEP_END = 11` characters, which is below `MIN_LENGTH` (18), so
the *second* mask classifies the already-masked band as a "short token" and collapses
`abcdef…ghij` to `***`. The idempotence guard (below) stops that second masking, so the band
survives. The consequence is that ENV-assigned credentials now reveal the same **first 6 +
last 4** characters that URL-, JSON-, and CLI-assigned credentials have always revealed —
i.e. ENV position stops being *accidentally* stricter than every other position.

**Measured, HEAD vs this PR** (feeding each key a 20-char value through the full redactor):

- **16 keys go from `***` (0 revealed) to `abcdef…ghij` (10 revealed = 6 head + 4 tail).**
  Eight generic: `TOKEN`, `SECRET`, `PASSWORD`, `PASSWD`, `API_KEY`, `APIKEY`,
  `ACCESS_TOKEN`, `REFRESH_TOKEN`. **Eight payment keys**: `CARD_NUMBER`, `CARD_CVC`,
  `CARD_CVV`, `CVC`, `CVV`, `SECURITY_CODE`, `PAYMENT_CREDENTIAL`, `SHARED_PAYMENT_TOKEN`.
- The delta applies to **any value ≥ 18 chars** (`MIN_LENGTH`). Values under 18 chars stay
  `***` at both HEAD and this PR — so naturally-short payment values (3–4 digit `CVV`/`CVC`)
  do **not** change in practice. The realistic payment exposure is **`CARD_NUMBER` for
  18–19-digit PANs** and long payment tokens.

**PAN / PCI dimension — call it out explicitly:** an 18–19-digit PAN logged as
`CARD_NUMBER=<pan>` now renders as first-6 + last-4, e.g. `424242…2123`. That is **BIN +
last four** — exactly the maximum display PCI-DSS 3.3 permits for a PAN, so it is defensible,
but it is card data moving from 0 to 10 revealed bytes and it arrived here as a side effect
of `maskToken`'s length constants rather than an explicit payment-redaction decision. If the
review wants payment keys held at `***`, that is a `maskToken`-level carve-out (see
*Considered and rejected* for why a per-key exception was **not** taken unilaterally).

**Bonus leak *fix* in the same delta — 2 keys go from full cleartext to masked:**

| key | HEAD | this PR |
|-----|------|---------|
| `JWT` | `JWT=abcdef1234567890ghij` (full leak) | `JWT=abcdef…ghij` |
| `CREDENTIAL` | `CREDENTIAL=abcdef1234567890ghij` (full leak) | `CREDENTIAL=abcdef…ghij` |

Neither has a `KEY`/`TOKEN`/`SECRET`/`PASSWORD` suffix, so the ENV pattern never matched
them and they leaked in full at HEAD. Adding `jwt` and `credential` to the standalone key
set (for #2903) closes that leak as a by-product.

---

## Blast radius — the guard changes output for EVERY pattern

The idempotence guard lives in `maskToken`, and **every** pattern's match flows through it.
A reviewer should not have to infer this from the diff:

```
redactText(text, patterns)
  for each pattern in DEFAULT_REDACT_PATTERNS:      // ENV, ENV-escaped, URL-query,
     replacePatternBounded(…, redactMatch)          // standalone, JSON, CLI, Bearer, PEM…
                             └─ redactMatch(match, groups)
                                   └─ maskToken(token)   ← isAlreadyMasked added here
```

So `isAlreadyMasked` is not scoped to the standalone pattern this PR set out to fix — it
governs the masked output of **all** patterns. (PEM blocks are handled by `redactPemBlock`
in `redactMatch` *before* `maskToken`, so they are unaffected.) This is the correct home:
"do not re-mask a mask" is a property of the *redactor* — any pattern can re-enter any
other's output — not of one pattern. But it does mean the change is redactor-wide, and that
is exactly why the exposure delta above spans keys the standalone pattern alone never
touches. Treated as a required review item.

---

## What changed (code)

**1. #2902 — leading boundary `whitelist` → `\b`** (standalone pattern):

```
- (^|[\s,;"'\x60])(?:…)=([^\s&#]+)
+ \b(?<![?&][-\w]*)(?:…)=([^\s&#]+)
```

`\b` is a strict superset of the old whitelist and still refuses to fire mid-word
(`mytoken=…` stays untouched, same as HEAD). It is zero-width, so the value is the only
capture group — which is what `redactMatch` consumes. The variable-length lookbehind
`(?<![?&][-\w]*)` keeps this pattern's domain disjoint from the URL-query pattern that runs
before it (patterns apply in array order, each fed the previous one's output); without it,
`\b` re-enters *inside* a hyphenated query key — `?auth-token=` has a boundary at `-|token` —
and re-matches an already-processed value.

**2. #2903 — compound keys added** (standalone pattern): `id_token`, `auth[-_]?token`,
`hook[-_]?token`, `client[-_]?secret`, `app[-_]?secret`, `jwt`, `credential`. `_` is a word
char, so `auth_token=` has no boundary before `token` and the generic `token` alternative
can never reach it — `\b` alone cannot fix this; the keys must be enumerated. Hyphenated
spellings need no entry — the hyphen already *is* a boundary, so generic `token` already
catches `auth-token=`. The two fixes are complementary; neither alone closes the gap.

The URL-query pattern's key set is extended **in lockstep** (`id[-_]?token`, `app[-_]?secret`,
`jwt`, `credential`) so it remains a **superset** of the standalone key set. That containment
is what makes the two patterns' disjoint domains lossless: every key redacted standalone is
also redacted at URL position, so the standalone pattern can safely refuse to fire there.

**3. Idempotence guard** in `maskToken`:

```js
const MASKED_TOKEN_LENGTH = DEFAULT_REDACT_KEEP_START + 1 + DEFAULT_REDACT_KEEP_END; // 11

function isAlreadyMasked(token) {
  return token.length === MASKED_TOKEN_LENGTH && token[DEFAULT_REDACT_KEEP_START] === "…";
}

function maskToken(token) {
  if (isAlreadyMasked(token)) return token;   // ← added
  if (token.length < DEFAULT_REDACT_MIN_LENGTH) return "***";
  return `${token.slice(0, 6)}…${token.slice(-4)}`;
}
```

The skip set is exactly `maskToken`'s own image — 11 chars with `…` (U+2026) at index
`KEEP_START`. That is the tightest guard available, and tightest is not empty: an 11-char
credential with `…` at exactly index 6 would be returned verbatim instead of `***`. No
credential alphabet (base64url, hex, JWT, PEM body) contains U+2026, so the set is empty in
practice, not in principle. This trade is pinned by a test so it fails loudly if it ever
stops being acceptable.

---

## Before / after (measured, HEAD vs this PR)

```
#2902 — boundary broadening (generic `token`, non-whitelisted leading delimiter):
  (token=abcdef1234567890ghij)      HEAD: LEAK (unredacted)   →  F4: (token=abcdef…hij)
  [token=abcdef1234567890ghij]      HEAD: LEAK                →  F4: [token=abcdef…hij]
  path:token=abcdef1234567890ghij   HEAD: LEAK                →  F4: path:token=abcdef…ghij
  --token=abcdef1234567890ghij      HEAD: LEAK                →  F4: --token=abcdef…ghij
  mytoken=abcdef1234567890ghij      HEAD: unredacted          →  F4: unredacted (mid-word, by design)

#2903 — compound lowercase keys at standalone position:
  auth_token=…      HEAD: LEAK  →  F4: auth_token=abcdef…ghij
  client_secret=…   HEAD: LEAK  →  F4: client_secret=abcdef…ghij
  id_token=…        HEAD: LEAK  →  F4: id_token=abcdef…ghij
  jwt=…             HEAD: LEAK  →  F4: jwt=abcdef…ghij
  credential=…      HEAD: LEAK  →  F4: credential=abcdef…ghij
```

(The `(token=…)` / `[token=…]` masks read `abcdef…hij)` / `abcdef…hij]` because the value
class swallows the trailing delimiter — see *Carried-forward: value class*, #2907. The value
is redacted either way; only the mask *tail* is affected.)

---

## Parity finding — the guard also prevents a regression

Five of the #2903 keys — `AUTH_TOKEN`, `ID_TOKEN`, `CLIENT_SECRET`, `APP_SECRET`,
`HOOK_TOKEN` — already redact to `abcdef…ghij` at ENV position at HEAD (their `TOKEN`/`SECRET`
suffix means the ENV pattern masks them once, and `_` blocked the old standalone pattern from
re-entering). **Without** the idempotence guard, adding these keys to the case-insensitive
standalone pattern makes it re-enter the ENV output and collapse them to `***` — a
regression. This PR holds them at parity. (This is one of the discrimination tests below.)

---

## Considered and rejected

- **Boundary + keys only, no idempotence guard.** Ships the parity regression above: the 5
  keys collapse `abcdef…ghij` → `***`. Caught by the `ENV-position parity` test.
- **Encode idempotence in the standalone regex — skip a value that "already contains a
  mask."** Leaks. The value class `[^\s&#]+` spans a whole comma-joined run, so
  `token=<secret>,user=alice` is one match; a fresh secret sharing a run with an existing
  mask gets skipped and leaks. Caught by the `fresh secret in a run that already contains a
  mask` test.
- **Shape-anchored regex guard — hardcode "11 chars with `…` at index 6" in the pattern.**
  Same skip set, but restates `maskToken`'s constants (`KEEP_START`/`KEEP_END`) in a regex
  instead of tracking them, so it silently disarms the moment either constant moves — a worse
  failure than the one it prevents — and scopes a redactor-wide property to one pattern.

The common thread in both rejected guards: they keyed on a *proxy* for "this value is a mask"
rather than on the mask itself. The guard is placed in `maskToken` precisely so it can ask
the real question at the one place the constants live.

---

## The lookbehind (retained, possibly redundant)

With the `maskToken` idempotence guard in place, the standalone pattern re-entering a
hyphenated query key is now harmless, so `(?<![?&][-\w]*)` *may* be redundant. That is **not
established** and deliberately **not acted on** here. The two patterns' value classes differ
(`[^\s&#]+` standalone vs `[^&\s"'<>]+` URL), so a re-entered match need not span the same
text as the original, and nothing in the corpus exercises that divergence — quotes and `#`
are exactly where the two classes part company, and no probe fed them. Removing it is a
separate question resting on an unproven premise; retained.

---

## Known gaps and carried-forward items

- **#2905** — `?csrf-token=…` (a hyphenated key absent from the URL key set) leaks at URL
  position. **Pre-existing at HEAD; not introduced here.** The standalone pattern is
  correctly blocked at URL position by the lookbehind, and the URL pattern does not know the
  key. The fix belongs in the URL key set (works for both separators there). Pinned by a test
  so the gap is visible, not silent.
- **#2907** — #2902's minor item (a) is carried forward here, **not dropped**: the value
  class `[^\s&#]+` stays **byte-identical** to HEAD on purpose. It admits `,` and `=`, so a
  whitespace-delimited run spans adjacent assignments (`token=<secret>,user=alice` masks as
  one blob), which both eats the neighbouring diagnostic and borrows the mask *tail* from
  neighbouring text — breaking the cross-line correlation the 6+4 shape exists to provide.
  Structural, out of scope for this PR, tracked separately.
- **#2904** — deliberately **not** added to the standalone key set: `pass` (over-masks
  `pass=1`/`pass=true` in ordinary prose); `authorization` and `private_key` (ordering-
  sensitive — this pattern runs before the dedicated Bearer/PEM patterns and its value class
  stops at whitespace, so it would mask the `Bearer`/`-----BEGIN` marker and let the actual
  credential through). Tracked separately.

---

## Test evidence

`src/logging/redact.test.ts` — **43 tests, all green** (30 pre-existing + 13 added). The
added tests are discriminating, not coverage theatre — each rejected alternative above is
failed by a specific test that this PR passes:

| variant | result (of 43) | the distinguishing failure |
|---------|----------------|----------------------------|
| **HEAD** (no fix) | **8 failed** | #2902 boundary, #2903 keys, exposure, idempotence, … |
| **Boundary + keys, no guard** | **3 failed** | `holds ENV-position parity for the keys #2903 adds` (the regression) |
| **Regex-side idempotence guard** | **2 failed** | `masks a fresh secret in a run that already contains a mask` (the leak) |
| **This PR** | **0 failed** | — |

Gates run locally (worktree):

- `pnpm check` — pass (oxfmt, `tsgo`, `oxlint --type-aware` "0 warnings and 0 errors", all
  custom `lint:no-*` gates).
- `pnpm test:fast` — 9729 passed / 42 skipped / 0 failed (full unit lane; `redact.test.ts`
  43/43 in-lane).
- `pnpm test:gateway src/gateway/ws-log.test.ts` — 12/12 (the only other
  `getDefaultRedactPatterns()` consumer; reached by the `maskToken` blast radius).

---

**Reminder: DO NOT MERGE — held for independent security review of the exposure delta and the
redactor-wide blast radius.**
