### PR TITLE
docs(redact): note the embedded-delimiter reading of the standalone value-class trade

### DIFF
--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -183,6 +183,17 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   // the token's real last-KEEP_END chars where an absorbed suffix previously hid them; maskToken's
   // 6+4 reveal is the deliberate product policy, so this is that policy applied honestly.
   //
+  // The same exclusion has a SECOND reading that DOES cost confidentiality (unlike the benign
+  // neighbour case above): a credential value whose OWN bytes contain one of the newly-excluded
+  // delimiters (`,` `<` `>` `)` `]` `}`) is captured only UP TO that delimiter, so the remainder
+  // ships in cleartext. `password=Tr0ub4dorExtra,LongPart9876` masks to `password=***,LongPart9876`
+  // — `Tr0ub4dorExtra` is shorter than MIN_LENGTH so it collapses to `***`, and `,LongPart9876`
+  // LEAKS. It is bounded to THIS lowercase-standalone form: the URL/ENV/JSON/CLI patterns keep their
+  // own comma-admitting value classes, so the same value masks WHOLE at those positions. And no
+  // standard high-entropy credential alphabet reaches it — base64, base64url, hex, JWT, and
+  // vendor-prefixed tokens all exclude every one of `,` `<` `>` `)` `]` `}` — so the only value that
+  // leaks here is a special-char passphrase logged UNQUOTED in a lowercase `key=value` line.
+  //
   // `=` is KEPT in the class on purpose: base64 padding (`…==`) must stay INSIDE the captured value.
   // Excluding it would strand the padding in cleartext and truncate the mask.
   //


### PR DESCRIPTION
## What

Adds one paragraph to the `CORRECT-BY-POLICY TRADE` comment on the **standalone** credential value class in `src/logging/redact.ts`. **Comment-only — no code, pattern, or value-class change.**

## Background

#2907 (PR #2915) narrowed the standalone `key=value` value class from `[^\s&#]+` to `[^\s&#,<>)\]}]+`, excluding `,` and the closing delimiters `<>)]}` so that adjacent assignments mask independently instead of one whitespace-delimited blob eating a neighbour (`token=<secret>,user=alice` no longer masks as one blob).

The `CORRECT-BY-POLICY TRADE` comment justified that narrowing via **one** reading only:

> a run no longer sweeps a **non-credential neighbour** into the mask, so `token=abcdef…ghij,other=<highentropy>` now leaves `other=<highentropy>` in cleartext.

That reading is benign — `other` is not a targeted credential key, so it was out of scope at every position anyway.

## The gap

The paragraph omits the sharper reading — the one that actually reduces confidentiality: **a credential value whose OWN bytes contain one of the newly-excluded delimiters (`, < > ) ] }`) is captured only up to that delimiter, so the remainder is left in cleartext.**

Example:

```
password=Tr0ub4dorExtra,LongPart9876
  → password=***,LongPart9876
     ("Tr0ub4dorExtra" is 14 chars, shorter than MIN_LENGTH(18) → collapses to ***;
      ",LongPart9876" is outside the capture and LEAKS)
```

## Why this is LOW severity / bounded

- **Bounded to the lowercase-standalone form only.** The URL / ENV / JSON / CLI patterns retain their own comma-admitting value classes (`[^&\s"'<>]+`, `[^\s"'\\]+`, `[^"]+`, `[^\s"']+`), so the same value masks **whole** at those positions. (ENV is additionally uppercase-only, which is why a lowercase `password=` lands on the standalone pattern in the first place.)
- **No standard high-entropy credential alphabet qualifies.** base64 / base64url / hex / JWT / vendor-prefixed tokens all exclude every one of `, < > ) ] }`. The trigger is specifically a **special-char passphrase logged unquoted in a lowercase `key=value` line**.

## Verification

- `pnpm check` (format + tsgo typecheck + lint + fork-integrity gates): clean, 0 warnings / 0 errors.
- Redaction suites (`src/logging/redact.test.ts`, `src/logging/logger-redaction.test.ts`): **85/85 pass, unchanged** — a comment edit has no runtime effect.

Closes #2916
