### PR TITLE
fix(redact): order patterns anchor-first, close prefixed-key + PEM-order leaks, narrow value class

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -384,16 +384,17 @@ describe("redactSensitiveText", () => {
     }
   });
 
-  it("borrows the mask tail from a trailing closing delimiter (#2907, pinned as-is)", () => {
-    // The value class admits `)` `]` `}` `>`, so a closing delimiter is captured INTO the value
-    // and supplies the mask's last KEEP_END chars: `(token=<secret>)` -> `(token=abcdef…hij)`.
-    // The secret is still masked — confidentiality holds — but the tail is NOT the token's tail,
-    // so the same token masks differently depending on surrounding punctuation. That breaks the
-    // cross-line correlation the 6+4 shape exists to provide. It lands hardest on exactly the
-    // bracket delimiters #2902 fixes. Value class deliberately byte-identical here; see #2907.
-    expect(redact(`(token=${SECRET})`)).toBe("(token=abcdef…hij)");
-    expect(redact(`[token=${SECRET}]`)).toBe("[token=abcdef…hij]");
-    expect(redact(`<token=${SECRET}>`)).toBe("<token=abcdef…hij>");
+  it("masks to an exact band when a closing delimiter trails the value (#2907)", () => {
+    // FLIPPED BY #2907. HEAD's value class `[^\s&#]+` admitted `)` `]` `}` `>`, so a closing
+    // delimiter was captured INTO the value and supplied the mask's last KEEP_END chars:
+    // `(token=<secret>)` -> `(token=abcdef…hij)`. The secret was still masked — confidentiality
+    // held — but the tail was NOT the token's tail, so the same token masked DIFFERENTLY depending
+    // on the punctuation around it, breaking the cross-line correlation the 6+4 shape exists to
+    // provide. It landed hardest on exactly the bracket delimiters #2902 had just fixed.
+    // The narrowed class excludes them, so the band is now exactly maskToken's image.
+    expect(redact(`(token=${SECRET})`)).toBe("(token=abcdef…ghij)");
+    expect(redact(`[token=${SECRET}]`)).toBe("[token=abcdef…ghij]");
+    expect(redact(`<token=${SECRET}>`)).toBe("<token=abcdef…ghij>");
   });
 
   it("still refuses to fire mid-word after boundary broadening (#2902)", () => {
@@ -432,8 +433,14 @@ describe("redactSensitiveText", () => {
 
   it("keeps the standalone key set contained in the URL key set (#2903 losslessness)", () => {
     // The standalone pattern refuses to fire at URL position (its lookbehind blocks `?`/`&`).
-    // That is only lossless because the URL pattern's key set is a superset: every key the
+    // That is only lossless because the URL pattern's key set is a SUPERSET: every key the
     // standalone pattern would redact must still be redacted at URL position by the URL pattern.
+    //
+    // This is the invariant that governs every future key addition: a key added to the standalone
+    // set and NOT to the URL set silently stops being redacted the moment it appears in a query
+    // string. The `authorization` / `private_key` keys (#2904) and the prefixed compounds (#2905)
+    // are listed here because they were added to the standalone set, so they MUST hold at URL
+    // position too. Extend this list whenever the standalone key set grows.
     const standaloneKeys = [
       "access_token",
       "refresh_token",
@@ -467,6 +474,24 @@ describe("redactSensitiveText", () => {
       "security_code",
       "payment_credential",
       "shared_payment_token",
+      // Added to the standalone set by #2904 — containment requires them here.
+      "authorization",
+      "private_key",
+      "private-key",
+      "privatekey",
+      // Added to the standalone set by #2905 — containment requires them here.
+      "csrf_token",
+      "csrf-token",
+      "session_token",
+      "session-token",
+      "webhook_secret",
+      "webhook-secret",
+      "signing_secret",
+      "signing-secret",
+      "bot_token",
+      "bot-token",
+      "user_password",
+      "user-password",
     ];
     for (const key of standaloneKeys) {
       expect(redact(`GET /x?${key}=${SECRET}&ok=1`), `URL-position leak: ${key}`).not.toContain(
@@ -537,12 +562,56 @@ describe("redactSensitiveText", () => {
   });
 
   it("masks a fresh secret in a run that already contains a mask", () => {
-    // The value class admits `,` and `=`, so a whitespace-delimited run spans adjacent
-    // assignments (#2907). Any guard keyed on "this RUN contains U+2026" is therefore disarmed by
-    // an already-masked NEIGHBOUR and lets the fresh secret through in full. maskToken's guard
-    // keys on the token itself, so the rest of the run is irrelevant to it.
+    // Any idempotence guard keyed on "this RUN contains U+2026" would be disarmed by an
+    // already-masked NEIGHBOUR and let the fresh secret through in full. maskToken's guard keys on
+    // the TOKEN itself, so the rest of the run is irrelevant to it — which is what this pins.
     expect(redact(`token=${SECRET},other=abcdef…ghij`)).not.toContain(SECRET);
-    expect(redact(`token=abcdef…ghij,other=${SECRET}`)).not.toContain(SECRET);
+
+    // REFRAMED BY #2907. The neighbour is now a CREDENTIAL key, so it is in scope and masks on its
+    // own merit. This assertion previously read `other=${SECRET}` and only passed because the wide
+    // value class swept the NON-credential `other=` neighbour into the token's mask — it was
+    // asserting an accident of the run-spanning bug, not the guard. Post-narrowing `other=<v>` is
+    // out of scope at every position, so a credential key is the honest way to test the guard.
+    expect(redact(`token=abcdef…ghij,secret=${SECRET}`)).not.toContain(SECRET);
+  });
+
+  it("masks each credential assignment independently and keeps the neighbour diagnostic (#2907)", () => {
+    // The positive demonstration of #2907. HEAD's value class admitted `,`, so the run spanned into
+    // the next assignment and `token=<secret>,user=alice` masked as ONE blob — eating the
+    // `user=alice` diagnostic AND borrowing the mask tail (`…lice`) from `alice` rather than from
+    // the token. Narrowed: the run stops at the comma, the token's own tail is revealed, and the
+    // non-credential neighbour survives intact.
+    expect(redact(`token=${SECRET},user=alice`)).toBe("token=abcdef…ghij,user=alice");
+  });
+
+  it("masks only the credential in a comma-separated run of assignments (#2907)", () => {
+    // Same property across a longer run: every non-credential diagnostic beside the secret is
+    // preserved verbatim instead of being swallowed into one blob.
+    expect(redact(`token=${SECRET},retries=3,region=eu-west-1`)).toBe(
+      "token=abcdef…ghij,retries=3,region=eu-west-1",
+    );
+  });
+
+  it("keeps base64 padding inside the captured value (#2907 value class keeps `=`)", () => {
+    // `=` is deliberately KEPT in the narrowed value class. Excluding it would terminate the
+    // capture at the padding — stranding `=`/`==` in cleartext beside a truncated mask.
+    const padded = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=";
+    const output = redact(`token=${padded}`);
+    expect(output).not.toContain(padded);
+    // Padding sits INSIDE the mask's revealed tail, not stranded next to it.
+    expect(output).toMatch(/^token=[A-Za-z0-9]{6}…[A-Za-z0-9]{3}=$/);
+  });
+
+  it("keeps the quoted-value form redacted (#2907 value class keeps quotes)", () => {
+    // `"` `'` and backtick are deliberately KEPT in the narrowed value class. This pattern is the
+    // SOLE handler of `token="<secret>"` — the ENV pattern is uppercase-only and the JSON pattern
+    // needs `"key":"value"`. A character class governs the value's FIRST character as well as its
+    // rest, so excluding `"` would make the class fail to match AT the opening quote: the pattern
+    // would not fire at all and the secret would ship in cleartext. Pinned so that trade cannot be
+    // silently reversed while chasing a tidier mask tail.
+    for (const input of [`token="${SECRET}"`, `token='${SECRET}'`, `token=\`${SECRET}\``]) {
+      expect(redact(input), `leaked: ${input}`).not.toContain(SECRET);
+    }
   });
 
   it("skips exactly maskToken's own image and nothing wider (idempotence guard)", () => {
@@ -563,13 +632,157 @@ describe("redactSensitiveText", () => {
     expect(redact("password=abcdef…ghijklmnopqrstuv")).toBe("password=abcdef…stuv");
   });
 
-  it("does not redact prefixed URL-query credential keys (known gap, #2905)", () => {
-    // `?csrf-token=` leaks at URL position: the URL pattern does not know the key, and the
-    // standalone pattern is correctly blocked from URL position by its lookbehind. Pre-existing
-    // at HEAD — NOT introduced here. The fix belongs in the URL key set, where it is legible and
-    // covers both separators. This pins current behavior so #2905 flips it deliberately.
-    const input = `GET /x?csrf-token=${SECRET}&ok=1`;
-    expect(redact(input)).toBe(input);
+  it("redacts prefixed URL-query credential keys (#2905)", () => {
+    // FLIPPED BY #2905. `?csrf-token=` used to leak IN FULL at URL position: `[?&]` anchors the URL
+    // pattern's alternation to the START of the key, so the generic `token` alternative could never
+    // reach the `token` inside `csrf-token`, and the standalone pattern is correctly blocked from
+    // URL position by its lookbehind. Neither pattern knew the key. It is now enumerated in the URL
+    // key set, so it masks — and the non-secret `&ok=1` beside it is still preserved.
+    const output = redact(`GET /x?csrf-token=${SECRET}&ok=1`);
+    expect(output).not.toContain(SECRET);
+    expect(output).toBe("GET /x?csrf-token=abcdef…ghij&ok=1");
+  });
+
+  it("redacts prefixed compound credential keys at BOTH positions, both separators (#2905)", () => {
+    // At URL position `[?&]` anchors the alternation to the START of the key, so a generic
+    // `token`/`secret`/`password` alternative can never reach the one inside `csrf-token` /
+    // `webhook-secret` / `user-password` — the compound must be enumerated.
+    //
+    // At STANDALONE position the UNDERSCORE spelling is the one that leaks: `_` is a word char, so
+    // `csrf_token=` has no `\b` before `token` for the generic alternative to reach through. The
+    // hyphen spelling does have one (the hyphen IS a boundary), so it was already caught there —
+    // pinned anyway, because the two spellings must not diverge.
+    const keys = [
+      "csrf-token",
+      "csrf_token",
+      "session-token",
+      "session_token",
+      "webhook-secret",
+      "webhook_secret",
+      "signing-secret",
+      "signing_secret",
+      "bot-token",
+      "bot_token",
+      "user-password",
+      "user_password",
+    ];
+    for (const key of keys) {
+      expect(redact(`GET /x?${key}=${SECRET}&ok=1`), `URL-position leak: ${key}`).toBe(
+        `GET /x?${key}=abcdef…ghij&ok=1`,
+      );
+      expect(redact(`connecting with ${key}=${SECRET} now`), `standalone leak: ${key}`).toBe(
+        `connecting with ${key}=abcdef…ghij now`,
+      );
+    }
+  });
+
+  it("does not over-mask non-credential prefixed keys (#2905 explicit-list discipline)", () => {
+    // #2905 is closed with an EXPLICIT list of unambiguous credential compounds. The shorter fix —
+    // a broad `[?&](?:[\w-]*[-_])?(?:token|secret|key)=` prefix — would also have swallowed these
+    // ordinary, non-secret parameters, masking routine diagnostics into uselessness. That is the
+    // trade this test pins: the list must stay explicit, and must not grow an ambiguous key.
+    for (const key of [
+      "public-key",
+      "sort-key",
+      "primary-key",
+      "partition-key",
+      "idempotency-key",
+    ]) {
+      const input = `GET /x?${key}=${SECRET}&ok=1`;
+      expect(redact(input), `over-masked: ${key}`).toBe(input);
+    }
+  });
+
+  it("keeps a PEM body redacted when the block is the value of a PRIVATE_KEY= assignment (#2904)", () => {
+    // THE live leak #2904 closes, and the reason the array is ordered anchored-first.
+    //
+    // The ENV pattern used to run FIRST, and its value class stops at the first space — so it
+    // captured `-----BEGIN` as the "value" of `PRIVATE_KEY=` and masked it to `***`. That destroyed
+    // the PEM opener; the PEM pattern could no longer match its own block; and the entire base64
+    // body shipped in CLEARTEXT. PEM now runs before every generic family, so the block is redacted
+    // before anything can chew its opener.
+    const body = "MIIEowIBAAKCAQEAxGZ1kQm9SxWfBnP0tOQiL7VnJ3hYdKcRbFgUvNzMpAeIoQwT";
+    const input = [
+      "PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----",
+      body,
+      "-----END RSA PRIVATE KEY-----",
+    ].join("\n");
+    const output = redact(input);
+    // The body is the thing that must never appear. The trailing ENV pass may additionally mask the
+    // now-orphaned `-----BEGIN` opener token to `***` — harmless, the body is already redacted.
+    expect(output).not.toContain(body);
+    expect(output).toContain("…redacted…");
+  });
+
+  it("still redacts a bare PEM block after the reorder (#2904)", () => {
+    const input = [
+      "-----BEGIN PRIVATE KEY-----",
+      "ABCDEF1234567890",
+      "ZYXWVUT987654321",
+      "-----END PRIVATE KEY-----",
+    ].join("\n");
+    expect(redact(input)).toBe(
+      ["-----BEGIN PRIVATE KEY-----", "…redacted…", "-----END PRIVATE KEY-----"].join("\n"),
+    );
+  });
+
+  it("masks an authorization= assignment at standalone position (#2904)", () => {
+    // `authorization` is newly IN the standalone key set — the reorder is what made it safe. It was
+    // excluded before because this pattern ran BEFORE the Bearer pattern and its value class stops
+    // at whitespace, so it masked the `Bearer` KEYWORD and let the real token through behind it.
+    //
+    // Bearer form: the Authorization pattern (now first) masks the token; the standalone pattern
+    // then masks the residual `Bearer` keyword to `***`. Belt and braces — no token leak.
+    const bearer = redact(`authorization=Bearer ${SECRET}`);
+    expect(bearer).not.toContain(SECRET);
+    expect(bearer).toBe("authorization=*** abcdef…ghij");
+
+    // Opaque form (NO `Bearer` keyword). THIS one leaked in full at HEAD: the Authorization pattern
+    // requires the `Bearer` keyword, and `authorization` was not a standalone key, so nothing
+    // matched it at all.
+    const opaque = redact(`authorization=${SECRET}`);
+    expect(opaque).not.toContain(SECRET);
+    expect(opaque).toBe("authorization=abcdef…ghij");
+  });
+
+  it("keeps the Authorization: Bearer header form masked after the reorder (#2904)", () => {
+    // The reorder moved this pattern from last-ish to near-first. It must still behave identically.
+    expect(redact(`Authorization: Bearer ${SECRET}`)).toBe("Authorization: Bearer abcdef…ghij");
+    expect(redact(`Bearer ${SECRET}`)).toBe("Bearer abcdef…ghij");
+  });
+
+  it("masks lowercase private_key= at standalone and URL position (#2904)", () => {
+    // Lowercase `private_key=<opaque>` leaked IN FULL at HEAD: the ENV pattern is uppercase-only,
+    // and `_` is a word char so the standalone pattern had no `\b` before `key` to reach it with —
+    // and it carried no bare `key` alternative anyway. `private[-_]?key` closes both spellings.
+    expect(redact(`private_key=${SECRET}`)).toBe("private_key=abcdef…ghij");
+    expect(redact(`private-key=${SECRET}`)).toBe("private-key=abcdef…ghij");
+    // Containment: both new keys must also mask at URL position (see the losslessness test).
+    expect(redact(`GET /x?private_key=${SECRET}&ok=1`)).toBe("GET /x?private_key=abcdef…ghij&ok=1");
+    expect(redact(`GET /x?authorization=${SECRET}&ok=1`)).toBe(
+      "GET /x?authorization=abcdef…ghij&ok=1",
+    );
+  });
+
+  it("masks a vendor-prefixed token exactly once under the new order (#2904 reorder safety)", () => {
+    // The vendor `sk-` pattern now runs BEFORE the generic families, so the generic pass sees an
+    // ALREADY-MASKED value. maskToken's idempotence guard returns it verbatim rather than
+    // collapsing the legible 11-char band to `***` (11 < DEFAULT_REDACT_MIN_LENGTH = 18). Parity
+    // across all three positions IS that guard holding across the new order — this test fails if
+    // the reorder is landed without it.
+    const vendor = "sk-1234567890abcdef";
+    const outputs = [
+      redact(`api_key=${vendor}`),
+      redact(`API_KEY=${vendor}`),
+      redact(`{"apiKey":"${vendor}"}`),
+    ];
+    expect(outputs[0]).toBe("api_key=sk-123…cdef");
+    expect(outputs[1]).toBe("API_KEY=sk-123…cdef");
+    expect(outputs[2]).toBe('{"apiKey":"sk-123…cdef"}');
+    for (const output of outputs) {
+      expect(output, `collapsed to ***: ${output}`).not.toContain("***");
+      expect(output, `leaked: ${output}`).not.toContain(vendor);
+    }
   });
 });
 

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -20,89 +20,48 @@ const PAYMENT_CREDENTIAL_ENV_KEYS = String.raw`CARD[_-]?NUMBER|CARD[_-]?CVC|CARD
 const PAYMENT_CREDENTIAL_QUERY_KEYS = String.raw`card[-_]?number|card[-_]?cvc|card[-_]?cvv|cvc|cvv|security[-_]?code|payment[-_]?credential|shared[-_]?payment[-_]?token`;
 const PAYMENT_CREDENTIAL_JSON_KEYS = String.raw`cardNumber|card_number|cardCvc|card_cvc|cardCvv|card_cvv|cvc|cvv|securityCode|security_code|paymentCredential|payment_credential|sharedPaymentToken|shared_payment_token`;
 
+// ORDER IS SEMANTIC — do not regroup by theme.
+//
+// `redactText` applies these SEQUENTIALLY in array order, feeding each pattern's `.replace()`
+// output to the next. A GENERIC `key=value` pattern that runs early can therefore capture and mask
+// the very ANCHOR a later, more specific pattern matches on — silently disabling it. That is not
+// hypothetical: it is #2904. The ENV pattern used to run first, and its value class stops at the
+// first space, so
+//
+//     PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\n<base64 body>\n-----END RSA PRIVATE KEY-----
+//
+// had `-----BEGIN` captured as the ENV "value" and masked to `***`. That destroyed the PEM opener,
+// the PEM pattern below could no longer match, and the entire base64 body shipped in CLEARTEXT.
+//
+// Hence: MOST-ANCHORED-FIRST, MOST-GENERIC-LAST.
+//
+//   1. PEM blocks              — multi-line, anchored on a `-----BEGIN` opener a generic can eat.
+//   2. Authorization / Bearer  — anchored on a `Bearer` keyword a generic can eat.
+//   3. Vendor-prefix tokens    — self-anchored on their own literal prefix (sk-, ghp_, AKIA, …).
+//   4. ENV → URL → standalone → JSON → CLI — the generic `key=value` families.
+//
+// Reordering is SAFE where a generic and a specific pattern both match the same token, because
+// `maskToken`'s idempotence guard (`isAlreadyMasked`) returns an already-masked value verbatim.
+// `OPENAI_API_KEY=sk-1234567890abcdef` is masked by the vendor `sk-` pattern first; the later ENV
+// pass then captures `sk-123…cdef`, recognises maskToken's own image, and leaves it alone instead
+// of collapsing it to `***`. Whichever of the two runs first wins; the other is a no-op. Order
+// therefore decides WHICH pattern masks a token, never WHETHER it is masked.
+//
+// Adding a pattern? Place it by ANCHOR STRENGTH, not by theme.
 const DEFAULT_REDACT_PATTERNS: string[] = [
-  // ENV-style assignments. Keep this case-sensitive so diagnostics like
-  // `Unrecognized key: "llm"` do not lose the actual config key.
-  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
-  // Same, but for backslash-escaped quotes. The pattern above excludes `\` from the
-  // value class, so a JSON-embedded shell command (`{"command":"export KEY=\"secret\""}`)
-  // never matches it and would otherwise log the credential in cleartext.
-  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*\\+(["'])([^\s"'\\]+)\\+\1/g`,
-  // URL query parameters. Kept separate from ENV-style assignments so lower-case URL
-  // secrets (e.g. `?access_token=…`) stay redacted without hiding config-key diagnostics.
-  // The key set here is a superset of the standalone pattern's key set below. That is what
-  // makes the two patterns' disjoint domains lossless: every key redacted standalone is
-  // also redacted at URL position, so the standalone pattern can safely refuse to fire
-  // there. `id[-_]?token`, `app[-_]?secret`, `jwt`, and `credential` were added for that
-  // containment (#2903); the first two also closed real leaks at URL position.
-  String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|id[-_]?token|api[-_]?key|client[-_]?secret|app[-_]?secret|jwt|token|key|secret|password|pass|passwd|auth|credential|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)`,
-  // Standalone credential assignments outside URLs (e.g. `token=…` in a log line).
-  //
-  // Leading boundary is `\b` (#2902). The previous delimiter whitelist accepted only
-  // whitespace/comma/semicolon/quote/backtick, so every other non-word delimiter leaked:
-  // `(token=…)`, `[token=…]`, `{cmd:token=…}`, `:token=…`, `.token=…`, `--token=…`. `\b` is
-  // a strict superset of that whitelist and still refuses to fire mid-word, so `mytoken=…`
-  // stays untouched. It is zero-width, so it consumes nothing and needs no capture group —
-  // the value is the only group, which is what `redactMatch` takes.
-  //
-  // `(?<![?&][-\w]*)` keeps this pattern's domain disjoint from the URL-query pattern above,
-  // which runs first (patterns apply in array order, each fed the previous one's output).
-  // Without the lookbehind, `\b` re-enters INSIDE a hyphenated query key — `?auth-token=`
-  // has a word boundary at `-|token` — and re-matches the already-masked value. Blocking only
-  // the single char before the key is not enough: a query key spans many chars, hence the
-  // variable-length lookbehind. It is unbounded on purpose — a length cap would only change
-  // behavior for keys longer than the cap, where it reverts to the broken re-entry. Cost is
-  // not measurable: the lookbehind fails fast and prunes the alternation attempt entirely.
-  //
-  // `maskToken`'s idempotence guard now makes that re-entry harmless, so the lookbehind may be
-  // redundant. That is NOT established. The two patterns' value classes differ (`[^\s&#]+` here
-  // vs `[^&\s"'<>]+` above), so a re-entered match need not span the same text as the original,
-  // and nothing exercises that divergence — quotes and `#` are exactly where they part company.
-  // Removing it is a separate question resting on an unproven premise; retained deliberately.
-  //
-  // Compound keys are enumerated explicitly (#2903) because `_` is a word character:
-  // `auth_token=` has NO word boundary before `token`, so the generic `token` alternative
-  // can never reach it and `\b` alone cannot fix that. Hyphenated spellings need no entry —
-  // the hyphen IS a boundary, so generic `token` already catches `auth-token=`. The
-  // boundary fix and the key list are complementary; neither alone closes the gap.
-  //
-  // Deliberately NOT here: `pass` (over-masks `pass=1`/`pass=true` in ordinary prose),
-  // `authorization` and `private_key`. The latter two are ordering-sensitive: this pattern
-  // runs BEFORE the dedicated Bearer and PEM patterns below, and its value class stops at
-  // whitespace, so it would mask the `Bearer`/`-----BEGIN` marker those patterns match on
-  // and let the actual credential through. Tracked in #2904.
-  //
-  // Idempotence — not re-masking a value some earlier pattern already masked — is deliberately
-  // NOT enforced here. It is a property of the redactor (any pattern can re-enter any other's
-  // output), not of this pattern, so the guard lives in `maskToken`; see `isAlreadyMasked`.
-  // Two attempts to encode it in this regex both got the skip set wrong, in the same way: they
-  // keyed on a proxy for "this value is a mask" rather than on the mask itself. Do not retry.
-  //
-  // The value class `[^\s&#]+` is byte-identical to HEAD's on purpose. It admits `,` and `=`,
-  // so a whitespace-delimited run spans adjacent assignments: `token=<secret>,user=alice` masks
-  // as one blob — eating the `user=alice` diagnostic, and making the mask tail (`…lice`) the
-  // tail of `alice` rather than of the token. The 6+4 shape exists to let the same token be
-  // correlated across log lines; a tail borrowed from neighbouring text breaks that. Structural,
-  // not cosmetic, and out of scope here. Tracked in #2907.
-  //
-  // Known gap: a hyphenated key absent from the URL key set above (`?csrf-token=…`) leaks at
-  // URL position — this pattern is correctly blocked there, and the URL pattern does not
-  // know the key. Pre-existing at HEAD, not introduced here. The fix belongs in the URL key
-  // set, where it is legible and works for BOTH separators. Tracked in #2905.
-  //
-  // Upstream shares this text-level gap and relies on structured tool-output redaction the
-  // fork does not carry. (Fork-side, #2852.)
-  String.raw`\b(?<![?&][-\w]*)(?:access_token|refresh_token|id_token|auth[-_]?token|hook[-_]?token|api[-_]?key|client[-_]?secret|app[-_]?secret|jwt|token|secret|password|passwd|credential|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#]+)`,
-  // JSON fields.
-  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|${PAYMENT_CREDENTIAL_JSON_KEYS})"\s*:\s*"([^"]+)"`,
-  // CLI flags.
-  String.raw`--(?:api[-_]?key|hook[-_]?token|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})\s+(["']?)([^\s"']+)\1`,
-  // Authorization headers.
+  // --- 1. PEM blocks ------------------------------------------------------------------------
+  // FIRST on purpose (#2904). Any generic `key=value` family running ahead of this would mask the
+  // `-----BEGIN` opener of a `PRIVATE_KEY=<pem>` line and leak the body. See the ORDER note above.
+  String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
+  // --- 2. Authorization headers / Bearer tokens ---------------------------------------------
+  // Anchored on the `Bearer` keyword. A generic family running first would capture `Bearer` as the
+  // VALUE of `authorization=…` and mask it, leaving the real token in cleartext behind it (#2904).
   String.raw`Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=]+)`,
   String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
-  // PEM blocks.
-  String.raw`-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----`,
-  // Common token prefixes.
+  // --- 3. Vendor-prefix / self-anchored tokens ----------------------------------------------
+  // Each anchors on its own literal prefix, so it is immune to key-name spelling — but NOT to a
+  // generic pattern masking its value first. Running them here means the pattern that actually
+  // understands a token's shape is the one that masks it, at every position it can appear.
   String.raw`\b(sk-[A-Za-z0-9_-]{8,})\b`,
   String.raw`\b(ghp_[A-Za-z0-9]{20,})\b`,
   String.raw`\b(github_pat_[A-Za-z0-9_]{20,})\b`,
@@ -123,8 +82,129 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   String.raw`\b(hf_[A-Za-z0-9]{10,})\b`,
   String.raw`\b(r8_[A-Za-z0-9]{10,})\b`,
   // Telegram Bot API URLs embed the token as `/bot<token>/...` (no word-boundary before digits).
+  // Distinct from the `bot[-_]?token` KEY added to the generic families below — that one is a
+  // query/log key literally named `bot-token`; this one is the token's own `<digits>:<secret>` shape.
   String.raw`\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
   String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
+  // --- 4. Generic `key=value` families ------------------------------------------------------
+  // ENV-style assignments. Keep this case-sensitive so diagnostics like
+  // `Unrecognized key: "llm"` do not lose the actual config key.
+  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
+  // Same, but for backslash-escaped quotes. The pattern above excludes `\` from the
+  // value class, so a JSON-embedded shell command (`{"command":"export KEY=\"secret\""}`)
+  // never matches it and would otherwise log the credential in cleartext.
+  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*\\+(["'])([^\s"'\\]+)\\+\1/g`,
+  // URL query parameters. Kept separate from ENV-style assignments so lower-case URL
+  // secrets (e.g. `?access_token=…`) stay redacted without hiding config-key diagnostics.
+  //
+  // CONTAINMENT INVARIANT: this key set is a SUPERSET of the standalone pattern's key set below.
+  // That is what makes the two patterns' disjoint domains lossless — the standalone pattern's
+  // lookbehind refuses to fire at URL position, which is only safe because every key it would
+  // redact is redacted HERE instead. `id[-_]?token`, `app[-_]?secret`, `jwt`, and `credential`
+  // were added for that containment (#2903); the first two also closed real leaks at URL position.
+  // ANY key added to the standalone set MUST be added here too or containment breaks — pinned by
+  // the "#2903 losslessness" test.
+  //
+  // `authorization` and `private[-_]?key` are here for containment with the standalone set (#2904).
+  //
+  // The prefixed compounds (`csrf[-_]?token`, `session[-_]?token`, `webhook[-_]?secret`,
+  // `signing[-_]?secret`, `bot[-_]?token`, `user[-_]?password`) close #2905: `?csrf-token=…` leaked
+  // because `[?&]` anchors the alternation to the START of the key, so the generic `token`
+  // alternative can never reach the `token` inside `csrf-token`. Enumerated EXPLICITLY rather than
+  // via a broad `(?:[\w-]*[-_])?(?:token|secret|key)=` prefix, which would over-mask non-secrets:
+  // `?public-key=`, `?sort-key=`, `?primary-key=`, `?partition-key=`, `?idempotency-key=`. Every
+  // key on this list is an unambiguous credential; a hyphen/underscore-agnostic `[-_]?` covers both
+  // spellings, so no lookbehind artefact is needed. Pinned by negative tests.
+  String.raw`[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|id[-_]?token|csrf[-_]?token|session[-_]?token|bot[-_]?token|api[-_]?key|private[-_]?key|client[-_]?secret|app[-_]?secret|webhook[-_]?secret|signing[-_]?secret|user[-_]?password|authorization|jwt|token|key|secret|password|pass|passwd|auth|credential|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)`,
+  // Standalone credential assignments outside URLs (e.g. `token=…` in a log line).
+  //
+  // Leading boundary is `\b` (#2902). The previous delimiter whitelist accepted only
+  // whitespace/comma/semicolon/quote/backtick, so every other non-word delimiter leaked:
+  // `(token=…)`, `[token=…]`, `{cmd:token=…}`, `:token=…`, `.token=…`, `--token=…`. `\b` is
+  // a strict superset of that whitelist and still refuses to fire mid-word, so `mytoken=…`
+  // stays untouched. It is zero-width, so it consumes nothing and needs no capture group —
+  // the value is the only group, which is what `redactMatch` takes.
+  //
+  // `(?<![?&][-\w]*)` keeps this pattern's domain disjoint from the URL-query pattern above,
+  // which runs first (patterns apply in array order, each fed the previous one's output).
+  // Without the lookbehind, `\b` re-enters INSIDE a hyphenated query key — `?auth-token=`
+  // has a word boundary at `-|token` — and re-matches the already-masked value. Blocking only
+  // the single char before the key is not enough: a query key spans many chars, hence the
+  // variable-length lookbehind. It is unbounded on purpose — a length cap would only change
+  // behavior for keys longer than the cap, where it reverts to the broken re-entry. Cost is
+  // not measurable: the lookbehind fails fast and prunes the alternation attempt entirely.
+  //
+  // `maskToken`'s idempotence guard now makes that re-entry harmless, so the lookbehind may be
+  // redundant. That is NOT established. The two patterns' value classes still differ
+  // (`[^\s&#,<>)\]}]+` here vs `[^&\s"'<>]+` above), so a re-entered match need not span the same
+  // text as the original, and nothing exercises that divergence — quotes and `#` are exactly where
+  // they part company. Removing it is a separate question resting on an unproven premise; retained
+  // deliberately.
+  //
+  // Compound keys are enumerated explicitly (#2903, #2905) because `_` is a word character:
+  // `auth_token=` has NO word boundary before `token`, so the generic `token` alternative
+  // can never reach it and `\b` alone cannot fix that. Hyphenated spellings need no entry —
+  // the hyphen IS a boundary, so generic `token` already catches `auth-token=`. The
+  // boundary fix and the key list are complementary; neither alone closes the gap. The #2905
+  // compounds are listed at BOTH positions: `csrf_token=<v>` leaks in a plain (non-URL) log line
+  // for exactly this `_`-is-a-word-char reason, and containment (see the URL pattern) requires any
+  // standalone key to exist at URL position too.
+  //
+  // `authorization` and `private[-_]?key` are now IN (#2904). They were previously excluded as
+  // ordering-sensitive: this pattern used to run BEFORE the Bearer and PEM patterns, and its value
+  // class stops at whitespace, so it masked the `Bearer` / `-----BEGIN` marker those patterns match
+  // on and let the real credential through. The reorder (see the ORDER note at the top of this
+  // array) puts PEM/Bearer FIRST, so both anchors are consumed before this pattern ever sees them —
+  // which is what makes these two keys safe to add. `authorization=<opaque-token>` (no `Bearer`
+  // keyword) and lowercase `private_key=<opaque>` were BOTH leaking in full at HEAD; they are the
+  // leaks this closes.
+  //
+  // Still deliberately NOT here: `pass` — it over-masks `pass=1` / `pass=true` in ordinary prose.
+  //
+  // Idempotence — not re-masking a value some earlier pattern already masked — is deliberately
+  // NOT enforced here. It is a property of the redactor (any pattern can re-enter any other's
+  // output), not of this pattern, so the guard lives in `maskToken`; see `isAlreadyMasked`.
+  // Two attempts to encode it in this regex both got the skip set wrong, in the same way: they
+  // keyed on a proxy for "this value is a mask" rather than on the mask itself. Do not retry.
+  //
+  // VALUE CLASS `[^\s&#,<>)\]}]+` (#2907). HEAD's `[^\s&#]+` admitted `,` and the closing
+  // delimiters, so a whitespace-delimited run spanned adjacent assignments:
+  // `token=<secret>,user=alice` masked as ONE blob — eating the `user=alice` diagnostic and making
+  // the mask tail (`…lice`) the tail of `alice` rather than of the token. The 6+4 shape exists to
+  // let the same token be correlated across log lines; a tail borrowed from neighbouring text
+  // breaks that. Excluding `,` `<` `>` `)` `]` `}` makes each credential assignment mask
+  // INDEPENDENTLY and leaves the band as exactly maskToken's image.
+  //
+  // CORRECT-BY-POLICY TRADE: a run no longer sweeps a NON-credential neighbour into the mask, so
+  // `token=abcdef…ghij,other=<highentropy>` now leaves `other=<highentropy>` in cleartext. That is
+  // not a new leak — this redactor targets KNOWN credential keys, and `other` is not one, so
+  // `other=<v>` is out of scope at EVERY position (a bare `other=<v>` was never masked either). The
+  // old behavior was an accidental, position-dependent over-mask. The mask tail now also reveals
+  // the token's real last-KEEP_END chars where an absorbed suffix previously hid them; maskToken's
+  // 6+4 reveal is the deliberate product policy, so this is that policy applied honestly.
+  //
+  // `=` is KEPT in the class on purpose: base64 padding (`…==`) must stay INSIDE the captured value.
+  // Excluding it would strand the padding in cleartext and truncate the mask.
+  //
+  // `"` `'` and `` ` `` are also KEPT, and that is load-bearing rather than an oversight: this
+  // pattern is the SOLE handler of the quoted-value form `token="<secret>"` (the ENV pattern is
+  // uppercase-only; the JSON pattern needs `"key":"value"`). The value class governs the value's
+  // FIRST character as well as its rest, so excluding `"` would make the class fail to match at the
+  // opening quote — the pattern would not fire at all and `token="<secret>"` would LEAK. Keeping
+  // them costs only a borrowed quote in the mask tail of the (rarer) trailing-quote form; the
+  // alternative costs a credential. Pinned by the `token="…"` test.
+  //
+  // The URL pattern's class above stays `[^&\s"'<>]+`, and the ENV pattern's stays `[^\s"'\\]+`.
+  // They terminate correctly for their own positions (URL on `&`, ENV on quote/backslash) and are
+  // deliberately NOT converged with this one: value classes differ BY POSITION.
+  //
+  // Upstream shares this text-level gap and relies on structured tool-output redaction the
+  // fork does not carry. (Fork-side, #2852.)
+  String.raw`\b(?<![?&][-\w]*)(?:access_token|refresh_token|id_token|auth[-_]?token|hook[-_]?token|csrf[-_]?token|session[-_]?token|bot[-_]?token|api[-_]?key|private[-_]?key|client[-_]?secret|app[-_]?secret|webhook[-_]?secret|signing[-_]?secret|user[-_]?password|authorization|jwt|token|secret|password|passwd|credential|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^\s&#,<>)\]}]+)`,
+  // JSON fields.
+  String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|${PAYMENT_CREDENTIAL_JSON_KEYS})"\s*:\s*"([^"]+)"`,
+  // CLI flags.
+  String.raw`--(?:api[-_]?key|hook[-_]?token|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})\s+(["']?)([^\s"']+)\1`,
 ];
 
 type RedactOptions = {
@@ -231,11 +311,15 @@ const MASKED_TOKEN_LENGTH = DEFAULT_REDACT_KEEP_START + 1 + DEFAULT_REDACT_KEEP_
 // Idempotence guard: `maskToken` must never mask its own output.
 //
 // Patterns apply in array order, each fed the previous one's output, and their domains overlap.
-// The ENV pattern at index 0 is case-SENSITIVE, while bare `String.raw` entries compile with
-// flags `gi`, so an `AUTH_TOKEN=` masked by index 0 is re-matched by `auth[-_]?token` under `i`.
-// Without this guard the second pass masks a mask \u2014 and since a mask is exactly
-// KEEP_START + 1 + KEEP_END = 11 chars while MIN_LENGTH is 18, `maskToken` would classify it as
-// a short token and collapse the legible `abcdef\u2026ghij` to `***`.
+// The ENV pattern is case-SENSITIVE, while bare `String.raw` entries compile with flags `gi`, so an
+// `AUTH_TOKEN=` masked by the ENV pattern is re-matched by `auth[-_]?token` under `i` in the
+// standalone pattern that follows it. Without this guard the second pass masks a mask \u2014 and since a
+// mask is exactly KEEP_START + 1 + KEEP_END = 11 chars while MIN_LENGTH is 18, `maskToken` would
+// classify it as a short token and collapse the legible `abcdef\u2026ghij` to `***`.
+//
+// This guard is also what makes the anchored-first pattern ORDER safe (see the note above
+// DEFAULT_REDACT_PATTERNS): a vendor-prefix pattern and a generic `key=value` pattern routinely
+// match the SAME token, and whichever runs second must not re-mask the first one's output.
 //
 // That collapse is an accident of two unrelated constants, not a policy. Nobody decided an
 // ENV-assigned secret should reveal 0 bytes where a URL-assigned one reveals 10; it falls out of


### PR DESCRIPTION
Three defects in `src/logging/redact.ts` share one root cause, so they are fixed together.

`redact.ts` is the **sole redaction barrier**: the gateway's `logs.tail` and the CLI `logs` command
serve the log sink to remote operators with **no read-side redaction**. Anything this module misses
is shipped in cleartext.

## The mechanism behind all three

`DEFAULT_REDACT_PATTERNS` is applied **sequentially in array order** — each pattern's `.replace()`
output is fed to the next (`redactText`). A **generic** `key=value` pattern that runs early can
therefore capture and mask the very **anchor** a later, more **specific** pattern matches on,
silently disabling it.

That is not hypothetical. It is #2904.

---

## #2904 — pattern order let a generic pattern eat the PEM opener

The ENV pattern ran **first**, and its value class (`[^\s"'\\]+`) stops at the first space. So:

```
PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEAxGZ1kQm9SxWfBnP0tOQiL7VnJ3hYdKcRbFgUvNzMpAeIoQwT
-----END RSA PRIVATE KEY-----
```

…had `-----BEGIN` captured as the ENV "value" and masked to `***`. That **destroyed the PEM
opener**, so the PEM pattern could no longer match its own block, and the **entire base64 body
shipped in cleartext**. Verified against this branch's parent:

```
BEFORE: "PRIVATE_KEY=*** RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAxGZ1kQm9Sx…IoQwT\n-----END RSA PRIVATE KEY-----"
AFTER:  "PRIVATE_KEY=*** RSA PRIVATE KEY-----\n…redacted…\n-----END RSA PRIVATE KEY-----"
```

**Fix:** reorder **most-anchored-first, most-generic-last**:

1. **PEM blocks** — anchored on a `-----BEGIN` opener a generic can eat
2. **Authorization / Bearer** — anchored on a `Bearer` keyword a generic can eat
3. **Vendor-prefix tokens** — self-anchored on their own literal prefix (`sk-`, `ghp_`, `AKIA`, …)
4. **ENV → URL → standalone → JSON → CLI** — the generic `key=value` families

The reorder is also what makes `authorization` and `private[-_]?key` **safe to add** to the
standalone key set. They were previously excluded as ordering-sensitive — the standalone pattern ran
*before* Bearer/PEM and would mask the `Bearer` / `-----BEGIN` marker those patterns anchor on. With
PEM/Bearer now first, both anchors are consumed before the generic families ever see them. Both keys
were **leaking in full** at HEAD:

| Input | Before | After |
|---|---|---|
| `authorization=<opaque>` (no `Bearer` keyword — nothing anchored on it) | `authorization=abcdef1234567890ghij` | `authorization=abcdef…ghij` |
| `private_key=<opaque>` (lowercase; `_` is a word char, so no `\b` before `key`) | `private_key=abcdef1234567890ghij` | `private_key=abcdef…ghij` |

### Why the reorder is safe

`maskToken`'s idempotence guard (`isAlreadyMasked`). Where a vendor pattern and a generic pattern
both match the same token, whichever runs **second** sees maskToken's own image (11 chars, `…` at
index 6) and returns it **verbatim** — rather than collapsing the legible band to `***`
(11 < `MIN_LENGTH` 18). So `OPENAI_API_KEY=sk-1234567890abcdef` masks to `sk-123…cdef` under either
order. **Order decides *which* pattern masks a token, never *whether* it is masked.** Pinned by a new
reorder-safety test across ENV / standalone / JSON positions.

---

## #2905 — prefixed compound keys leaked at URL position

`[?&]` anchors the URL alternation to the **start** of the key, so the generic `token` alternative
can never reach the `token` inside `csrf-token`. The standalone pattern is correctly blocked from URL
position by its lookbehind. **Neither pattern knew the key**, so it leaked:

```
BEFORE: GET /x?csrf-token=abcdef1234567890ghij&ok=1
AFTER:  GET /x?csrf-token=abcdef…ghij&ok=1
```

**Fix:** add the unambiguous credential compounds to **both** the URL and standalone key sets —
`csrf[-_]?token`, `session[-_]?token`, `bot[-_]?token`, `webhook[-_]?secret`, `signing[-_]?secret`,
`user[-_]?password`. `[-_]?` covers both separators.

**Both positions, deliberately.** The issue scopes the fix to URL, but the same key leaks in a plain
log line in its **underscore** spelling — `_` is a word char, so `csrf_token=` has no `\b` before
`token` for the generic alternative to reach through. (The hyphen spelling *does*, so it was already
caught at standalone position.) Adding to both also preserves the **containment invariant** below.

**Explicit list, not a broad prefix.** The shorter fix — `[?&](?:[\w-]*[-_])?(?:token|secret|key)=` —
would also swallow ordinary non-secrets: `?public-key=`, `?sort-key=`, `?primary-key=`,
`?partition-key=`, `?idempotency-key=`. Pinned by a **negative test** asserting those stay untouched.

I also grepped `src/gateway`, `src/channels` and `extensions` for query-string credential keys that
actually occur in the fork: only `?token=` and `?password=`, both already covered. No additions
beyond the list above.

### The containment invariant

The URL key set is a **superset** of the standalone key set. That is what makes the two patterns'
disjoint domains lossless — the standalone pattern's lookbehind refuses to fire at URL position,
which is only safe because every key it *would* redact is redacted by the URL pattern instead.
**Any key added to the standalone set must be added to the URL set too**, or containment breaks. The
`#2903 losslessness` test now pins this for the new #2904 and #2905 keys as well.

---

## #2907 — the standalone value class spanned adjacent assignments

The value class `[^\s&#]+` admitted `,` and the closing delimiters, so a whitespace-run ran straight
through into the next assignment:

```
BEFORE: token=abcdef…lice          <- one blob; `user=alice` EATEN, mask tail borrowed from "alice"
AFTER:  token=abcdef…ghij,user=alice
```

The 6+4 shape exists so the same token can be correlated across log lines; a tail borrowed from
neighbouring text destroys that. Same defect with brackets: `(token=<secret>)` captured the `)` and
masked to `(token=abcdef…hij)`.

**Fix:** narrow to `[^\s&#,<>)\]}]+`.

`=` is **kept** on purpose — base64 padding (`…==`) must stay *inside* the captured value; excluding
it would strand the padding in cleartext beside a truncated mask. The **URL** (`[^&\s"'<>]+`) and
**ENV** (`[^\s"'\\]+`) value classes are left **unchanged**: they terminate correctly for their own
positions (URL on `&`, ENV on quote/backslash). They are deliberately *not* converged — value classes
differ **by position**.

### ⚠️ The confidentiality trade — correct-by-policy, please read

Narrowing means a run **no longer sweeps a non-credential neighbour into the mask**. So:

```
token=abcdef…ghij,other=<highentropy>     <- `other=<highentropy>` now stays in cleartext
```

**This is not a new leak.** The redactor targets **known credential keys**. `other` is not one, so
`other=<v>` is out of scope at *every* position — a bare `other=<v>` was never masked either. The old
behavior was an **accidental, position-dependent over-mask**: the same value masked or didn't
depending purely on whether a credential happened to sit before it. Narrowing makes each credential
assignment mask **independently** and preserves non-credential diagnostics — the point of #2907.

Relatedly, the mask tail now reveals the token's **real** last-`KEEP_END` chars where an absorbed
suffix previously hid them. `maskToken`'s 6+4 reveal is the deliberate product policy (unchanged) —
this is that policy applied **honestly**, not a regression.

---

## 🔶 One deviation from the reviewed design — quotes stay in the value class

The design specified the narrowed class as ``[^\s&#,"'`<>)\]}]+`` — i.e. **also** excluding `"`, `'`
and `` ` ``. **I did not exclude those three**, and this is deliberate: doing so **introduces a
credential leak**.

A character class governs the value's **first** character as well as its rest. The standalone pattern
is the **sole handler** of the quoted-value form `token="<secret>"` — the ENV pattern is
uppercase-only, and the JSON pattern needs `"key":"value"`. Excluding `"` makes the class fail to
match **at the opening quote**, so the pattern does not fire *at all*:

```
regex capture on  token="abcdef1234567890ghij"
  current class [^\s&#]+           -> ["abcdef1234567890ghij"]   (masked)
  spec's class  [^\s&#,"'`<>)\]}]+ -> []                          (NO MATCH -> LEAKS)
```

Confirmed end-to-end against the real module: with the standalone pattern removed, nothing else in
`DEFAULT_REDACT_PATTERNS` masks `token="<secret>"` — it is genuinely the only handler. Excluding `"`
would have regressed the currently-passing assertion at `redact.test.ts:321`, which the design did
not list among the tests to flip.

Excluding `"'` `` ` `` buys only a tidier mask tail on the *trailing*-quote form. It costs a
credential on the *leading*-quote form. Quotes stay in; the exclusion set is `,` `<` `>` `)` `]` `}`,
which is what #2907 actually needs (comma-runs and bracket tail-borrow). A new test pins the
quoted-value form so this trade cannot be silently reversed later while chasing a tidier tail.

---

## Verification

Every new test is a genuine regression test — each **fails at this branch's parent** and passes here.
Confirmed by running the same probe against both revisions:

| Case | Parent | This PR |
|---|---|---|
| `PRIVATE_KEY=<pem>` — base64 body | **CLEARTEXT** | `…redacted…` |
| `authorization=<opaque>` | **CLEARTEXT** | masked |
| `private_key=<opaque>` (lowercase) | **CLEARTEXT** | masked |
| `?csrf-token=` / `?webhook-secret=` | **CLEARTEXT** | masked |
| `csrf_token=` (standalone, underscore) | **CLEARTEXT** | masked |
| `token=<s>,user=alice` | one blob, tail from `alice` | `token=abcdef…ghij,user=alice` |
| `token="<secret>"` (guardrail) | masked | **still masked** |

**Three pre-existing pinned tests flipped** (they pinned the deferred defects):

- `borrows the mask tail from a trailing closing delimiter (#2907, pinned as-is)` → now asserts the
  exact band `(token=abcdef…ghij)`
- `masks a fresh secret in a run that already contains a mask` → its second assertion only passed
  because the wide class swept a **non-credential** neighbour into the mask; reframed onto a
  **credential** neighbour, so it tests the idempotence guard rather than an artefact of the bug
- `does not redact prefixed URL-query credential keys (known gap, #2905)` → now asserts it **is** masked

Gates:

- `pnpm vitest run src/logging/redact.test.ts` → **64 passed** (52 before; +12 new, 3 flipped)
- `pnpm test:fast` → **9756 passed**, 0 failed (1010 files)
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) → **clean**

If `test-ui-smoke` reports a Vite failure, it is the known chronic flake in that lane and is unrelated
to this change — nothing here touches `ui/`.

## Files changed

- `src/logging/redact.ts` — reorder + key-set additions + narrowed standalone value class; all stale
  comments documenting the three deferrals rewritten to describe the landed fix, plus a new
  ordering-rationale note at the top of the array (order is **semantic** — a future pattern must be
  placed by anchor strength, not by theme).
- `src/logging/redact.test.ts` — 3 pins flipped, 12 tests added.

Closes #2904
Closes #2905
Closes #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
