### PR TITLE
fix(redact): fall back to defaults instead of disabling redaction on bad redactPatterns

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { getDefaultRedactPatterns, redactSensitiveText } from "./redact.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  compileRedactPatternForTests,
+  getDefaultRedactPatterns,
+  redactSensitiveText,
+  resetRedactDiagnosticsForTests,
+} from "./redact.js";
 
 const defaults = getDefaultRedactPatterns();
 
@@ -135,13 +140,23 @@ describe("redactSensitiveText", () => {
     expect(output).toBe("token=abcdef…ghij");
   });
 
-  it("ignores unsafe nested-repetition custom patterns", () => {
-    const input = `${"a".repeat(28)}!`;
-    const output = redactSensitiveText(input, {
-      mode: "tools",
-      patterns: ["(a+)+$"],
-    });
-    expect(output).toBe(input);
+  it("falls back to defaults (not zero redaction) for an unsafe nested-repetition custom pattern", () => {
+    // A lone ReDoS-rejected pattern used to resolve to [] and disable redaction
+    // entirely (#2906). It now degrades to the built-in defaults, so a real secret
+    // in the same text is still masked rather than returned verbatim.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const output = redactSensitiveText("OPENAI_API_KEY=sk-1234567890abcdef", {
+        mode: "tools",
+        patterns: ["(a+)+$"],
+      });
+      expect(output).toBe("OPENAI_API_KEY=sk-123…cdef");
+      expect(output).not.toContain("sk-1234567890abcdef");
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
   });
 
   it("redacts large payloads with bounded regex passes", () => {
@@ -555,5 +570,193 @@ describe("redactSensitiveText", () => {
     // covers both separators. This pins current behavior so #2905 flips it deliberately.
     const input = `GET /x?csrf-token=${SECRET}&ok=1`;
     expect(redact(input)).toBe(input);
+  });
+});
+
+describe("redactSensitiveText — redactPatterns compilation guard (#2906)", () => {
+  const SECRET = "abcdef1234567890ghij";
+  const ENV_LINE = "OPENAI_API_KEY=sk-1234567890abcdef";
+
+  beforeEach(() => {
+    // The once-per-process diagnostic dedupe is module state; reset it so each test
+    // observes the diagnostics for its own input regardless of execution order.
+    resetRedactDiagnosticsForTests();
+  });
+
+  it("falls back to built-in defaults when every caller pattern is uncompilable", () => {
+    // A non-empty redactPatterns list REPLACES the defaults. Before the fix an
+    // all-uncompilable list resolved to [] and redactSensitiveText returned its input
+    // verbatim — redaction silently disabled while redactSensitive still read enabled.
+    // It must degrade to the defaults instead, which still mask the secret.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const output = redactSensitiveText(ENV_LINE, {
+        mode: "tools",
+        patterns: ["(unclosed-group"],
+      });
+      expect(output).toBe("OPENAI_API_KEY=sk-123…cdef");
+      expect(output).not.toContain("sk-1234567890abcdef");
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("does not return input verbatim when the sole caller pattern is uncompilable", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const output = redactSensitiveText(`connecting with token=${SECRET} now`, {
+        mode: "tools",
+        patterns: ["[unterminated-class"],
+      });
+      expect(output).not.toContain(SECRET);
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("emits a WARN diagnostic naming the rejected pattern and reason (invalid regex)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      redactSensitiveText(ENV_LINE, { mode: "tools", patterns: ["(bad-regex"] });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const message = String(warn.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain("logging.redactPatterns");
+      expect(message).toContain("(bad-regex");
+      expect(message).toContain("invalid-regex");
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("emits a diagnostic for a ReDoS-rejected (unsafe nested repetition) pattern", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      redactSensitiveText(ENV_LINE, { mode: "tools", patterns: ["(a+)+$"] });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const message = String(warn.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain("(a+)+$");
+      expect(message).toContain("unsafe-nested-repetition");
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("emits an ERROR when the whole set is rejected and it falls back to defaults", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      redactSensitiveText(ENV_LINE, { mode: "tools", patterns: ["(fallback-probe"] });
+      expect(error).toHaveBeenCalledTimes(1);
+      const message = String(error.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain("falling back to built-in default redaction patterns");
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("keeps compiled caller patterns and warns only about the rejected one (partial failure)", () => {
+    // One good pattern + one broken. The good one must still apply; the broken one is
+    // reported but does NOT trigger fallback (the resolved set is non-empty).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const output = redactSensitiveText(`token=${SECRET}`, {
+        mode: "tools",
+        patterns: ["/token=([A-Za-z0-9]+)/i", "(broken-partial"],
+      });
+      expect(output).toBe("token=abcdef…ghij");
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("(broken-partial");
+      // Non-empty resolved set -> no fallback -> no error.
+      expect(error).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("emits each distinct diagnostic only once across repeated calls", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        redactSensitiveText(ENV_LINE, { mode: "tools", patterns: ["(dedupe-probe"] });
+      }
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("bounds re-entry depth to one when captured console routes diagnostics back through redaction", () => {
+    // enableConsoleCapture() patches console.* to re-run redactSensitiveText on each
+    // console line. Emitting a diagnostic from inside resolvePatterns therefore
+    // re-enters it. Without the `emitting` guard, a config of N distinct broken
+    // patterns recurses to depth ~N (stack-overflow risk); the guard suppresses
+    // emission during a re-entry, so depth never exceeds 1 regardless of N. Measuring
+    // depth (not relying on an actual overflow) makes this environment-independent.
+    const broken = Array.from({ length: 6 }, (_, i) => `(broken-${i}`);
+    let depth = 0;
+    let maxDepth = 0;
+    let warnCalls = 0;
+    let errorCalls = 0;
+    const reenter = (msg?: unknown) => {
+      depth += 1;
+      maxDepth = Math.max(maxDepth, depth);
+      try {
+        // mimic console.ts forward(): re-redact the console line with the same config
+        redactSensitiveText(String(msg), { mode: "tools", patterns: broken });
+      } finally {
+        depth -= 1;
+      }
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation((msg?: unknown) => {
+      warnCalls += 1;
+      reenter(msg);
+    });
+    const error = vi.spyOn(console, "error").mockImplementation((msg?: unknown) => {
+      errorCalls += 1;
+      reenter(msg);
+    });
+    try {
+      expect(() =>
+        redactSensitiveText("OPENAI_API_KEY=sk-1234567890abcdef", {
+          mode: "tools",
+          patterns: broken,
+        }),
+      ).not.toThrow();
+      expect(maxDepth).toBeLessThanOrEqual(1);
+      expect(warnCalls).toBe(broken.length);
+      expect(errorCalls).toBe(1);
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("compiles every built-in DEFAULT_REDACT_PATTERNS entry to a non-null RegExp", () => {
+    // A dropped default silently weakens the shipped redaction posture with no operator
+    // signal; this makes such a regression loud at CI (#2906). Confined to a read of
+    // getDefaultRedactPatterns(); it does not touch the pattern array itself.
+    const failures = getDefaultRedactPatterns()
+      .map((raw) => ({ raw, ...compileRedactPatternForTests(raw) }))
+      .filter((entry) => entry.regex === null);
+    expect(
+      failures,
+      `these DEFAULT_REDACT_PATTERNS entries do not compile: ${JSON.stringify(
+        failures.map((entry) => ({ pattern: entry.raw, reason: entry.reason })),
+      )}`,
+    ).toEqual([]);
   });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,5 +1,5 @@
 import type { RemoteClawConfig } from "../config/config.js";
-import { compileSafeRegex } from "../security/safe-regex.js";
+import { compileSafeRegexDetailed, type SafeRegexRejectReason } from "../security/safe-regex.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { replacePatternBounded } from "./redact-bounded.js";
 
@@ -136,21 +136,94 @@ function normalizeMode(value?: string): RedactSensitiveMode {
   return value === "off" ? "off" : DEFAULT_REDACT_MODE;
 }
 
-function parsePattern(raw: string): RegExp | null {
+// Human-readable text for each rejection reason, surfaced in the operator-facing
+// diagnostic below. Keyed by the exhaustive SafeRegexRejectReason union, so a new
+// reason added upstream fails the type-check here until it is described.
+const REJECT_REASON_TEXT: Record<SafeRegexRejectReason, string> = {
+  empty: "pattern is empty",
+  "invalid-regex": "not a valid regular expression",
+  "unsafe-nested-repetition": "rejected as ReDoS-prone (unsafe nested repetition)",
+};
+
+// A redaction pattern is a security control; a silently-dropped one weakens it with
+// no operator-visible signal (#2906). Emit each distinct diagnostic once — enough to
+// alert, not enough to spam a path called on every log line.
+//
+// enableConsoleCapture() (logging/console.ts) monkey-patches console.* to route back
+// through redactSensitiveText -> resolvePatterns, so emitting a diagnostic re-enters
+// this module. Two guards keep that bounded: the key is added BEFORE emit so the
+// re-entrant call for the SAME diagnostic is deduped, and `emitting` suppresses
+// emission (not resolution) during a re-entry, so a config with many distinct broken
+// patterns cannot drive resolve depth past one re-entry. Resolution still runs on
+// re-entry, so the diagnostic line itself is redacted. Mirrors
+// loggingState.resolvingConsoleSettings in logging/console.ts.
+const emittedRedactDiagnostics = new Set<string>();
+let emittingRedactDiagnostic = false;
+
+function emitRedactDiagnosticOnce(key: string, emit: () => void): void {
+  if (emittingRedactDiagnostic || emittedRedactDiagnostics.has(key)) {
+    return;
+  }
+  emittedRedactDiagnostics.add(key);
+  emittingRedactDiagnostic = true;
+  try {
+    emit();
+  } finally {
+    emittingRedactDiagnostic = false;
+  }
+}
+
+type ParsedPattern = {
+  regex: RegExp | null;
+  reason: SafeRegexRejectReason | null;
+};
+
+function parsePatternDetailed(raw: string): ParsedPattern {
   if (!raw.trim()) {
-    return null;
+    return { regex: null, reason: "empty" };
   }
   const match = raw.match(/^\/(.+)\/([gimsuy]*)$/);
-  if (match) {
-    const flags = match[2].includes("g") ? match[2] : `${match[2]}g`;
-    return compileSafeRegex(match[1], flags);
-  }
-  return compileSafeRegex(raw, "gi");
+  const result = match
+    ? compileSafeRegexDetailed(match[1], match[2].includes("g") ? match[2] : `${match[2]}g`)
+    : compileSafeRegexDetailed(raw, "gi");
+  return { regex: result.regex, reason: result.reason };
 }
 
 function resolvePatterns(value?: string[]): RegExp[] {
+  const callerSupplied = Boolean(value?.length);
   const source = value?.length ? value : DEFAULT_REDACT_PATTERNS;
-  return source.map(parsePattern).filter((re): re is RegExp => Boolean(re));
+  const compiled: RegExp[] = [];
+  for (const raw of source) {
+    const { regex, reason } = parsePatternDetailed(raw);
+    if (regex) {
+      compiled.push(regex);
+      continue;
+    }
+    if (reason) {
+      // (a) Never drop silently — name the offending pattern and why it was rejected.
+      emitRedactDiagnosticOnce(`reject:${reason}:${raw}`, () => {
+        console.warn(
+          `[remoteclaw] logging.redactPatterns: ignoring pattern ${JSON.stringify(raw)} — ${REJECT_REASON_TEXT[reason]} (${reason}). It will NOT be used to redact logs.`,
+        );
+      });
+    }
+  }
+  if (compiled.length > 0) {
+    return compiled;
+  }
+  // (b) Fail closed. A caller-supplied set that resolves to empty degrades to the
+  // built-in defaults, never to zero redaction (#2906): a broken redactPatterns
+  // config must not silently disable a security control that still reads enabled.
+  if (callerSupplied) {
+    emitRedactDiagnosticOnce("fallback:defaults", () => {
+      console.error(
+        "[remoteclaw] logging.redactPatterns: every configured pattern was rejected — falling back to built-in default redaction patterns so logs are still redacted. Custom patterns are NOT applied until the reported patterns are fixed.",
+      );
+    });
+    return resolvePatterns(undefined);
+  }
+  // Source was already the defaults and produced nothing — nothing to fall back to.
+  return compiled;
 }
 
 const MASKED_TOKEN_LENGTH = DEFAULT_REDACT_KEEP_START + 1 + DEFAULT_REDACT_KEEP_END;
@@ -269,4 +342,20 @@ export function redactToolDetail(detail: string): string {
 
 export function getDefaultRedactPatterns(): string[] {
   return [...DEFAULT_REDACT_PATTERNS];
+}
+
+// Test-only: reset the once-per-process diagnostic dedupe so each test observes the
+// diagnostics for its own input, independent of order. Mirrors the
+// setConsoleConfigLoaderForTests test-hook convention in logging/console.ts.
+export function resetRedactDiagnosticsForTests(): void {
+  emittedRedactDiagnostics.clear();
+  emittingRedactDiagnostic = false;
+}
+
+// Test-only: compile one pattern string through the redactor's own parsing path,
+// exposing the null-or-RegExp result plus rejection reason. Used by the CI guard
+// asserting every DEFAULT_REDACT_PATTERNS entry compiles (#2906) — a dropped default
+// silently weakens the shipped redaction posture.
+export function compileRedactPatternForTests(raw: string): ParsedPattern {
+  return parsePatternDetailed(raw);
 }


### PR DESCRIPTION
## Summary

`logging.redactPatterns` is a documented, operator-facing config field. If the
patterns an operator supplies fail to compile, they were **silently discarded**
with no error, warning, or log — and because a supplied list **replaces** the
built-in defaults rather than extending them, a config whose patterns all fail
to compile resulted in **redaction being silently disabled entirely**, while
`logging.redactSensitive: "tools"` continued to report as enabled.

This was a fail-**open** on a user-configured security control: the operator
believed secrets were being redacted from logs and transcripts, and they were
not. It lands on exactly the security-conscious operators who set the field to
harden redaction. `compileSafeRegex` rejects more than typos — it also rejects
ReDoS-prone patterns — so a perfectly valid-looking regex could be rejected for
a property the operator never considered, with no signal whatsoever.

## The bug (`src/logging/redact.ts`)

Three behaviours composed into the bypass:

1. **Replace, not extend** — `resolvePatterns` used `value?.length ? value : DEFAULT_REDACT_PATTERNS`, so a non-empty `redactPatterns` array meant the built-in defaults were not used at all.
2. **Silent drop** — `parsePattern` returned `RegExp | null` and `resolvePatterns` did `.map(parsePattern).filter(Boolean)`, discarding every rejection. `compileSafeRegex` throws away the `reason` that `compileSafeRegexDetailed` already computes.
3. **Empty means off** — `redactSensitiveText`'s `if (!patterns.length) return text;` returns the raw, unredacted input.

So `redactPatterns: ["<one pattern that does not compile>"]` → `[]` → every call to `redactSensitiveText` returned its input verbatim, silently, across every sink that routes through it (log tail served to remote operators, persisted transcripts, tool detail, error/stack formatting, ACP/browser-CDP paths).

## The fix

Non-breaking and **fail-closed**, confined to the resolution/guard path
(`resolvePatterns` / `redactSensitiveText`). `DEFAULT_REDACT_PATTERNS` itself is
intentionally untouched.

1. **Do not drop silently.** Each rejected pattern is surfaced once at `WARN`, naming the offending pattern and the rejection reason — obtained from `compileSafeRegexDetailed` (`empty` / `invalid-regex` / `unsafe-nested-repetition`), which `compileSafeRegex` had been discarding.
2. **Fail closed, not open.** When a caller-supplied (non-empty) pattern set resolves to empty after compilation, it now falls back to `DEFAULT_REDACT_PATTERNS` (logged once at `ERROR`) instead of to nothing. A broken config degrades to the built-ins — never to zero redaction. Partial failures (some patterns compile) keep the compiled patterns and do **not** fall back.
3. **Re-entrancy guard.** `enableConsoleCapture()` monkey-patches `console.*` to route each console line back through `redactSensitiveText` → `resolvePatterns`. Emitting a diagnostic therefore re-enters this module. A guard suppresses diagnostic *emission* (not resolution) during a re-entry, so a config with many distinct broken patterns cannot drive resolve depth past one re-entry; resolution still runs on re-entry, so the diagnostic line itself is redacted. (Mirrors the existing `loggingState.resolvingConsoleSettings` pattern in `logging/console.ts`.)

## Tests (`src/logging/redact.test.ts`)

- An all-uncompilable caller set falls back to the defaults — the secret in the same text is still masked, not returned verbatim.
- Whitespace-only and ReDoS-rejected caller patterns also fall back (input still redacted).
- Each rejection emits a diagnostic naming the pattern and reason (invalid-regex and ReDoS cases); the full-fallback case emits the `ERROR`.
- A partial failure keeps the compiled patterns and does **not** fall back / error.
- Diagnostics are emitted at most once per distinct pattern across repeated calls.
- Re-entry depth stays bounded (≤ 1) under a simulated console-capture loop.
- **Every `DEFAULT_REDACT_PATTERNS` entry compiles to a non-null RegExp** — a dropped default is a silent shipped-posture regression, now loud at CI.

## Verification

- `pnpm check` (oxfmt + tsgo + oxlint + fork gates): clean.
- Full unit lane (`vitest.unit.config.ts`, the relevant suite for `src/logging/**`): **9738 passed | 42 skipped, 0 failed**.

## Follow-up decision for the maintainer (not included here)

The issue notes a **stricter** alternative to the fallback: **hard-error at config
load** on any uncompilable `redactPatterns` entry, surfacing the problem before
the process serves traffic (arguably the most defensible posture for a security
control). This PR deliberately implements the *non-breaking* fallback instead, so
a broken config never crashes a running deployment. Whether to additionally
reject bad `redactPatterns` at config-load time is left as a separate call.

Also worth an explicit decision (out of scope here): whether `redactPatterns`
*should* replace the defaults at all, versus **extending** them (defaults + user
patterns), which is likely what operators expect from a field described as
"Regex patterns used to redact sensitive tokens."

Closes #2906
