### PR TITLE
test(session): drop 3 stale explicit-session-key tests (feature removed in the gut)

### DIFF
--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -144,8 +144,7 @@ describe("resolveSessionKeyForRequest", () => {
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
   });
 
-  // Skipped: asserts a sessionId cross-store search / --session-id-within-agent behavior
-  // that the gutted code no longer implements — triage (stale vs regression) tracked in #2798.
+  // Skipped: pending a maintainer decision on intended --agent + --session-id semantics — see #2798.
   it.skip("does not let --agent short-circuit --session-id back to the agent main session", async () => {
     setupMainAndMybotStorePaths();
     mocks.resolveExplicitAgentSessionKey.mockReturnValue("agent:mybot:main");
@@ -188,31 +187,6 @@ describe("resolveSessionKeyForRequest", () => {
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
   });
 
-  // Skipped: expects a deterministic `agent:<id>:explicit:<sessionId>` key no longer generated — see #2798.
-  it.skip("does not search other agent stores when --agent scopes --session-id", async () => {
-    setupMainAndMybotStorePaths();
-    mockStoresByPath({
-      [MAIN_STORE_PATH]: {
-        "agent:main:whatsapp:direct:+15550000000": {
-          sessionId: "target-session-id",
-          updatedAt: 10,
-        },
-      },
-      [MYBOT_STORE_PATH]: {},
-    });
-
-    const result = resolveSessionKeyForRequest({
-      cfg: baseCfg,
-      agentId: "mybot",
-      sessionId: "target-session-id",
-    });
-
-    expect(result.sessionKey).toBe("agent:mybot:explicit:target-session-id");
-    expect(result.storePath).toBe(MYBOT_STORE_PATH);
-    expect(mocks.loadSessionStore).toHaveBeenCalledTimes(1);
-    expect(mocks.loadSessionStore).toHaveBeenCalledWith(MYBOT_STORE_PATH);
-  });
-
   it("returns correct sessionStore when session found in non-primary agent store", () => {
     const mybotStore = {
       "agent:mybot:main": { sessionId: "target-session-id", updatedAt: 0 },
@@ -227,18 +201,6 @@ describe("resolveSessionKeyForRequest", () => {
       sessionId: "target-session-id",
     });
     expect(result.sessionStore["agent:mybot:main"]?.sessionId).toBe("target-session-id");
-  });
-
-  // Skipped: expects a deterministic `agent:<id>:explicit:<sessionId>` key no longer generated — see #2798.
-  it.skip("returns a deterministic explicit sessionKey when sessionId not found in any store", async () => {
-    setupMainAndMybotStorePaths();
-    mocks.loadSessionStore.mockReturnValue({});
-
-    const result = resolveSessionKeyForRequest({
-      cfg: baseCfg,
-      sessionId: "nonexistent-id",
-    });
-    expect(result.sessionKey).toBe("agent:main:explicit:nonexistent-id");
   });
 
   it("does not search other stores when explicitSessionKey is set", () => {
@@ -277,24 +239,6 @@ describe("resolveSessionKeyForRequest", () => {
     // so the cross-store search finds it in the mybot store
     expect(result.sessionKey).toBe("agent:mybot:main");
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
-  });
-
-  // Skipped: asserts an exact loadSessionStore call count tied to the old search/skip loop — see #2798.
-  it.skip("skips already-searched primary store when iterating agents", async () => {
-    setupMainAndMybotStorePaths();
-    mocks.loadSessionStore.mockReturnValue({});
-
-    resolveSessionKeyForRequest({
-      cfg: baseCfg,
-      sessionId: "nonexistent-id",
-    });
-
-    // loadSessionStore should be called twice: once for main, once for mybot
-    // (not twice for main)
-    const storePaths = mocks.loadSessionStore.mock.calls.map((call) => String(call[0]));
-    expect(storePaths).toHaveLength(2);
-    expect(storePaths).toContain(MAIN_STORE_PATH);
-    expect(storePaths).toContain(MYBOT_STORE_PATH);
   });
 });
 


### PR DESCRIPTION
## What

Deletes 3 stale `it.skip`-ped tests in `src/commands/agent/session.test.ts`
(the `resolveSessionKeyForRequest` block) that assert a feature this fork
removed, and refines the skip comment on a 4th test that is intentionally
kept skipped.

## Why — the asserted feature is gone

The three deleted tests assert a **deterministic
`agent:<id>:explicit:<sessionId>` session key** plus a **sessionId
cross-store search** that the Pi-era session machinery used to implement.
That machinery was gutted in the RemoteClaw fork. `resolveSessionKeyForRequest`
(`src/commands/agent/session.ts`) still does a reverse lookup + cross-store
search but **never synthesizes an `…:explicit:…` key**. A production grep
confirms there is no generator anywhere outside tests:

```
$ rg ':explicit:|explicit:\$\{|:explicit\b' src --type ts -g '!*.test.ts'
# (no matches — exit 1)
```

So these three tests exercised dead behavior:

| Deleted test | Stale expectation (no longer produced) |
|---|---|
| `does not search other agent stores when --agent scopes --session-id` | `agent:mybot:explicit:target-session-id` |
| `returns a deterministic explicit sessionKey when sessionId not found in any store` | `agent:main:explicit:nonexistent-id` |
| `skips already-searched primary store when iterating agents` | exact `loadSessionStore` call count tied to the old search/skip loop |

## Kept skipped: the 4th test (a possible real bug, not a stale test)

`does not let --agent short-circuit --session-id back to the agent main
session` stays `it.skip`-ped. Unlike the other three it is **not** a
stale-feature test — it flags a possible genuine `--agent` + `--session-id`
semantics question: with `--agent` set, the reverse lookup is gated on
`!explicitSessionKey`, so `--session-id` appears to be ignored and the agent
falls back to its main session. Whether that is the intended behavior needs a
maintainer decision, so this test is neither deleted nor un-skipped — only its
skip comment is updated to point at that pending decision.

## Scope & verification

- **Test-file only** — no production or runtime code is touched. The whole
  diff is one file, `+1 / -57`.
- The file is **not** CI-gated (`vitest.unit.config.ts` excludes
  `src/commands/**`, and it is not in `scripts/test-parallel.mjs`), so it was
  verified by running it directly against the base vitest config:

  ```
  $ node ./node_modules/vitest/vitest.mjs run --config vitest.config.ts \
      src/commands/agent/session.test.ts
   Test Files  1 passed (1)
        Tests  13 passed | 1 skipped (14)
  ```

  The single remaining skip is test 1 above (intentional). `pnpm check`
  (oxfmt + tsgo + oxlint, plus the fork-integrity gates) passes.

## Tracking

Addresses #2798 (tests 2-4 only). This PR intentionally leaves #2798 **open**:
test 1 is kept skipped pending the `--agent` + `--session-id` semantics
decision described above. No issue-closing keyword is used here, by design.
