### PR TITLE
security(plugin-sdk): key doctor --fix bundled-origin gate on object identity (#2921)

### DIFF
--- a/src/plugin-sdk/_health/health-check-registry.ts
+++ b/src/plugin-sdk/_health/health-check-registry.ts
@@ -2,12 +2,18 @@ import type { HealthCheck } from "./health-checks.js";
 
 const REGISTRY = new Map<string, HealthCheck>();
 
-// Ids of checks registered via the bundled-origin path (`registerBundledHealthCheck`).
-// This is the ONLY trustworthy origin signal: `HealthCheck.kind`/`.source` are
-// self-declared on the check object and therefore spoofable, so a check's own fields
-// can never certify its provenance. Membership here gates whether a check's `repair()`
-// output may mutate persisted config (see `repair-runner.ts` and #2896).
-const BUNDLED_ORIGIN = new Set<string>();
+// Object identities of checks registered via the bundled-origin path
+// (`registerBundledHealthCheck`). Keyed on OBJECT IDENTITY — not the check's `id`
+// string — because `HealthCheck.kind`/`.source`/`.id` are all self-declared on the
+// check object and therefore spoofable, so a check's own fields can never certify its
+// provenance. `id` in particular is not even stable: a polymorphic `get id()` can
+// return one value at registration and another when the gate reads it (#2921), which
+// would defeat any id-string join key. Object identity is unforgeable — an attacker
+// cannot make their check object BE a bundled check object — so membership here is a
+// structural gate on whether a check's `repair()` output may mutate persisted config
+// (see `repair-runner.ts`, #2896, #2921). Reassigned rather than `.clear()`d on test
+// reset because a `WeakSet` is not enumerable.
+let BUNDLED_ORIGIN = new WeakSet<HealthCheck>();
 
 export class HealthCheckRegistrationError extends Error {
   readonly code = "OC_DOCTOR_DUPLICATE_CHECK";
@@ -23,7 +29,7 @@ function register(check: HealthCheck, bundledOrigin: boolean): void {
   }
   REGISTRY.set(check.id, check);
   if (bundledOrigin) {
-    BUNDLED_ORIGIN.add(check.id);
+    BUNDLED_ORIGIN.add(check);
   }
 }
 
@@ -50,11 +56,13 @@ export function registerBundledHealthCheck(check: HealthCheck): void {
   register(check, true);
 }
 
-// Whether the check registered under `id` was registered via the bundled-origin
-// path. Ids are unique in the registry (duplicate registration throws), so this
-// reliably reflects the provenance of the single check holding that id.
-export function isBundledOriginCheck(id: string): boolean {
-  return BUNDLED_ORIGIN.has(id);
+// Whether `check` was registered via the bundled-origin path. Keyed on the check's
+// OBJECT IDENTITY, so the caller must pass the very object the reducer is about to
+// persist for. This makes the gate immune to a polymorphic `get id()` that borrows a
+// bundled check's `id` at gate-time (#2921): an object the caller/attacker controls is
+// never identical to a bundled check object registered through the internal path.
+export function isBundledOriginCheck(check: HealthCheck): boolean {
+  return BUNDLED_ORIGIN.has(check);
 }
 
 export function listHealthChecks(): readonly HealthCheck[] {
@@ -67,5 +75,7 @@ export function getHealthCheck(id: string): HealthCheck | undefined {
 
 export function clearHealthChecksForTest(): void {
   REGISTRY.clear();
-  BUNDLED_ORIGIN.clear();
+  // `WeakSet` has no `.clear()`; reassign a fresh set so a test re-registering the
+  // same object instance does not inherit a stale bundled-origin marking.
+  BUNDLED_ORIGIN = new WeakSet<HealthCheck>();
 }

--- a/src/plugin-sdk/_health/repair-runner.test.ts
+++ b/src/plugin-sdk/_health/repair-runner.test.ts
@@ -129,9 +129,15 @@ describe("runDoctorHealthRepairs gate fails closed (#2896)", () => {
     clearHealthChecksForTest();
   });
 
-  it("treats an unregistered or empty id as non-bundled (fails closed)", () => {
-    expect(isBundledOriginCheck("")).toBe(false);
-    expect(isBundledOriginCheck("never-registered")).toBe(false);
+  it("treats an unregistered or public-path check as non-bundled (fails closed)", () => {
+    // A check object that was never registered is not bundled-origin.
+    const neverRegistered = configRewritingCheck("never-registered", baseCfg);
+    expect(isBundledOriginCheck(neverRegistered)).toBe(false);
+
+    // A check registered via the PUBLIC path is not bundled-origin either.
+    const publicCheck = configRewritingCheck("thirdparty/plain", baseCfg);
+    registerHealthCheck(publicCheck);
+    expect(isBundledOriginCheck(publicCheck)).toBe(false);
   });
 
   it("does not persist a bundled repair under dryRun, but previews the change", async () => {
@@ -183,6 +189,69 @@ describe("runDoctorHealthRepairs gate fails closed (#2896)", () => {
 
     expect(repairInvoked).toBe(false);
     expect(result.config).toBe(baseCfg);
+    expect(result.checksRepaired).toBe(0);
+  });
+});
+
+describe("runDoctorHealthRepairs rejects polymorphic-id origin forgery (#2921)", () => {
+  beforeEach(() => {
+    clearHealthChecksForTest();
+  });
+  afterEach(() => {
+    clearHealthChecksForTest();
+  });
+
+  it("does not persist a public-path check that borrows a bundled id at gate-time", async () => {
+    // A genuinely bundled check occupies a known id, so that id string IS present in
+    // the (pre-#2921) id-string origin marker. Clean detect() ⇒ its own repair never
+    // runs; it exists only to make "policy/secure" a real bundled id to borrow.
+    registerBundledHealthCheck({
+      id: "policy/secure",
+      kind: "plugin",
+      description: "bundled seed check",
+      async detect() {
+        return [];
+      },
+    });
+
+    // The attack: a third-party check registered through the PUBLIC `registerHealthCheck`
+    // whose `id` is polymorphic — a unique non-bundled id while it is registered (so it
+    // is NOT marked bundled-origin), flipped to the bundled id before the reducer's gate
+    // reads it. Its repair() weakens gateway auth.
+    const maliciousConfig = {
+      gateway: { auth: { requireAuth: false } },
+    } as unknown as RemoteClawConfig;
+    let gatePhase = false;
+    const malicious: HealthCheck = {
+      get id() {
+        return gatePhase ? "policy/secure" : "thirdparty/forger";
+      },
+      kind: "plugin",
+      description: "polymorphic-id forger",
+      async detect() {
+        return [finding("thirdparty/forger")];
+      },
+      async repair() {
+        return { config: maliciousConfig, changes: ["forger rewrote config"] };
+      },
+    };
+    registerHealthCheck(malicious);
+    // Flip the phase: from here the `id` getter returns the bundled id, so a gate that
+    // re-read `check.id` (the pre-#2921 id-string join) would treat this as bundled.
+    gatePhase = true;
+
+    const result = await runDoctorHealthRepairs(repairCtx(baseCfg));
+
+    // Object-identity keying (#2921): the attacker object is never identical to a
+    // bundled object, so the malicious config is dropped. Pre-#2921 this FAILED — the
+    // gate read the now-bundled `check.id`, matched the seed id, and persisted it.
+    expect(result.config).toBe(baseCfg);
+    expect(result.config).not.toBe(maliciousConfig);
+    const persisted = result.config as unknown as {
+      gateway: { auth: { requireAuth: boolean } };
+    };
+    expect(persisted.gateway.auth.requireAuth).toBe(true);
+    expect(result.changes).not.toContain("forger rewrote config");
     expect(result.checksRepaired).toBe(0);
   });
 });

--- a/src/plugin-sdk/_health/repair-runner.ts
+++ b/src/plugin-sdk/_health/repair-runner.ts
@@ -105,7 +105,10 @@ async function runSplitHealthCheck(
     // and it is not counted as repaired. There is no other persistence channel
     // (upstream file/effect application was gutted in the fork), so dropping the
     // returned config fully neutralizes an untrusted check's attempt to rewrite it.
-    if (!isBundledOriginCheck(check.id)) {
+    // #2921: the gate keys on the check's OBJECT IDENTITY (`check`), not its `check.id`
+    // string, so a public-path check cannot borrow a bundled check's id at gate-time
+    // through a polymorphic `get id()`.
+    if (!isBundledOriginCheck(check)) {
       return repairRunResult(cfg, findings, remainingFindings, changes);
     }
     if (result.config !== undefined && opts.dryRun !== true) {

--- a/src/plugins/health-check-origin.test.ts
+++ b/src/plugins/health-check-origin.test.ts
@@ -7,6 +7,7 @@ import {
 import type { RemoteClawConfig } from "../config/config.js";
 import {
   clearHealthChecksForTest,
+  getHealthCheck,
   isBundledOriginCheck,
 } from "../plugin-sdk/_health/health-check-registry.js";
 import type { HealthCheck } from "../plugin-sdk/_health/health-checks.js";
@@ -70,9 +71,10 @@ describe("api.registerHealthCheck origin marking (#2896)", () => {
     const { createApi } = createPluginRegistry(makeRegistryParams());
     const api = createApi(makeRecord({ origin: "bundled" }), { config: EMPTY_CONFIG });
 
-    api.registerHealthCheck(stubCheck("bundled/x"));
+    const check = stubCheck("bundled/x");
+    api.registerHealthCheck(check);
 
-    expect(isBundledOriginCheck("bundled/x")).toBe(true);
+    expect(isBundledOriginCheck(check)).toBe(true);
   });
 
   it("does NOT mark a check bundled-origin for a non-bundled plugin", () => {
@@ -81,9 +83,10 @@ describe("api.registerHealthCheck origin marking (#2896)", () => {
       clearHealthChecksForTest();
       const api = createApi(makeRecord({ origin }), { config: EMPTY_CONFIG });
 
-      api.registerHealthCheck(stubCheck(`${origin}/x`));
+      const check = stubCheck(`${origin}/x`);
+      api.registerHealthCheck(check);
 
-      expect(isBundledOriginCheck(`${origin}/x`)).toBe(false);
+      expect(isBundledOriginCheck(check)).toBe(false);
     }
   });
 });
@@ -107,10 +110,18 @@ describe("bundled policy ext registers as bundled-origin (#2896)", () => {
     // Mirrors extensions/policy/index.ts `register(api)`.
     registerPolicyDoctorChecks({ registerHealthCheck: (check) => api.registerHealthCheck(check) });
 
-    // The one repairable check must be bundled-origin so `doctor --fix` persists it.
-    expect(isBundledOriginCheck("policy/channels-denied-provider")).toBe(true);
+    // Resolve each id to the actual registered object (the registry stores the object
+    // registered under that id) and assert its object identity is bundled-origin. The
+    // one repairable check must be bundled-origin so `doctor --fix` persists it.
+    const repairable = getHealthCheck("policy/channels-denied-provider");
+    expect(repairable !== undefined && isBundledOriginCheck(repairable)).toBe(true);
     // ...and so must every other policy check.
-    expect(POLICY_CHECK_IDS.every((id) => isBundledOriginCheck(id))).toBe(true);
+    expect(
+      POLICY_CHECK_IDS.every((id) => {
+        const check = getHealthCheck(id);
+        return check !== undefined && isBundledOriginCheck(check);
+      }),
+    ).toBe(true);
   });
 
   it("would NOT mark the policy checks if the ext were loaded as non-bundled", () => {
@@ -119,6 +130,9 @@ describe("bundled policy ext registers as bundled-origin (#2896)", () => {
 
     registerPolicyDoctorChecks({ registerHealthCheck: (check) => api.registerHealthCheck(check) });
 
-    expect(isBundledOriginCheck("policy/channels-denied-provider")).toBe(false);
+    // Registered (so resolvable), but via the non-bundled path ⇒ not bundled-origin.
+    const repairable = getHealthCheck("policy/channels-denied-provider");
+    expect(repairable).toBeDefined();
+    expect(repairable !== undefined && isBundledOriginCheck(repairable)).toBe(false);
   });
 });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -293,8 +293,11 @@ export type RemoteClawPluginApi = {
    * is marked bundled-origin — the only origin whose `repair()` output the
    * `doctor --fix` reducer will persist. A non-bundled plugin's check still runs its
    * read-only `detect()`, but its `repair()` cannot mutate persisted config (#2896).
-   * The bundled marker is keyed on the loader-derived, non-forgeable plugin origin,
-   * not on anything the plugin declares.
+   * The bundled marker is keyed on the loader-derived plugin origin (`record.origin`,
+   * not anything the plugin declares) AND recorded against the check's object identity,
+   * so it is forgeable neither at registration (only a bundled loader origin marks a
+   * check) nor at gate-time (the persistence gate matches the check object itself, not
+   * its self-declared, potentially polymorphic `id`) — see #2896, #2921.
    */
   registerHealthCheck: (check: HealthCheck) => void;
   /**


### PR DESCRIPTION
## What & why

The `doctor --fix` **repair()-persistence gate** restricts config-mutating `repair()`
output to **bundled-origin (first-party)** health checks — a non-bundled check still
runs its read-only `detect()`, but its `repair()` config must never reach the config
writer. That gate keyed on the check's **`id` string**, re-read from the check object
**at gate-time**:

```ts
// src/plugin-sdk/_health/health-check-registry.ts (before)
const BUNDLED_ORIGIN = new Set<string>();            // keyed by id STRING
// registerBundledHealthCheck → BUNDLED_ORIGIN.add(check.id)
export function isBundledOriginCheck(id: string) { return BUNDLED_ORIGIN.has(id); }

// src/plugin-sdk/_health/repair-runner.ts:108 (before)
if (!isBundledOriginCheck(check.id)) { /* drop repair */ }
```

Because membership was recorded with the id read **at registration** but the gate
re-reads `check.id` **at persistence time**, a third-party in-process plugin
registered through the **public** `registerHealthCheck` export defeats the gate with a
**polymorphic `id` getter**:

1. Register via the public path with `get id()` returning a **unique non-bundled id**
   → the check is **not** marked bundled-origin.
2. Flip a phase flag so `get id()` now returns a **bundled** check's id (e.g.
   `policy/channels-denied-provider`).
3. `doctor --fix` runs → the gate reads the now-bundled id, `Set.has(bundledId)` is
   `true` (a real bundled check registered that id), and the malicious `repair()`
   config — e.g. `{ gateway: { auth: { requireAuth: false } } }` — **persists**.

This defeats the "unforgeable / first-party" guarantee the code's own comments and the
plugin-API type assert. Severity is **MEDIUM** (defense-in-depth): the bypass needs an
unambiguously malicious polymorphic getter, and an in-process plugin already has full
host capability (it could write the config file directly via `fs`), so it grants
nothing *structurally new* — but it reduces an asserted-structural guarantee to
nothing, and the fix is a trivial drop-in.

## The fix — object-identity keying

Key the origin marker on **object identity**, not the forgeable id string:

```ts
// health-check-registry.ts (after)
let BUNDLED_ORIGIN = new WeakSet<HealthCheck>();     // keyed by OBJECT identity
// registerBundledHealthCheck → BUNDLED_ORIGIN.add(check)   // the object
export function isBundledOriginCheck(check: HealthCheck) { return BUNDLED_ORIGIN.has(check); }

// repair-runner.ts (after) — the reducer already holds the object
if (!isBundledOriginCheck(check)) { /* drop repair */ }
```

An attacker cannot make their object **be** a bundled check object, and object identity
is immune to `id` polymorphism, so the guarantee is now genuinely structural. Comments
in `health-check-registry.ts` and the `registerHealthCheck` doc in `src/plugins/types.ts`
are updated to describe the now-accurate structural guarantee (without overstating it).

**`WeakSet` has no `.clear()`** — a `WeakSet` cannot be enumerated or cleared. The
test-reset helper `clearHealthChecksForTest()` reassigns a fresh `WeakSet` (the binding
is now `let`) for deterministic test isolation (so a test re-registering the same object
instance never inherits a stale marking).

## Forward-fix on #2919 — NOT a revert

This hardens the bundled-origin constraint introduced in **#2919**, which correctly
closed the naive vector (a plain third-party check with a malicious `repair()`). #2919
is a strict improvement and stays; this PR closes the residual **polymorphic-getter**
bypass surfaced by adversarial review of that change.

## Differential test (load-bearing)

`repair-runner.test.ts` gains a test that registers a third-party check through the
**public** `registerHealthCheck` with a **polymorphic `id` getter** (unique non-bundled
id at registration → bundled id at the gate) whose `repair()` weakens gateway auth, then
drives the real reducer and asserts the malicious config is **not** persisted
(`result.config` is the unmodified base; `requireAuth` stays `true`; `checksRepaired === 0`).

Verified as a genuine differential: reverting only the two production source files to the
pre-fix id-string gate and re-running the file, **exactly** this test fails
(`expected requireAuth: true, received requireAuth: false`) while the other 9 pass;
restoring the fix makes it pass.

## Preserved (regression guards, all green)

- Bundled policy checks still persist their config repair — the policy smoke emits
  `Policy repairs applied — Disabled channels.telegram.enabled for policy conformance`.
- Detect path unchanged: third-party checks still run `detect()`; **only** persistence
  is gated; no check is dropped from detection.
- Fail-closed preserved: a never-registered / public-path check → not bundled → not
  persisted.

## Files changed

| File | Change |
|------|--------|
| `src/plugin-sdk/_health/health-check-registry.ts` | `Set<string>` → `WeakSet<HealthCheck>`; `add(check)`; `isBundledOriginCheck(check)`; reset reassigns; accurate comments |
| `src/plugin-sdk/_health/repair-runner.ts` | gate `isBundledOriginCheck(check.id)` → `isBundledOriginCheck(check)` + comment |
| `src/plugins/types.ts` | `registerHealthCheck` doc updated to the structural guarantee |
| `src/plugin-sdk/_health/repair-runner.test.ts` | new #2921 differential test; fails-closed test moved to object identity |
| `src/plugins/health-check-origin.test.ts` | origin-marking assertions use object identity (resolve ids via `getHealthCheck`) |

## Local verification

- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) — clean.
- `_health` unit lane (`vitest.unit.config.ts`): `repair-runner.test.ts` + `health-check-origin.test.ts` — 14 passed.
- Policy doctor smoke + boundary (base config): 8 passed.
- `extensions/policy` doctor (`register` + `singleton`, extensions config): 173 passed.

Closes #2921
