### PR TITLE
test(node-pairing): cover the empty-string-key drop in toSafeRecord

### DIFF
--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -341,6 +341,30 @@ describe("node pairing prototype-key hardening", () => {
     expect(({} as Record<string, unknown>).nodeId).toBeUndefined();
   });
 
+  test("drops the empty-string own-key from a corrupted paired-node state file on load", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
+    const { dir, pairedPath } = resolvePairingPaths(baseDir, "nodes");
+    await mkdir(dir, { recursive: true });
+    // A corrupted/hostile state file carrying a literal empty-string own-key.
+    // normalizeNodeId maps every blocked id (e.g. "__proto__") to "", so if this
+    // "" entry survived load, pairedByNodeId[""] would resolve to it and a
+    // blocked-key lookup would return the attacker-planted node and its token.
+    // toSafeRecord's `!key` drop closes that: the "" key never lands in the map.
+    const entries = [
+      `"node-1":${JSON.stringify({ nodeId: "node-1", token: "t".repeat(43), createdAtMs: 1, approvedAtMs: 2 })}`,
+      `"":${JSON.stringify({ nodeId: "", token: "planted-empty-key-token", createdAtMs: 0, approvedAtMs: 0 })}`,
+    ];
+    await writeFile(pairedPath, `{${entries.join(",")}}`, "utf8");
+
+    // The legit node survives; the "" entry is dropped on load.
+    const listed = await listNodePairing(baseDir);
+    expect(listed.paired.map((node) => node.nodeId)).toEqual(["node-1"]);
+    // A blocked-key lookup (normalizes to "") and a literal "" lookup must both
+    // miss — no path can resolve to the planted "" entry.
+    await expect(getPairedNode("__proto__", baseDir)).resolves.toBeNull();
+    await expect(getPairedNode("", baseDir)).resolves.toBeNull();
+  });
+
   test("loads pairing maps as null-prototype objects (positional invariant tripwire)", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "remoteclaw-node-pairing-"));
     const state = await loadNodePairingStateForTest(baseDir);


### PR DESCRIPTION
## What

Adds **one** focused unit test to `src/infra/node-pairing.test.ts` covering the empty-string (`""`) own-key drop in `toSafeRecord` on state-file load. **Test-only — no runtime/behavior change** (`src/infra/node-pairing.ts` is untouched).

## Why

`toSafeRecord` in `src/infra/node-pairing.ts` rebuilds the persisted pairing maps as null-prototype objects and drops both blocked prototype keys **and** the empty-string key on load:

```ts
if (!key || isBlockedObjectKey(key)) { continue; }
```

The `!key` (empty-string) branch was **untested** — the existing suite covers the `__proto__`/`constructor`/`prototype` corrupted-key drops but never a literal `""` own-key. This matters because `normalizeNodeId` maps every blocked id to `""`:

```ts
return isBlockedObjectKey(trimmed) ? "" : trimmed;
```

So without the `!key` drop, a corrupted/hostile `paired.json` containing a literal `""` own-key would survive load, and any blocked-key lookup (e.g. `getPairedNode("__proto__")`, which normalizes to `""`) would resolve `pairedByNodeId[""]` to the attacker-planted entry — including its token.

## The test

Writes a raw `paired.json` with a legit `node-1` entry plus a `""` own-key entry, then asserts:

- `listNodePairing` returns only `node-1` (the `""` entry is dropped on load),
- `getPairedNode("__proto__", baseDir)` resolves `null` (blocked-key lookup normalizes to `""`, which is now absent),
- `getPairedNode("", baseDir)` resolves `null` (literal `""` lookup misses).

Structure mirrors the adjacent `__proto__` corrupted-state test.

**Non-vacuous verification:** temporarily reverting the guard to `isBlockedObjectKey(key)` alone makes exactly this one test fail (`AssertionError: expected [ 'node-1', '' ] to deeply equal [ 'node-1' ]`) while the other 20 tests in the file pass — matching the issue's claim that the branch was previously uncovered. The source was restored before commit; the final diff touches **only** the test file.

## Severity

**LOW** — exploiting the underlying hole requires direct write access to `paired.json`, which is mode-`0600` and operator-gated (i.e. already full host compromise). This is test-completeness for an already-correct hardening, not a live vulnerability.

## Verification

- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) — pass, 0 warnings / 0 errors
- `pnpm test:fast` (`vitest run --config vitest.unit.config.ts`; `src/infra/**` is in the fast unit lane) — 9775 passed / 42 skipped, including the new test

Closes #2920
