### PR TITLE
test(channels): bot-loop guard adapter regression coverage + Google Chat botUser doc note

### DIFF
--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -218,6 +218,7 @@ Notes:
 - `typingIndicator` supports `none`, `message` (default), and `reaction` (reaction requires user OAuth).
 - Attachments are downloaded through the Chat API and stored in the media pipeline (size capped by `mediaMaxMb`).
 - Bot-authored Google Chat messages are ignored by default. If you intentionally set `allowBots: true`, accepted bot-authored messages use shared [bot loop protection](/channels/bot-loop-protection). Configure `channels.defaults.botLoopProtection`, then override with `channels.googlechat.botLoopProtection` or `channels.googlechat.groups.<space>.botLoopProtection` when one space needs a different budget.
+- With `allowBots: true`, also set `botUser` to the app's own `users/<id>` sender name for accurate self-exclusion. Third-party bot-loop detection is unaffected either way — the tracked pair key is stable — but the app only excludes _its own_ messages from the guard when `botUser` matches the sender name Google Chat delivers; when `botUser` is unset it falls back to `users/app`, so a self-message whose real sender name differs would be pair-tracked instead of self-excluded. Low impact in practice, since an app's own messages are not normally re-ingested as inbound in Google Chat.
 
 Secrets reference details: [Secrets Management](/gateway/secrets).
 

--- a/extensions/discord/src/monitor/message-handler.bot-loop-protection.test.ts
+++ b/extensions/discord/src/monitor/message-handler.bot-loop-protection.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelBotLoopProtectionFacts } from "../../../../src/channels/turn/bot-loop-protection.js";
+
+// Regression coverage for the Discord bot-loop guard short-circuit (#2873 item 1).
+//
+// Discord's guard facts are assembled in `preflightDiscordMessage` and consumed
+// here by `processDiscordMessage`, which calls the shared guard and MUST `return`
+// before `dispatchInboundMessage` on a suppressed result. This test drives the
+// REAL consumer with the assembled facts and mocks only the guard (capture facts
+// + control verdict) and the dispatch fn (to prove the short-circuit).
+//
+// NOTE ON ASSEMBLY COVERAGE: unlike Slack/Google Chat — whose assembly is
+// reachable through a callable seam — Discord's field mapping lives at the very
+// end of `preflightDiscordMessage`, behind ~30 admission gates that currently
+// drop bot-authored messages in this environment (see the pre-existing failures
+// in the quarantined `message-handler.preflight.test.ts`). Driving that path
+// would require either a red test or an out-of-scope source change, so this test
+// asserts the short-circuit + the four-id forwarding contract at the consumer
+// boundary. The preflight assembly's per-field mapping is documented at
+// `message-handler.preflight.ts` (scopeId<-accountId, conversationId<-channelId,
+// senderId<-author.id, receiverId<-botUserId).
+
+const guardMock = vi.hoisted(() => vi.fn());
+const dispatchSpy = vi.hoisted(() =>
+  vi.fn(async () => ({ queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } })),
+);
+
+vi.mock("../../../../src/channels/turn/bot-loop-protection.js", () => ({
+  recordChannelBotPairLoopAndCheckSuppression: guardMock,
+}));
+
+vi.mock("../../../../src/auto-reply/dispatch.js", () => ({
+  dispatchInboundMessage: dispatchSpy,
+}));
+
+const { processDiscordMessage } = await import("./message-handler.process.js");
+
+const ACCOUNT_ID = "default";
+const CHANNEL_ID = "c1";
+const SENDER_BOT_ID = "other-bot-999";
+const SELF_BOT_ID = "remoteclaw-bot";
+
+function createBotCtx(): Parameters<typeof processDiscordMessage>[0] {
+  const botLoopProtection: ChannelBotLoopProtectionFacts = {
+    scopeId: ACCOUNT_ID,
+    conversationId: CHANNEL_ID,
+    senderId: SENDER_BOT_ID,
+    receiverId: SELF_BOT_ID,
+    defaultEnabled: true,
+  };
+  // Minimal context: only the fields the guarded short-circuit reads. On a
+  // suppressed result `processDiscordMessage` returns before touching any of the
+  // heavier dispatch machinery.
+  return { botLoopProtection } as never;
+}
+
+describe("discord processDiscordMessage bot-loop protection", () => {
+  beforeEach(() => {
+    guardMock.mockReset();
+    dispatchSpy.mockReset();
+    dispatchSpy.mockResolvedValue({ queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } });
+  });
+
+  it("forwards the four assembled guard ids to the shared guard", async () => {
+    guardMock.mockReturnValue({ suppressed: true, cooldownUntilMs: 1_700_000_060_000 });
+
+    await processDiscordMessage(createBotCtx());
+
+    expect(guardMock).toHaveBeenCalledTimes(1);
+    const facts = guardMock.mock.calls[0][0] as ChannelBotLoopProtectionFacts;
+    expect(facts.scopeId).toBe(ACCOUNT_ID);
+    expect(facts.conversationId).toBe(CHANNEL_ID);
+    expect(facts.senderId).toBe(SENDER_BOT_ID);
+    expect(facts.receiverId).toBe(SELF_BOT_ID);
+  });
+
+  it("short-circuits before dispatch when the guard suppresses", async () => {
+    guardMock.mockReturnValue({ suppressed: true, cooldownUntilMs: 1_700_000_060_000 });
+
+    await processDiscordMessage(createBotCtx());
+
+    expect(guardMock).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/googlechat/src/monitor.bot-loop-protection.test.ts
+++ b/extensions/googlechat/src/monitor.bot-loop-protection.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelBotLoopProtectionFacts } from "../../../src/channels/turn/bot-loop-protection.js";
+
+// Regression coverage for the Google Chat bot-loop guard wiring (#2873 item 1).
+//
+// The guard facts are assembled inline in `processMessageWithPipeline` and the
+// guard is called BEFORE `dispatchReplyWithBufferedBlockDispatcher`. That pipeline
+// is module-private, reachable only through the event processor that `monitor.js`
+// registers at import time. We capture that processor by mocking
+// `setGoogleChatWebhookEventProcessor`, then invoke it directly — exercising the
+// REAL assembly + short-circuit while mocking only the guard (capture facts +
+// control verdict), the dispatch fn (a `core` method), and the access policy.
+// Non-vacuous: swapping sender/receiver (or scope/conversation) in the assembly
+// makes the id assertions fail.
+
+const guardMock = vi.hoisted(() => vi.fn());
+const dispatchReplySpy = vi.hoisted(() => vi.fn(async () => {}));
+const processorHolder = vi.hoisted(
+  () =>
+    ({ current: undefined }) as {
+      current?: (event: unknown, target: unknown) => Promise<void>;
+    },
+);
+
+vi.mock("./monitor-routing.js", () => ({
+  setGoogleChatWebhookEventProcessor: (fn: (event: unknown, target: unknown) => Promise<void>) => {
+    processorHolder.current = fn;
+  },
+  registerGoogleChatWebhookTarget: vi.fn(() => () => {}),
+  handleGoogleChatWebhookRequest: vi.fn(),
+}));
+
+vi.mock("./monitor-access.js", () => ({
+  applyGoogleChatInboundAccessPolicy: vi.fn(async () => ({
+    ok: true,
+    commandAuthorized: false,
+    effectiveWasMentioned: false,
+    groupSystemPrompt: undefined,
+  })),
+  isSenderAllowed: vi.fn(() => true),
+}));
+
+vi.mock("remoteclaw/plugin-sdk/googlechat", () => ({
+  recordChannelBotPairLoopAndCheckSuppression: guardMock,
+  createWebhookInFlightLimiter: vi.fn(),
+  createReplyPrefixOptions: vi.fn(() => ({})),
+  registerWebhookTargetWithPluginRoute: vi.fn(),
+  resolveInboundRouteEnvelopeBuilderWithRuntime: vi.fn(),
+  resolveWebhookPath: vi.fn(),
+}));
+
+// Importing the monitor registers `processGoogleChatEvent` via the mocked setter.
+await import("./monitor.js");
+
+const ACCOUNT_ID = "gc-acct";
+const SPACE_ID = "spaces/AAA";
+const SENDER_BOT = "users/other-bot";
+const SELF_APP_USER = "users/self-app";
+
+function createBotMessageEvent() {
+  return {
+    type: "MESSAGE",
+    eventTime: "2026-03-02T00:00:00.000Z",
+    space: { name: SPACE_ID, type: "SPACE", displayName: "Test Space" },
+    message: {
+      name: `${SPACE_ID}/messages/1`,
+      text: "hello from a peer bot",
+      sender: { name: SENDER_BOT, displayName: "Other Bot", type: "BOT" },
+    },
+  };
+}
+
+function createTarget() {
+  return {
+    account: { accountId: ACCOUNT_ID, config: { allowBots: true, botUser: SELF_APP_USER } },
+    config: { channels: { defaults: {} } },
+    runtime: { log: vi.fn(), error: vi.fn() },
+    core: {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        reply: {
+          dispatchReplyWithBufferedBlockDispatcher: dispatchReplySpy,
+          finalizeInboundContext: vi.fn(),
+        },
+      },
+    },
+    statusSink: vi.fn(),
+    mediaMaxMb: 20,
+  };
+}
+
+describe("googlechat processMessageWithPipeline bot-loop protection", () => {
+  beforeEach(() => {
+    guardMock.mockReset();
+    dispatchReplySpy.mockReset();
+    dispatchReplySpy.mockResolvedValue(undefined);
+  });
+
+  it("registered a processor at import time", () => {
+    expect(typeof processorHolder.current).toBe("function");
+  });
+
+  it("assembles the four guard ids from the inbound Google Chat message", async () => {
+    guardMock.mockReturnValue({ suppressed: true, cooldownUntilMs: 1_700_000_060_000 });
+
+    await processorHolder.current?.(createBotMessageEvent(), createTarget());
+
+    expect(guardMock).toHaveBeenCalledTimes(1);
+    const facts = guardMock.mock.calls[0][0] as ChannelBotLoopProtectionFacts;
+    // scopeId <- account.accountId, conversationId <- space.name,
+    // senderId <- message.sender.name (the peer bot),
+    // receiverId <- appUserId (account.config.botUser, else "users/app").
+    expect(facts.scopeId).toBe(ACCOUNT_ID);
+    expect(facts.conversationId).toBe(SPACE_ID);
+    expect(facts.senderId).toBe(SENDER_BOT);
+    expect(facts.receiverId).toBe(SELF_APP_USER);
+  });
+
+  it("short-circuits before dispatch when the guard suppresses", async () => {
+    guardMock.mockReturnValue({ suppressed: true, cooldownUntilMs: 1_700_000_060_000 });
+
+    await processorHolder.current?.(createBotMessageEvent(), createTarget());
+
+    expect(guardMock).toHaveBeenCalledTimes(1);
+    expect(dispatchReplySpy).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/dispatch.bot-loop-protection.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.bot-loop-protection.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelBotLoopProtectionFacts } from "../../../../../src/channels/turn/bot-loop-protection.js";
+
+// Regression coverage for the Slack bot-loop guard wiring (#2873 item 1).
+//
+// `dispatchPreparedSlackMessage` assembles `ChannelBotLoopProtectionFacts` from
+// the inbound Slack message (via `resolveSlackBotLoopProtection`) and calls the
+// shared guard BEFORE `dispatchInboundMessage`. On a suppressed result it must
+// short-circuit before dispatch. This test drives the REAL assembly + guard call
+// and mocks only the guard (to capture the facts + control the verdict) and the
+// dispatch fn (to prove the short-circuit). It is non-vacuous: swapping
+// sender/receiver (or scope/conversation) in `resolveSlackBotLoopProtection`
+// makes the id assertions fail.
+
+const guardMock = vi.hoisted(() => vi.fn());
+const dispatchSpy = vi.hoisted(() =>
+  vi.fn(async () => ({ queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } })),
+);
+
+vi.mock("../../../../../src/channels/turn/bot-loop-protection.js", () => ({
+  recordChannelBotPairLoopAndCheckSuppression: guardMock,
+}));
+
+vi.mock("../../../../../src/auto-reply/dispatch.js", () => ({
+  dispatchInboundMessage: dispatchSpy,
+}));
+
+const { dispatchPreparedSlackMessage } = await import("./dispatch.js");
+
+const RECEIVER_BOT_ID = "B_SELF";
+const RECEIVER_BOT_USER_ID = "U_SELF";
+const SENDER_BOT_ID = "B_OTHER";
+
+function createPreparedBotMessage(): Parameters<typeof dispatchPreparedSlackMessage>[0] {
+  return {
+    ctx: {
+      cfg: { channels: { defaults: {} } },
+      runtime: { error: vi.fn() },
+      botId: RECEIVER_BOT_ID,
+      botUserId: RECEIVER_BOT_USER_ID,
+    },
+    account: { accountId: "acct-1", config: {} },
+    message: {
+      channel: "C123",
+      bot_id: SENDER_BOT_ID,
+      user: "U_OTHER",
+      ts: "1700000000.000100",
+    },
+    route: { accountId: "acct-1" },
+    channelConfig: null,
+  } as never;
+}
+
+describe("slack dispatchPreparedSlackMessage bot-loop protection", () => {
+  beforeEach(() => {
+    guardMock.mockReset();
+    dispatchSpy.mockReset();
+    dispatchSpy.mockResolvedValue({ queuedFinal: false, counts: { final: 0, tool: 0, block: 0 } });
+  });
+
+  it("assembles the four guard ids from the inbound Slack message", async () => {
+    guardMock.mockReturnValue({ suppressed: true, cooldownUntilMs: 1_700_000_060_000 });
+
+    await dispatchPreparedSlackMessage(createPreparedBotMessage());
+
+    expect(guardMock).toHaveBeenCalledTimes(1);
+    const facts = guardMock.mock.calls[0][0] as ChannelBotLoopProtectionFacts;
+    // scopeId <- route.accountId, conversationId <- message.channel,
+    // senderId <- message.bot_id (the peer bot), receiverId <- ctx.botId (self).
+    expect(facts.scopeId).toBe("acct-1");
+    expect(facts.conversationId).toBe("C123");
+    expect(facts.senderId).toBe(SENDER_BOT_ID);
+    expect(facts.receiverId).toBe(RECEIVER_BOT_ID);
+  });
+
+  it("short-circuits before dispatch when the guard suppresses", async () => {
+    guardMock.mockReturnValue({ suppressed: true, cooldownUntilMs: 1_700_000_060_000 });
+
+    await dispatchPreparedSlackMessage(createPreparedBotMessage());
+
+    expect(guardMock).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Adds focused per-adapter regression tests for the shared **bot-to-bot loop guard** wiring, plus a Google Chat `botUser` documentation note. **Addresses items 1–2 of #2873**; item 3 (Matrix wiring) remains **deferred** and is not touched here.

## Why

The loop guard's decision semantics are unit-tested at `src/channels/turn/bot-loop-protection.test.ts` (budget trip at N+1, cooldown persistence/expiry, per-pair scoping) — but that suite never imports the Discord / Google Chat / Slack adapters. So the two adapter-level behaviors had **no automated regression coverage**:

1. **Fact assembly** — each adapter maps its inbound message onto `ChannelBotLoopProtectionFacts` (`scopeId` / `conversationId` / `senderId` / `receiverId`). A refactor that swaps sender↔receiver (or scope↔conversation) would ship silently.
2. **Short-circuit placement** — the guard must run and `return` **before** the adapter's dispatch step. Moving it after dispatch would defeat the protection with no failing test.

## Item 1 — per-adapter regression tests

Each test drives the **real** adapter code and mocks only the guard (to capture the assembled facts and control the verdict) and the dispatch fn (to prove the short-circuit). The four-id mapping asserted per adapter:

| Adapter (entry point) | scopeId | conversationId | senderId | receiverId |
|---|---|---|---|---|
| **Slack** — `dispatchPreparedSlackMessage` | `route.accountId` | `message.channel` | `message.bot_id` (peer bot) | `ctx.botId` (self) |
| **Google Chat** — `processMessageWithPipeline` | `account.accountId` | `space.name` | `message.sender.name` (peer bot) | `appUserId` (`botUser`, else `users/app`) |
| **Discord** — `processDiscordMessage` | `accountId` | `messageChannelId` | `author.id` (peer bot) | `botUserId` (self) |

- **Slack** (`extensions/slack/src/monitor/message-handler/dispatch.bot-loop-protection.test.ts`) — exercises the real `resolveSlackBotLoopProtection` assembly and the short-circuit before `dispatchInboundMessage`.
- **Google Chat** (`extensions/googlechat/src/monitor.bot-loop-protection.test.ts`) — the assembly + guard live in a module-private pipeline reachable only through the webhook plumbing, so the test **captures the event processor that `monitor.ts` registers at import** and invokes it directly — exercising the real assembly and short-circuit before the block dispatcher, without the HTTP path.
- **Discord** (`extensions/discord/src/monitor/message-handler.bot-loop-protection.test.ts`) — drives the real `processDiscordMessage` consumer, asserting the forwarded ids and the short-circuit before `dispatchInboundMessage`. **Adaptation:** Discord's per-field assembly lives at the very end of `preflightDiscordMessage`, behind ~30 admission gates that currently drop bot-authored messages in this repo's test env (pre-existing — see the failing bot cases in the quarantined `message-handler.preflight.test.ts`). Driving that path would require a red test or an out-of-scope source change, so Discord coverage is anchored at the consumer boundary (short-circuit + four-id forwarding contract).

**Non-vacuity verified** (each mutation reverted afterward):
- Swapping sender↔receiver in the Slack assembly → id test fails (`expected 'B_SELF' to be 'B_OTHER'`).
- Swapping sender↔receiver in the Google Chat assembly → id test fails (`expected 'users/self-app' to be 'users/other-bot'`).
- Removing the guard's `return` in `processDiscordMessage` → both Discord tests fall through past the guard and fail (`Cannot read properties of undefined (reading 'browser')`).

## Item 2 — Google Chat `botUser` doc note

`docs/channels/googlechat.md` now recommends setting `botUser` (the app's own `users/<id>` sender name) for **accurate self-exclusion** when `allowBots: true`. Third-party bot-loop detection is unaffected either way (the tracked pair key is stable); precise self-exclusion (`senderId !== appUserId`) only holds when `botUser` matches the sender name Google Chat delivers — otherwise it falls back to `users/app`. **Low impact** in practice, since an app's own messages are not normally re-ingested as inbound.

## Scope / safety

- **Test + doc only — no runtime/behavior change.** No production source is modified (verified via `git diff`).
- Verified locally: `pnpm check` (format + tsgo + oxlint + fork-integrity gates) green; the `test-extensions` CI lane green (381 files / 3549 tests, 1 skipped) with all three new files included and passing.

This PR does **not** close #2873 — item 3 remains outstanding.
