### PR TITLE
fix(node-pairing): enforce prototype-key safety locally at un-normalized index sites

### DIFF
--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -6,6 +6,8 @@ import {
   approveNodePairing,
   getPairedNode,
   listNodePairing,
+  loadNodePairingStateForTest,
+  rejectNodePairing,
   removePairedNode,
   renamePairedNode,
   requestNodePairing,
@@ -325,6 +327,7 @@ describe("node pairing prototype-key hardening", () => {
       `"node-1":${JSON.stringify({ nodeId: "node-1", token: "t".repeat(43), createdAtMs: 1, approvedAtMs: 2 })}`,
       `"__proto__":${JSON.stringify({ nodeId: "__proto__", ...evil })}`,
       `"constructor":${JSON.stringify({ nodeId: "constructor", ...evil })}`,
+      `"prototype":${JSON.stringify({ nodeId: "prototype", ...evil })}`,
     ];
     await writeFile(pairedPath, `{${entries.join(",")}}`, "utf8");
 
@@ -334,7 +337,82 @@ describe("node pairing prototype-key hardening", () => {
     expect(listed.paired.map((node) => node.nodeId)).toEqual(["node-1"]);
     await expect(getPairedNode("__proto__", baseDir)).resolves.toBeNull();
     await expect(getPairedNode("constructor", baseDir)).resolves.toBeNull();
+    await expect(getPairedNode("prototype", baseDir)).resolves.toBeNull();
     expect(({} as Record<string, unknown>).nodeId).toBeUndefined();
+  });
+
+  test("loads pairing maps as null-prototype objects (positional invariant tripwire)", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const state = await loadNodePairingStateForTest(baseDir);
+    // The un-normalized index sites (approve/reject by requestId, approve by
+    // pending.nodeId) are safe partly because these maps carry no prototype. If a
+    // future refactor restores a plain `{}`, this trips before the hole reopens.
+    expect(Object.getPrototypeOf(state.pairedByNodeId)).toBeNull();
+    expect(Object.getPrototypeOf(state.pendingById)).toBeNull();
+  });
+
+  test("approve and reject treat special-key request ids as not-found", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    for (const key of dangerousKeys) {
+      await expect(
+        approveNodePairing(key, { callerScopes: ["operator.pairing", "operator.admin"] }, baseDir),
+      ).resolves.toBeNull();
+      await expect(rejectNodePairing(key, baseDir)).resolves.toBeNull();
+    }
+    // A raw special-key index of the store would have leaked a value onto every
+    // object; nothing must persist to the prototype.
+    expect(Object.prototype).not.toHaveProperty("token");
+  });
+
+  test("approve refuses a corrupted pending entry whose nodeId is a special key", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const { dir, pendingPath } = resolvePairingPaths(baseDir, "nodes");
+    await mkdir(dir, { recursive: true });
+    // A corrupted pending map keyed by a benign requestId but carrying a special
+    // key as its nodeId. Approving it must not write pairedByNodeId["__proto__"]
+    // nor pollute the prototype; the local normalizeNodeId guard reads it as
+    // not-found instead. Keep ts fresh so the entry survives load-time pruning.
+    const ts = Date.now();
+    for (const key of dangerousKeys) {
+      const requestId = `req-${key}`;
+      await writeFile(
+        pendingPath,
+        JSON.stringify({ [requestId]: { requestId, nodeId: key, ts } }),
+        "utf8",
+      );
+      await expect(
+        approveNodePairing(
+          requestId,
+          { callerScopes: ["operator.pairing", "operator.admin"] },
+          baseDir,
+        ),
+      ).resolves.toBeNull();
+    }
+    expect(({} as Record<string, unknown>).token).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty("token");
+  });
+
+  test("drops dangerous own-keys from a corrupted pending state file on load", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const { dir, pendingPath } = resolvePairingPaths(baseDir, "nodes");
+    await mkdir(dir, { recursive: true });
+    // Keep the legit entry within the pending TTL so load-time pruning retains it.
+    const ts = Date.now();
+    const evil = (key: string) => JSON.stringify({ requestId: key, nodeId: key, ts });
+    const entries = [
+      `"req-1":${JSON.stringify({ requestId: "req-1", nodeId: "node-1", ts })}`,
+      `"__proto__":${evil("__proto__")}`,
+      `"constructor":${evil("constructor")}`,
+      `"prototype":${evil("prototype")}`,
+    ];
+    await writeFile(pendingPath, `{${entries.join(",")}}`, "utf8");
+
+    // listNodePairing enumerates pendingById directly, exercising toSafeRecord's
+    // own-key sanitization on load.
+    const listed = await listNodePairing(baseDir);
+    expect(listed.pending.map((req) => req.requestId)).toEqual(["req-1"]);
+    expect(({} as Record<string, unknown>).nodeId).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty("nodeId");
   });
 
   test("node ids that merely contain a special key are still handled normally", async () => {

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -76,7 +76,11 @@ function toSafeRecord<T>(source: Record<string, T> | null | undefined): Record<s
   const safe = Object.create(null) as Record<string, T>;
   if (source) {
     for (const key of Object.keys(source)) {
-      if (isBlockedObjectKey(key)) {
+      // Drop blocked prototype keys and the empty-string key. No legitimate
+      // node/request id is empty (creation rejects empty ids) and normalizeNodeId
+      // maps every blocked id to "", so refusing "" as a real key keeps a
+      // blocked-key lookup resolving to not-found even against a corrupted file.
+      if (!key || isBlockedObjectKey(key)) {
         continue;
       }
       safe[key] = source[key];
@@ -171,6 +175,19 @@ async function loadState(baseDir?: string): Promise<NodePairingStateFile> {
   return state;
 }
 
+/**
+ * Test-only accessor returning the freshly loaded state maps so a tripwire test
+ * can assert their null-prototype invariant directly. The un-normalized index
+ * sites in this module (approve/reject by requestId, approve by pending.nodeId)
+ * are safe partly because these maps carry no prototype — this export lets CI
+ * fail if a future refactor drops that guarantee.
+ */
+export async function loadNodePairingStateForTest(
+  baseDir?: string,
+): Promise<{ pendingById: Record<string, unknown>; pairedByNodeId: Record<string, unknown> }> {
+  return await loadState(baseDir);
+}
+
 async function persistState(state: NodePairingStateFile, baseDir?: string) {
   const { pendingPath, pairedPath } = resolvePairingPaths(baseDir, "nodes");
   await Promise.all([
@@ -257,9 +274,22 @@ export async function approveNodePairing(
   baseDir?: string,
 ): Promise<ApproveNodePairingResult> {
   return await withLock(async () => {
+    // Defense-in-depth: never index the pending/paired maps with a raw prototype
+    // key. requestId is not a nodeId, so guard it with the blocked-key check
+    // directly; pending.nodeId is a nodeId, so route it through normalizeNodeId.
+    // A blocked key reads as not-found — identical to a missing entry — so
+    // legitimate approvals are unchanged and safety no longer relies solely on
+    // the maps being null-prototype.
+    if (isBlockedObjectKey(requestId)) {
+      return null;
+    }
     const state = await loadState(baseDir);
     const pending = state.pendingById[requestId];
     if (!pending) {
+      return null;
+    }
+    const nodeKey = normalizeNodeId(pending.nodeId);
+    if (!nodeKey) {
       return null;
     }
     const requiredScopes = resolveNodeApprovalRequiredScopes(pending);
@@ -273,7 +303,7 @@ export async function approveNodePairing(
     }
 
     const now = Date.now();
-    const existing = state.pairedByNodeId[pending.nodeId];
+    const existing = state.pairedByNodeId[nodeKey];
     const node: NodePairingPairedNode = {
       nodeId: pending.nodeId,
       token: newToken(),
@@ -293,7 +323,7 @@ export async function approveNodePairing(
     };
 
     delete state.pendingById[requestId];
-    state.pairedByNodeId[pending.nodeId] = node;
+    state.pairedByNodeId[nodeKey] = node;
     await persistState(state, baseDir);
     return { requestId, node };
   });
@@ -304,6 +334,12 @@ export async function rejectNodePairing(
   baseDir?: string,
 ): Promise<{ requestId: string; nodeId: string } | null> {
   return await withLock(async () => {
+    // Defense-in-depth: requestId indexes pendingById via a raw key inside the
+    // shared reject helper. Reject a blocked prototype key up front so it reads
+    // as not-found, matching the helper's own missing-entry path.
+    if (isBlockedObjectKey(requestId)) {
+      return null;
+    }
     return await rejectPendingPairingRequest<
       NodePairingPendingRequest,
       NodePairingStateFile,


### PR DESCRIPTION
## Summary

Low-severity **security defense-in-depth** hardening of node-pairing state
indexing. Follow-up to #2911 (which introduced the null-prototype maps and the
`normalizeNodeId` guards); an independent review flagged that a few index sites
still use raw keys and are protected only by a *positional* invariant.

## Background — the positional invariant

`node-pairing` persists two maps: `pendingById` (keyed by requestId) and
`pairedByNodeId` (keyed by nodeId). `loadState` builds both via `toSafeRecord`,
which returns an `Object.create(null)` (null-prototype) record and strips blocked
own-keys (`__proto__`, `constructor`, `prototype`). #2911 also routes the
nodeId-facing lookups (`getPairedNode`, `verifyNodeToken`,
`updatePairedNodeMetadata`, `renamePairedNode`, `removePairedNode`) through
`normalizeNodeId`, which rejects those blocked keys.

But three index sites still use **raw** keys:

- `approveNodePairing` → `state.pendingById[requestId]` (read) and
  `delete state.pendingById[requestId]`
- `approveNodePairing` → `state.pairedByNodeId[pending.nodeId]` (read) and
  `state.pairedByNodeId[pending.nodeId] = node` (write)
- `rejectNodePairing` → the shared reject helper's
  `state.pendingById[requestId]` (read + `delete`)

These are safe **today only because both maps are null-prototype**. Nothing
asserts that. If a future refactor restores a plain `{}` for either map (drops
`toSafeRecord`, or a new accessor builds a plain map), these sites silently
re-open the pre-#2911 hole:

- a write like `pairedByNodeId["__proto__"] = node` on a plain object invokes the
  inherited `__proto__` setter and mutates `Object.prototype` — **prototype
  pollution**;
- a read like `pendingById["constructor"]` on a plain object resolves to an
  inherited value and is treated as a real pending request — **false resolution**.

The regression would be invisible: no existing test would fail.

## Change — convert the positional invariant into an enforced one

Enforce prototype-key safety **locally at each raw site**, using the
semantically-correct guard per key kind:

- **`approveNodePairing`** — guard `requestId` (not a nodeId) with the blocked-key
  check `isBlockedObjectKey`; route `pending.nodeId` (a nodeId) through
  `normalizeNodeId` and index both maps by that guarded key. A blocked key reads
  as **not-found — identical to a missing entry** — so the call returns `null`
  before any read / write / delete.
- **`rejectNodePairing`** — reject a blocked `requestId` up front. The reject
  helper is **shared with `device-pairing`**, so the guard lives at the
  node-pairing caller (not the helper) to keep this change scoped and leave
  device-pairing behavior untouched.
- **`toSafeRecord`** — also drop the empty-string key on load. No legitimate node
  or request id is empty (creation rejects empty ids) and `normalizeNodeId` maps
  every blocked id to `""`, so refusing `""` as a real key keeps a blocked-key
  lookup resolving to not-found even against a corrupted state file.

**No legitimate pairing flow changes behavior.** Legit requestIds are UUIDs and
legit nodeIds are already normalized / non-empty when stored, so every guard is a
pass-through for real inputs. All pre-existing tests still pass.

## Tests

- **Tripwire (positional-invariant guard):** asserts both maps load
  null-prototype (`Object.getPrototypeOf(...) === null`) immediately after load,
  so a future refactor that drops the null-proto guarantee fails CI. Backed by a
  narrow test-only `loadNodePairingStateForTest` accessor.
- **Local-guard regression tests:** approve/reject treat special-key requestIds as
  not-found; approve refuses a corrupted pending entry whose `nodeId` is a special
  key (without the guard, this would write `pairedByNodeId["__proto__"]` and
  return a paired node — this test fails if the guard is removed).
- **Corrupted-state-load coverage:** extended to the `pendingById` map (previously
  only `pairedByNodeId` was covered) and to the `prototype` token for both maps
  (previously only `__proto__` + `constructor`).

## Verification

- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity lints): clean.
- Pairing test cluster (node-pairing, device-pairing, pairing-pending,
  pairing-files, prototype-keys, node-pairing-authz, pairing-token): 50 tests
  passing — including device-pairing, confirming the shared reject helper was left
  untouched.

Closes #2912
