### PR TITLE
fix(node-pairing): guard store lookups/writes against special prototype keys (#2900)

### DIFF
--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -6,7 +6,10 @@ import {
   approveNodePairing,
   getPairedNode,
   listNodePairing,
+  removePairedNode,
+  renamePairedNode,
   requestNodePairing,
+  updatePairedNodeMetadata,
   verifyNodeToken,
 } from "./node-pairing.js";
 import { resolvePairingPaths } from "./pairing-files.js";
@@ -258,5 +261,100 @@ describe("node pairing tokens", () => {
       ),
     ).rejects.toThrow(/paired\.json/);
     await expect(readFile(pairedPath, "utf8")).resolves.toBe("{not-json}");
+  });
+});
+
+describe("node pairing prototype-key hardening", () => {
+  const dangerousKeys = ["__proto__", "constructor", "prototype"] as const;
+
+  test("read paths do not resolve special prototype keys to inherited values", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    for (const key of dangerousKeys) {
+      await expect(getPairedNode(key, baseDir)).resolves.toBeNull();
+      await expect(verifyNodeToken(key, "any-token", baseDir)).resolves.toEqual({ ok: false });
+    }
+  });
+
+  test("removePairedNode reports not-found for special keys instead of a false success", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    for (const key of dangerousKeys) {
+      await expect(removePairedNode(key, baseDir)).resolves.toBeNull();
+    }
+  });
+
+  test("write paths never mutate a prototype through a special key", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    for (const key of dangerousKeys) {
+      await expect(renamePairedNode(key, "pwned", baseDir)).resolves.toBeNull();
+      await expect(
+        updatePairedNodeMetadata(key, { displayName: "pwned" }, baseDir),
+      ).resolves.toBeUndefined();
+    }
+    // Prototype pollution would leak the injected value onto every object.
+    expect(({} as Record<string, unknown>).displayName).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty("displayName");
+  });
+
+  test("special-key inputs leave a real paired node and persisted state intact", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    await setupPairedNode(baseDir);
+
+    for (const key of dangerousKeys) {
+      await expect(removePairedNode(key, baseDir)).resolves.toBeNull();
+      await expect(renamePairedNode(key, "pwned", baseDir)).resolves.toBeNull();
+      await expect(
+        updatePairedNodeMetadata(key, { displayName: "pwned" }, baseDir),
+      ).resolves.toBeUndefined();
+    }
+
+    const paired = await getPairedNode("node-1", baseDir);
+    expect(paired?.nodeId).toBe("node-1");
+    const listed = await listNodePairing(baseDir);
+    expect(listed.paired.map((node) => node.nodeId)).toEqual(["node-1"]);
+  });
+
+  test("drops dangerous own-keys from a corrupted paired-node state file on load", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const { dir, pairedPath } = resolvePairingPaths(baseDir, "nodes");
+    await mkdir(dir, { recursive: true });
+    // A corrupted state file carrying special keys as own properties. `__proto__`
+    // set via an object literal would mutate the prototype rather than serialize,
+    // so build the raw JSON directly — JSON.parse materializes these as own keys.
+    const evil = { token: "x", createdAtMs: 0, approvedAtMs: 0 };
+    const entries = [
+      `"node-1":${JSON.stringify({ nodeId: "node-1", token: "t".repeat(43), createdAtMs: 1, approvedAtMs: 2 })}`,
+      `"__proto__":${JSON.stringify({ nodeId: "__proto__", ...evil })}`,
+      `"constructor":${JSON.stringify({ nodeId: "constructor", ...evil })}`,
+    ];
+    await writeFile(pairedPath, `{${entries.join(",")}}`, "utf8");
+
+    // listNodePairing enumerates the map directly (bypassing normalizeNodeId),
+    // so it exercises toSafeRecord's own-key sanitization on load.
+    const listed = await listNodePairing(baseDir);
+    expect(listed.paired.map((node) => node.nodeId)).toEqual(["node-1"]);
+    await expect(getPairedNode("__proto__", baseDir)).resolves.toBeNull();
+    await expect(getPairedNode("constructor", baseDir)).resolves.toBeNull();
+    expect(({} as Record<string, unknown>).nodeId).toBeUndefined();
+  });
+
+  test("node ids that merely contain a special key are still handled normally", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const nearMissId = "__proto__-device";
+    const request = await requestNodePairing({ nodeId: nearMissId, platform: "darwin" }, baseDir);
+    await approveNodePairing(
+      request.request.requestId,
+      { callerScopes: ["operator.pairing"] },
+      baseDir,
+    );
+
+    const paired = await getPairedNode(nearMissId, baseDir);
+    expect(paired?.nodeId).toBe(nearMissId);
+    await expect(renamePairedNode(nearMissId, "Renamed", baseDir)).resolves.toEqual(
+      expect.objectContaining({ nodeId: nearMissId, displayName: "Renamed" }),
+    );
+    await expect(removePairedNode(nearMissId, baseDir)).resolves.toEqual(
+      expect.objectContaining({ nodeId: nearMissId }),
+    );
+    await expect(getPairedNode(nearMissId, baseDir)).resolves.toBeNull();
   });
 });

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -11,6 +11,7 @@ import {
 } from "./pairing-files.js";
 import { rejectPendingPairingRequest } from "./pairing-pending.js";
 import { generatePairingToken, verifyPairingToken } from "./pairing-token.js";
+import { isBlockedObjectKey } from "./prototype-keys.js";
 
 type NodeDeclaredSurface = {
   nodeId: string;
@@ -65,6 +66,24 @@ const PENDING_TTL_MS = 5 * 60 * 1000;
 const OPERATOR_ROLE = "operator";
 
 const withLock = createAsyncLock();
+
+// Rebuild an untrusted record as a null-prototype object so JavaScript special
+// keys (`__proto__` etc.) carry no inherited meaning, dropping any blocked
+// own-keys a corrupted state file may hold (JSON.parse materializes `__proto__`
+// as an own data property). Pairing surfaces are already gated by the
+// operator.pairing scope, so this is defense-in-depth / input-hardening.
+function toSafeRecord<T>(source: Record<string, T> | null | undefined): Record<string, T> {
+  const safe = Object.create(null) as Record<string, T>;
+  if (source) {
+    for (const key of Object.keys(source)) {
+      if (isBlockedObjectKey(key)) {
+        continue;
+      }
+      safe[key] = source[key];
+    }
+  }
+  return safe;
+}
 
 function normalizeStringList(values?: string[]): string[] | undefined {
   if (!Array.isArray(values)) {
@@ -145,8 +164,8 @@ async function loadState(baseDir?: string): Promise<NodePairingStateFile> {
     readDurableJsonFile<Record<string, NodePairingPairedNode>>(pairedPath),
   ]);
   const state: NodePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByNodeId: paired ?? {},
+    pendingById: toSafeRecord(pending),
+    pairedByNodeId: toSafeRecord(paired),
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;
@@ -161,7 +180,12 @@ async function persistState(state: NodePairingStateFile, baseDir?: string) {
 }
 
 function normalizeNodeId(nodeId: string) {
-  return nodeId.trim();
+  const trimmed = nodeId.trim();
+  // Reject JavaScript special prototype keys so an untrusted nodeId can never
+  // index or mutate the paired-node map through its prototype chain. Every
+  // caller already treats an empty id as not-found / invalid (e.g.
+  // requestNodePairing's `if (!nodeId) throw`).
+  return isBlockedObjectKey(trimmed) ? "" : trimmed;
 }
 
 function newToken() {


### PR DESCRIPTION
## Summary

Hardens the node-pairing store (`src/infra/node-pairing.ts`) against JavaScript
prototype-pollution keys. The store looked up and mutated its `pairedByNodeId`
map using a caller-supplied `nodeId` that was only `.trim()`-normalized, with no
guard against special prototype keys (`__proto__`, `constructor`, `prototype`).
Because the map is a plain object, those keys reached its prototype chain.

**Severity: LOW / defense-in-depth.** Every pairing surface is already gated by
the `operator.pairing` scope (enforced at the gateway dispatch layer), so this is
input-hardening / correctness on a trusted control surface — not a
privilege-escalation vector. It is closed family-wide so a future refactor cannot
turn the assignment paths into a real pollution vector.

## The unguarded paths (live, gateway-wired)

`normalizeNodeId` returned `nodeId.trim()` and nothing else; the store functions
then indexed `state.pairedByNodeId[normalized]` directly:

- **Read false-resolution** — `getPairedNode` / `verifyNodeToken`: a `__proto__`
  nodeId resolved to the truthy `Object.prototype` (inherited value) instead of
  not-found.
- **False-positive success** — `removePairedNode({nodeId: "__proto__"})` on a
  store with no such node resolved `existing` to `Object.prototype` and returned
  it, so the handler reported `ok=true` for a node that was never paired.
- **Assignment paths** — `renamePairedNode` / `updatePairedNodeMetadata` perform
  `state.pairedByNodeId[key] = next` (the higher-risk write-via-special-key shape
  of the same idiom).

Callers are live: `gateway/server-methods/nodes.ts` (`removePairedNode`,
`verifyNodeToken`, `renamePairedNode`) and `gateway/server/ws-connection/message-handler.ts`
(`getPairedNode`, `updatePairedNodeMetadata`).

## Fix

Both layers, applied consistently across the family (not a one-function
half-measure):

1. **Null-prototype maps** — `loadState` builds `pairedByNodeId` and `pendingById`
   as `Object.create(null)` records via a new `toSafeRecord` helper, so special
   keys carry no inherited meaning. It also drops any blocked own-keys a corrupted
   state file might hold (`JSON.parse` materializes a stored `"__proto__"` as an
   own data property).
2. **Boundary rejection** — `normalizeNodeId` rejects blocked keys, returning `""`
   (which every accessor already treats as not-found / invalid, e.g.
   `requestNodePairing`'s `if (!nodeId) throw`). This reuses the repo's existing
   `isBlockedObjectKey` helper (`src/infra/prototype-keys.ts`), the same predicate
   used across `src/config/*` and `src/routing/*`.

## Tests

New `node pairing prototype-key hardening` block in `node-pairing.test.ts`,
covering all three blocked keys:

- read paths (`getPairedNode`, `verifyNodeToken`) resolve not-found;
- `removePairedNode` reports not-found instead of a false success;
- write paths (`renamePairedNode`, `updatePairedNodeMetadata`) are no-ops with no
  prototype pollution;
- a real paired node and its persisted state are unaffected by special-key ops;
- a corrupted `paired.json` carrying literal `__proto__` / `constructor` own-keys
  is sanitized on load (exercises `toSafeRecord` via `listNodePairing`, which
  bypasses `normalizeNodeId`);
- a node id that merely *contains* a special substring (`__proto__-device`) is
  handled normally (no over-rejection).

## Verification

- `node_modules/.bin/vitest run --config vitest.unit.config.ts src/infra/node-pairing.test.ts src/infra/node-pairing-authz.test.ts` → **19 passed**
- `vitest run --config vitest.gateway.config.ts --pool=forks` on the three
  gateway node-pairing suites → **34 passed** (no regression in live callers)
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) → **pass**

## Acceptance criteria

- [x] Lookup/mutation with `nodeId ∈ {__proto__, constructor, prototype}` neither
  resolves an inherited prototype value nor writes via a special key.
- [x] `removePairedNode({nodeId: "__proto__"})` returns not-found, not a false
  success.
- [x] Existing node-pairing behavior unchanged for normal node ids; existing
  tests stay green.
- [x] Regression test covers special-key input across the read and write paths.
- [x] `pnpm check` passes.

Closes #2900
