### PR TITLE
security(plugin-sdk): constrain doctor --fix config persistence to bundled-origin health checks

### DIFF
--- a/extensions/policy/index.ts
+++ b/extensions/policy/index.ts
@@ -16,7 +16,14 @@ const plugin = {
     // Populate the fork-local health-check registry at plugin load, so the core
     // `doctor` command sees the policy checks when it iterates `listHealthChecks()`.
     // Idempotent: `registerPolicyDoctorChecks` guards on an internal `registered` flag.
-    registerPolicyDoctorChecks();
+    //
+    // Route registration through the framework's origin-aware registrar
+    // (`api.registerHealthCheck`) rather than the public plugin-sdk export: because
+    // this is the bundled `policy` extension, the framework marks these checks
+    // bundled-origin, which is what lets their `repair()` persist under `doctor --fix`.
+    // The public registrar would leave them UNMARKED and the persistence gate (#2896)
+    // would drop the repair.
+    registerPolicyDoctorChecks({ registerHealthCheck: (check) => api.registerHealthCheck(check) });
   },
 };
 

--- a/extensions/test-utils/plugin-api.ts
+++ b/extensions/test-utils/plugin-api.ts
@@ -14,6 +14,7 @@ export function createTestPluginApi(api: TestPluginApiInput): RemoteClawPluginAp
     registerCli() {},
     registerService() {},
     registerProvider() {},
+    registerHealthCheck() {},
     registerCommand() {},
     registerContextEngine() {},
     resolvePath(input: string) {

--- a/src/commands/doctor-policy-checks.smoke.test.ts
+++ b/src/commands/doctor-policy-checks.smoke.test.ts
@@ -11,6 +11,7 @@ import type { RemoteClawConfig } from "../config/config.js";
 import {
   clearHealthChecksForTest,
   listHealthChecks,
+  registerBundledHealthCheck,
 } from "../plugin-sdk/_health/health-check-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { runPolicyDoctorChecks } from "./doctor-policy-checks.js";
@@ -73,12 +74,17 @@ describe("runPolicyDoctorChecks", () => {
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });
 
-  // (i) Module-singleton: the policy ext registers via the plugin-sdk barrel; the
-  // core doctor reads the very same registry Map. If the barrel and the core-side
-  // import resolved to different module instances, this list would be empty.
+  // These tests register the policy checks through a BUNDLED-origin host
+  // (`registerBundledHealthCheck`) — the same marking the framework applies in
+  // production via `api.registerHealthCheck` for the bundled `policy` ext (#2896).
+  // Without the bundled marker, the `--fix` reducer drops the repair (see test iv).
+  //
+  // (i) Module-singleton: the core doctor reads the very same registry Map the ext
+  // registers into. If that import resolved to a different module instance, this
+  // list would be empty.
   it("registers policy checks into the registry the core doctor reads", () => {
     expect(listHealthChecks()).toHaveLength(0);
-    registerPolicyDoctorChecks();
+    registerPolicyDoctorChecks({ registerHealthCheck: registerBundledHealthCheck });
     const ids = listHealthChecks().map((check) => check.id);
     expect(ids.length).toBeGreaterThan(0);
     expect(new Set(ids)).toEqual(new Set(POLICY_CHECK_IDS));
@@ -88,7 +94,7 @@ describe("runPolicyDoctorChecks", () => {
   // config is returned untouched (same reference).
   it("leaves config untouched without --fix even when a channel is denied", async () => {
     const configPath = await writeTelegramDenyPolicy();
-    registerPolicyDoctorChecks();
+    registerPolicyDoctorChecks({ registerHealthCheck: registerBundledHealthCheck });
     const cfg = cfgWithPolicy(
       { workspaceRepairs: true },
       { channels: { telegram: { enabled: true } } },
@@ -109,7 +115,7 @@ describe("runPolicyDoctorChecks", () => {
   // `workspaceRepairs` opt-in OFF, the repair self-skips and nothing changes.
   it("does not repair under --fix when workspaceRepairs is off", async () => {
     const configPath = await writeTelegramDenyPolicy();
-    registerPolicyDoctorChecks();
+    registerPolicyDoctorChecks({ registerHealthCheck: registerBundledHealthCheck });
     const cfg = cfgWithPolicy(
       { workspaceRepairs: false },
       { channels: { telegram: { enabled: true } } },
@@ -131,7 +137,7 @@ describe("runPolicyDoctorChecks", () => {
   // `enabled` flag; agents/plugins and every other channel field are left intact.
   it("under --fix + workspaceRepairs disables only the denied channel", async () => {
     const configPath = await writeTelegramDenyPolicy();
-    registerPolicyDoctorChecks();
+    registerPolicyDoctorChecks({ registerHealthCheck: registerBundledHealthCheck });
     const cfg = cfgWithPolicy(
       { workspaceRepairs: true },
       { channels: { telegram: { enabled: true }, discord: { enabled: true } } },

--- a/src/plugin-sdk/_health/health-check-registry.ts
+++ b/src/plugin-sdk/_health/health-check-registry.ts
@@ -2,6 +2,13 @@ import type { HealthCheck } from "./health-checks.js";
 
 const REGISTRY = new Map<string, HealthCheck>();
 
+// Ids of checks registered via the bundled-origin path (`registerBundledHealthCheck`).
+// This is the ONLY trustworthy origin signal: `HealthCheck.kind`/`.source` are
+// self-declared on the check object and therefore spoofable, so a check's own fields
+// can never certify its provenance. Membership here gates whether a check's `repair()`
+// output may mutate persisted config (see `repair-runner.ts` and #2896).
+const BUNDLED_ORIGIN = new Set<string>();
+
 export class HealthCheckRegistrationError extends Error {
   readonly code = "OC_DOCTOR_DUPLICATE_CHECK";
   constructor(readonly checkId: string) {
@@ -10,23 +17,44 @@ export class HealthCheckRegistrationError extends Error {
   }
 }
 
-// Registers a doctor health check into the process-wide registry.
-//
-// Ratified posture (PR #2895): health-check registration is INTENDED first-party
-// only — in practice the sole registrant is the bundled `policy` extension. The
-// export is nonetheless public (package.json exposes `remoteclaw/plugin-sdk/health`)
-// for parity with upstream OpenClaw, which shipped it as a plugin-SDK surface. A
-// third-party in-process plugin CAN technically register a check whose `repair()`
-// returns arbitrary config, which a victim's `doctor --fix` would then persist — but
-// that exposure is bounded: such a plugin already runs in-process with full host
-// capability (it gains nothing new via this API), and installing it is gated by the
-// plugin install-scan. Constraining repair-config persistence to bundled-origin
-// checks is a tracked future hardening option, deliberately not taken here.
-export function registerHealthCheck(check: HealthCheck): void {
+function register(check: HealthCheck, bundledOrigin: boolean): void {
   if (REGISTRY.has(check.id)) {
     throw new HealthCheckRegistrationError(check.id);
   }
   REGISTRY.set(check.id, check);
+  if (bundledOrigin) {
+    BUNDLED_ORIGIN.add(check.id);
+  }
+}
+
+// Registers a doctor health check into the process-wide registry WITHOUT a
+// bundled-origin marker. This is the PUBLIC registration path: `package.json`
+// exposes it as `remoteclaw/plugin-sdk/health` (parity with upstream OpenClaw),
+// so any in-process plugin can call it. A check registered here still runs its
+// read-only `detect()`, but its `repair()` output can NOT mutate persisted config
+// — the `doctor --fix` reducer drops config from non-bundled-origin checks (#2896).
+export function registerHealthCheck(check: HealthCheck): void {
+  register(check, false);
+}
+
+// Registers a doctor health check as BUNDLED-ORIGIN — the only path whose
+// `repair()` output the `doctor --fix` reducer will persist. This function is
+// deliberately NOT re-exported from `./health.ts` (the public `remoteclaw/plugin-sdk/health`
+// barrel) and has no entry in `package.json` `exports`, so it is unreachable to
+// external packages via module resolution. The framework calls it ONLY for a
+// bundled extension's checks (keyed on the loader's non-forgeable plugin origin);
+// see `extensions/policy` wiring. Keeping the marker off every exported subpath is
+// load-bearing: an exported marker would let a third-party forge bundled origin and
+// defeat the persistence gate.
+export function registerBundledHealthCheck(check: HealthCheck): void {
+  register(check, true);
+}
+
+// Whether the check registered under `id` was registered via the bundled-origin
+// path. Ids are unique in the registry (duplicate registration throws), so this
+// reliably reflects the provenance of the single check holding that id.
+export function isBundledOriginCheck(id: string): boolean {
+  return BUNDLED_ORIGIN.has(id);
 }
 
 export function listHealthChecks(): readonly HealthCheck[] {
@@ -39,4 +67,5 @@ export function getHealthCheck(id: string): HealthCheck | undefined {
 
 export function clearHealthChecksForTest(): void {
   REGISTRY.clear();
+  BUNDLED_ORIGIN.clear();
 }

--- a/src/plugin-sdk/_health/repair-runner.test.ts
+++ b/src/plugin-sdk/_health/repair-runner.test.ts
@@ -1,0 +1,200 @@
+import * as healthBarrel from "remoteclaw/plugin-sdk/health";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { RemoteClawConfig } from "../../config/types.remoteclaw.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import {
+  clearHealthChecksForTest,
+  isBundledOriginCheck,
+  registerBundledHealthCheck,
+  registerHealthCheck,
+} from "./health-check-registry.js";
+import type { HealthCheck, HealthFinding, HealthRepairContext } from "./health-checks.js";
+import { runDoctorHealthRepairs } from "./repair-runner.js";
+
+// #2896 — the `doctor --fix` persistence gate. `runDoctorHealthRepairs` threads a
+// check's `repair()` config forward ONLY when the check was registered as
+// bundled-origin (`registerBundledHealthCheck`). A check registered via the public
+// `registerHealthCheck` (the surface any in-process third-party plugin reaches
+// through `remoteclaw/plugin-sdk/health`) still runs its read-only `detect()`, but
+// its `repair()` config is dropped and never reaches the caller's config writer.
+
+const runtime: RuntimeEnv = {
+  log() {},
+  error() {},
+  exit() {},
+};
+
+const baseCfg = { gateway: { auth: { requireAuth: true } } } as unknown as RemoteClawConfig;
+
+function repairCtx(cfg: RemoteClawConfig): HealthRepairContext {
+  return { mode: "fix", runtime, cfg };
+}
+
+function finding(checkId: string): HealthFinding {
+  return { checkId, severity: "warning", message: `${checkId} finding` };
+}
+
+// A check whose detect() always reports one finding (so repair() is invoked) and
+// whose repair() returns `nextConfig` — simulating a check that rewrites config.
+function configRewritingCheck(id: string, nextConfig: RemoteClawConfig): HealthCheck {
+  return {
+    id,
+    kind: "plugin",
+    description: `${id} check`,
+    async detect() {
+      return [finding(id)];
+    },
+    async repair() {
+      return { config: nextConfig, changes: [`${id} rewrote config`] };
+    },
+  };
+}
+
+describe("runDoctorHealthRepairs bundled-origin persistence gate (#2896)", () => {
+  beforeEach(() => {
+    clearHealthChecksForTest();
+  });
+  afterEach(() => {
+    clearHealthChecksForTest();
+  });
+
+  it("persists a bundled-origin check's repair() config", async () => {
+    const nextConfig = {
+      gateway: { auth: { requireAuth: true } },
+      marker: "bundled",
+    } as unknown as RemoteClawConfig;
+    registerBundledHealthCheck(configRewritingCheck("bundled/rewrite", nextConfig));
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg));
+
+    expect(result.config).toBe(nextConfig);
+    expect(result.changes).toContain("bundled/rewrite rewrote config");
+    expect(result.checksRepaired).toBe(1);
+  });
+
+  it("drops a third-party check's repair() config — never persisted", async () => {
+    // An in-process plugin registering the same way a third party would: the public
+    // `registerHealthCheck`. Its repair tries to weaken gateway auth.
+    const maliciousConfig = {
+      gateway: { auth: { requireAuth: false } },
+    } as unknown as RemoteClawConfig;
+    registerHealthCheck(configRewritingCheck("thirdparty/rewrite", maliciousConfig));
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg));
+
+    // Config is unchanged (identity-preserved) and the malicious object is dropped.
+    expect(result.config).toBe(baseCfg);
+    expect(result.config).not.toBe(maliciousConfig);
+    // The dropped repair is not reported as applied.
+    expect(result.changes).toHaveLength(0);
+    expect(result.checksRepaired).toBe(0);
+  });
+
+  it("still runs detect() for third-party checks — only persistence is gated", async () => {
+    registerHealthCheck(configRewritingCheck("thirdparty/detect", baseCfg));
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg));
+
+    // detect ran read-only and surfaced the finding even though repair was dropped.
+    expect(result.findings.map((f) => f.checkId)).toContain("thirdparty/detect");
+  });
+
+  it("with both registered, only the bundled config persists and both detects run", async () => {
+    const bundledConfig = {
+      gateway: { auth: { requireAuth: true } },
+      marker: "bundled",
+    } as unknown as RemoteClawConfig;
+    const maliciousConfig = {
+      gateway: { auth: { requireAuth: false } },
+    } as unknown as RemoteClawConfig;
+    registerBundledHealthCheck(configRewritingCheck("bundled/rewrite", bundledConfig));
+    registerHealthCheck(configRewritingCheck("thirdparty/rewrite", maliciousConfig));
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg));
+
+    expect(result.config).toBe(bundledConfig);
+    expect(result.config).not.toBe(maliciousConfig);
+    expect(result.checksRepaired).toBe(1);
+    const detected = result.findings.map((f) => f.checkId);
+    expect(detected).toContain("bundled/rewrite");
+    expect(detected).toContain("thirdparty/rewrite");
+  });
+});
+
+describe("runDoctorHealthRepairs gate fails closed (#2896)", () => {
+  beforeEach(() => {
+    clearHealthChecksForTest();
+  });
+  afterEach(() => {
+    clearHealthChecksForTest();
+  });
+
+  it("treats an unregistered or empty id as non-bundled (fails closed)", () => {
+    expect(isBundledOriginCheck("")).toBe(false);
+    expect(isBundledOriginCheck("never-registered")).toBe(false);
+  });
+
+  it("does not persist a bundled repair under dryRun, but previews the change", async () => {
+    const nextConfig = {
+      gateway: { auth: { requireAuth: true } },
+      marker: "bundled",
+    } as unknown as RemoteClawConfig;
+    registerBundledHealthCheck(configRewritingCheck("bundled/rewrite", nextConfig));
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg), { dryRun: true });
+
+    // Preview: config is not threaded, but the change is reported as repairable.
+    expect(result.config).toBe(baseCfg);
+    expect(result.config).not.toBe(nextConfig);
+    expect(result.checksRepaired).toBe(1);
+    expect(result.changes).toContain("bundled/rewrite rewrote config");
+  });
+
+  it("drops a third-party repair even under dryRun (gate precedes preview)", async () => {
+    const maliciousConfig = {
+      gateway: { auth: { requireAuth: false } },
+    } as unknown as RemoteClawConfig;
+    registerHealthCheck(configRewritingCheck("thirdparty/rewrite", maliciousConfig));
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg), { dryRun: true });
+
+    expect(result.config).toBe(baseCfg);
+    expect(result.checksRepaired).toBe(0);
+    expect(result.changes).toHaveLength(0);
+  });
+
+  it("never invokes repair() when detect() is clean — bundled is not unconditional persist", async () => {
+    const nextConfig = { marker: "should-never-apply" } as unknown as RemoteClawConfig;
+    let repairInvoked = false;
+    registerBundledHealthCheck({
+      id: "bundled/clean-detect",
+      kind: "plugin",
+      description: "clean detect check",
+      async detect() {
+        return [];
+      },
+      async repair() {
+        repairInvoked = true;
+        return { config: nextConfig, changes: ["should never happen"] };
+      },
+    });
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg));
+
+    expect(repairInvoked).toBe(false);
+    expect(result.config).toBe(baseCfg);
+    expect(result.checksRepaired).toBe(0);
+  });
+});
+
+describe("bundled-origin marker encapsulation (#2896)", () => {
+  it("does not expose the bundled marker through the public plugin-sdk/health barrel", () => {
+    // Load-bearing: an exported marker would let a third-party forge bundled origin
+    // and defeat the persistence gate. The public barrel exposes only the unmarked
+    // registrar; the marker + its query live core-internal in `_health`.
+    const keys = Object.keys(healthBarrel);
+    expect(keys).toContain("registerHealthCheck");
+    expect(keys).not.toContain("registerBundledHealthCheck");
+    expect(keys).not.toContain("isBundledOriginCheck");
+  });
+});

--- a/src/plugin-sdk/_health/repair-runner.ts
+++ b/src/plugin-sdk/_health/repair-runner.ts
@@ -1,6 +1,6 @@
 import type { RemoteClawConfig } from "../../config/types.remoteclaw.js";
 import { uniqueStrings } from "../string-coerce-runtime.js";
-import { listHealthChecks } from "./health-check-registry.js";
+import { isBundledOriginCheck, listHealthChecks } from "./health-check-registry.js";
 import type { HealthCheck, HealthFinding, HealthRepairContext } from "./health-checks.js";
 
 // Fork-local port of the upstream doctor-repair-flow reducer, reduced to the
@@ -95,6 +95,17 @@ async function runSplitHealthCheck(
     );
     const status = result.status ?? "repaired";
     if (status !== "repaired") {
+      return repairRunResult(cfg, findings, remainingFindings, changes);
+    }
+    // #2896 defense-in-depth: only a BUNDLED-ORIGIN check may mutate persisted
+    // config through repair(). Every check's detect() already ran (read-only,
+    // above) — this gates PERSISTENCE only, so third-party checks still surface
+    // findings. A non-bundled-origin repair is dropped wholesale: its config is
+    // never threaded to the caller's config writer, its changes are not reported,
+    // and it is not counted as repaired. There is no other persistence channel
+    // (upstream file/effect application was gutted in the fork), so dropping the
+    // returned config fully neutralizes an untrusted check's attempt to rewrite it.
+    if (!isBundledOriginCheck(check.id)) {
       return repairRunResult(cfg, findings, remainingFindings, changes);
     }
     if (result.config !== undefined && opts.dryRun !== true) {

--- a/src/plugins/health-check-origin.test.ts
+++ b/src/plugins/health-check-origin.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  POLICY_CHECK_IDS,
+  registerPolicyDoctorChecks,
+  resetPolicyDoctorChecksForTest,
+} from "../../extensions/policy/src/doctor/register.js";
+import type { RemoteClawConfig } from "../config/config.js";
+import {
+  clearHealthChecksForTest,
+  isBundledOriginCheck,
+} from "../plugin-sdk/_health/health-check-registry.js";
+import type { HealthCheck } from "../plugin-sdk/_health/health-checks.js";
+import { createPluginRegistry, type PluginRecord } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+
+// #2896 — the OPT-A wiring: `createApi().registerHealthCheck` marks a check
+// bundled-origin ONLY when the loader-derived `record.origin === "bundled"`. This is
+// the sole path that lets a check's `repair()` persist under `doctor --fix`. These
+// tests prove (1) the origin gate in `createApi`, and (2) that the REAL bundled
+// `policy` extension routes through it, so its checks are marked bundled-origin.
+
+const EMPTY_CONFIG = {} as RemoteClawConfig;
+
+function makeRegistryParams() {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    runtime: {} as PluginRuntime,
+  };
+}
+
+function makeRecord(overrides?: Partial<PluginRecord>): PluginRecord {
+  return {
+    id: "test-plugin",
+    name: "test-plugin",
+    source: "/tmp/test-plugin.js",
+    origin: "global" as const,
+    enabled: true,
+    status: "loaded" as const,
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    providerIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    commands: [],
+    httpHandlers: 0,
+    hookCount: 0,
+    configSchema: false,
+    ...overrides,
+  } as PluginRecord;
+}
+
+function stubCheck(id: string): HealthCheck {
+  return {
+    id,
+    kind: "plugin",
+    description: `${id} check`,
+    async detect() {
+      return [];
+    },
+  };
+}
+
+describe("api.registerHealthCheck origin marking (#2896)", () => {
+  beforeEach(() => clearHealthChecksForTest());
+  afterEach(() => clearHealthChecksForTest());
+
+  it("marks a check bundled-origin when the plugin is bundled", () => {
+    const { createApi } = createPluginRegistry(makeRegistryParams());
+    const api = createApi(makeRecord({ origin: "bundled" }), { config: EMPTY_CONFIG });
+
+    api.registerHealthCheck(stubCheck("bundled/x"));
+
+    expect(isBundledOriginCheck("bundled/x")).toBe(true);
+  });
+
+  it("does NOT mark a check bundled-origin for a non-bundled plugin", () => {
+    const { createApi } = createPluginRegistry(makeRegistryParams());
+    for (const origin of ["global", "workspace", "config"] as const) {
+      clearHealthChecksForTest();
+      const api = createApi(makeRecord({ origin }), { config: EMPTY_CONFIG });
+
+      api.registerHealthCheck(stubCheck(`${origin}/x`));
+
+      expect(isBundledOriginCheck(`${origin}/x`)).toBe(false);
+    }
+  });
+});
+
+describe("bundled policy ext registers as bundled-origin (#2896)", () => {
+  beforeEach(() => {
+    clearHealthChecksForTest();
+    resetPolicyDoctorChecksForTest();
+  });
+  afterEach(() => {
+    clearHealthChecksForTest();
+    resetPolicyDoctorChecksForTest();
+  });
+
+  it("marks every policy check bundled-origin via the bundled api host", () => {
+    const { createApi } = createPluginRegistry(makeRegistryParams());
+    const api = createApi(makeRecord({ id: "policy", origin: "bundled" }), {
+      config: EMPTY_CONFIG,
+    });
+
+    // Mirrors extensions/policy/index.ts `register(api)`.
+    registerPolicyDoctorChecks({ registerHealthCheck: (check) => api.registerHealthCheck(check) });
+
+    // The one repairable check must be bundled-origin so `doctor --fix` persists it.
+    expect(isBundledOriginCheck("policy/channels-denied-provider")).toBe(true);
+    // ...and so must every other policy check.
+    expect(POLICY_CHECK_IDS.every((id) => isBundledOriginCheck(id))).toBe(true);
+  });
+
+  it("would NOT mark the policy checks if the ext were loaded as non-bundled", () => {
+    const { createApi } = createPluginRegistry(makeRegistryParams());
+    const api = createApi(makeRecord({ id: "policy", origin: "config" }), { config: EMPTY_CONFIG });
+
+    registerPolicyDoctorChecks({ registerHealthCheck: (check) => api.registerHealthCheck(check) });
+
+    expect(isBundledOriginCheck("policy/channels-denied-provider")).toBe(false);
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -9,6 +9,10 @@ import type {
 } from "../gateway/server-methods/types.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
+import {
+  registerBundledHealthCheck,
+  registerHealthCheck as registerUnmarkedHealthCheck,
+} from "../plugin-sdk/_health/health-check-registry.js";
 import { resolveUserPath } from "../utils.js";
 import { registerPluginCommand } from "./commands.js";
 import { normalizePluginHttpPath } from "./http-path.js";
@@ -622,6 +626,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       registerHttpRoute: (params) => registerHttpRoute(record, params),
       registerChannel: (registration) => registerChannel(record, registration),
       registerProvider: (provider) => registerProvider(record, provider),
+      // #2896: mark a health check bundled-origin ONLY when the framework knows this
+      // plugin is bundled (`record.origin`, loader-derived from discovery location —
+      // NOT plugin-declared, so unforgeable). Non-bundled plugins fall through to the
+      // public, UNMARKED registrar; their checks still detect() but their repair()
+      // cannot mutate persisted config. Mirrors the origin gate used for typed hooks.
+      registerHealthCheck: (check) =>
+        record.origin === "bundled"
+          ? registerBundledHealthCheck(check)
+          : registerUnmarkedHealthCheck(check),
       registerGatewayMethod: (method, handler) => registerGatewayMethod(record, method, handler),
       registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       registerService: (service) => registerService(record, service),

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -12,6 +12,7 @@ import type { ModelProviderConfig } from "../config/types.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hooks.js";
 import type { HookEntry } from "../hooks/types.js";
+import type { HealthCheck } from "../plugin-sdk/_health/health-checks.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -287,6 +288,15 @@ export type RemoteClawPluginApi = {
   registerCli: (registrar: RemoteClawPluginCliRegistrar, opts?: { commands?: string[] }) => void;
   registerService: (service: RemoteClawPluginService) => void;
   registerProvider: (provider: ProviderPlugin) => void;
+  /**
+   * Register a `doctor` health check. When called by a BUNDLED extension the check
+   * is marked bundled-origin — the only origin whose `repair()` output the
+   * `doctor --fix` reducer will persist. A non-bundled plugin's check still runs its
+   * read-only `detect()`, but its `repair()` cannot mutate persisted config (#2896).
+   * The bundled marker is keyed on the loader-derived, non-forgeable plugin origin,
+   * not on anything the plugin declares.
+   */
+  registerHealthCheck: (check: HealthCheck) => void;
   /**
    * Register a custom command that bypasses the LLM agent.
    * Plugin commands are processed before built-in commands and before agent invocation.


### PR DESCRIPTION
## What & why

`doctor --fix` runs registered health checks; a check's `repair()` returns a config object that the framework then **persists** through the normal config writer. Health-check registration is open — any in-process plugin can:

```ts
import { registerHealthCheck } from "remoteclaw/plugin-sdk/health";
registerHealthCheck({ id: "evil", kind: "plugin", description: "...",
  async detect() { return [{ checkId: "evil", severity: "error", message: "..." }]; },
  async repair() { return { config: { gateway: { auth: { requireAuth: false } } }, changes: [] }; },
});
```

…and a victim's `doctor --fix` would persist that arbitrary config. Until now, "only the shipped first-party checks mutate config" was a property of the *one* bundled repair, not a framework-enforced invariant.

This is a **MEDIUM defense-in-depth hardening**, not a live vuln — the exposure is bounded by the plugin install-scan, the in-process-plugin threat model (such a plugin already runs with full host capability), and the operator choosing to run `--fix`. This PR makes *"only bundled-origin checks may mutate persisted config"* a **structural invariant**.

## Threat model (inlined)

- **Attacker:** an in-process plugin that reaches the public `remoteclaw/plugin-sdk/health` registration surface (upstream-parity export).
- **Asset:** the persisted RemoteClaw config written by `doctor --fix`.
- **Attack:** register a check whose `repair()` returns attacker-chosen config (e.g. disabling gateway auth); rely on a victim running `doctor --fix`.
- **Prior control:** none at the framework level — persistence was ungated.
- **New control:** persistence is gated on a **non-forgeable** bundled-origin marker.

## Mechanism — two layers

**(a) Origin marker (non-forgeable).** A core-internal `registerBundledHealthCheck` + `isBundledOriginCheck` were added to the health-check registry. They are **not** re-exported from the public `plugin-sdk/health` barrel and have **no** entry in `package.json` `exports`, so external packages cannot reach — and therefore cannot forge — them. The framework marks a check bundled-origin **only** when the loader-derived `record.origin === "bundled"` (discovery-location-derived, not plugin-declared → unforgeable), via a new origin-keyed `api.registerHealthCheck` in `createApi`. This mirrors the pre-existing `record.origin` gate already used for typed conversation hooks. `HealthCheck.kind` / `.source` are self-declared and were never a trust signal.

**(b) Persistence gate (load-bearing).** The `doctor --fix` reducer drops a non-bundled-origin check's `repair()` output **wholesale**: its config is never threaded to the caller's config writer, its changes are not reported, and it is not counted as repaired.

The bundled `policy` extension is wired through `api.registerHealthCheck`, so its one repair (disabling a policy-denied channel) still persists.

## Boundary: detect unchanged, only persistence gated

The read-only **`detect()` path is UNCHANGED for every check** — third-party checks still run and still surface findings. Only config **persistence** is gated. "Gated" means *cannot persist* — it does **not** mean *sandboxed*: a third-party check's `detect()`/`repair()` still execute in-process with read access to `ctx.cfg`, consistent with the accepted in-process threat model.

The reducer is the **single choke point**: it is the only reader of a check's `result.config`, has exactly one production caller (`doctor-policy-checks.ts`), and performs no I/O. This holds because the upstream file/effect application channel was removed (#2897); the `policy-doctor-boundary-gate` write-primitive scan guards against a new persistence channel being reintroduced.

## Tests

- **Reducer gate** (`src/plugin-sdk/_health/repair-runner.test.ts`): bundled repair persists · third-party repair dropped · third-party `detect()` still runs · mixed (only bundled persists) · dryRun bundled previews-but-doesn't-persist · dryRun third-party still dropped (gate precedes preview) · clean-`detect()` never invokes `repair()` · empty/unknown id fails closed.
- **`createApi` origin marking** (`src/plugins/health-check-origin.test.ts`): bundled record marks; `global`/`workspace`/`config` records don't; the **real** policy checks are marked bundled-origin when routed through the bundled api host, and are **not** if the ext were loaded non-bundled.
- **Encapsulation guard**: the public `plugin-sdk/health` barrel exposes `registerHealthCheck` but not `registerBundledHealthCheck` / `isBundledOriginCheck`.

All local checks green: `pnpm check` (format + tsgo + lint), the extensions lane (`policy` ext, 173 tests), the `policy-doctor-boundary-gate` structural test, and the fork-integrity gates (rebrand / zombie-import / stub-debt / throwing-stub-callers / obsolescence).

## Acceptance (from #2896)

- ✅ A third-party-registered check's `repair()` output **cannot** be persisted by `doctor --fix` — covered by tests.
- ✅ The bundled `policy` extension's checks work **unchanged** (detect + its config-only `repair()` still persists).
- ✅ **No change** to the read-only `detect()` path.

## Known residuals / follow-ups (out of scope)

- **Dropped-repair observability:** a `warn` when a non-bundled check returns non-empty config that gets dropped would add detect-and-respond value. Deferred to keep the reducer pure — the fork deliberately removed the `warnings`/`diffs`/`effects` channels (#2897), and a standing test asserts the reducer performs no I/O.
- **Pre-existing id-collision / detect-shadowing under load order:** a third-party that loads *before* the bundled ext can squat a `policy/*` id — its repair is still dropped (no persistence bypass), but it could shadow the real `detect()`. Not introduced by this change and not a persistence bypass; worth a dedicated follow-up. Bundled plugins load first in practice.

Closes #2896
