### PR TITLE
test(auto-reply): shrink the quarantine ledger (#2782 auto-reply batch)

### DIFF
--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -4,7 +4,11 @@ import {
   isHeartbeatOkResponse,
   isHeartbeatUserMessage,
 } from "./heartbeat-filter.js";
-import { HEARTBEAT_PROMPT } from "./heartbeat.js";
+// `HEARTBEAT_PROMPT` is gutted to "" in the RemoteClaw fork — heartbeat prompts
+// must be explicitly configured and resolved at runtime (#281), then passed to
+// these helpers. This local sample stands in for a resolved prompt so the
+// config-provided-prompt matching path in heartbeat-filter.ts stays covered.
+const HEARTBEAT_PROMPT = "Read HEARTBEAT.md and run any periodic tasks that are due.";
 
 describe("isHeartbeatUserMessage", () => {
   it("matches heartbeat prompts", () => {

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerSessionRun,
+  resetSessionRunRegistryForTest,
+} from "../../agents/session-run-registry.js";
 import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import {
@@ -404,16 +408,24 @@ describe("abort detection", () => {
     expectSessionLaneCleared(sessionKey);
   });
 
-  it("plain-language stop on ACP-bound session triggers ACP cancel", async () => {
+  it("plain-language stop on ACP-bound session terminates the active run", async () => {
     const sessionKey = "agent:codex:acp:test-1";
     const sessionId = "session-123";
     const { cfg } = await createAbortConfig({
       sessionIdsByKey: { [sessionKey]: sessionId },
     });
-    acpManagerMocks.resolveSession.mockReturnValue({
-      kind: "ready",
+    // Fork reality: the upstream ACP control-plane manager cancel path
+    // (getAcpSessionManager().cancelSession) was gutted (a8374ec5ca) and no longer
+    // exists in the tree; fix(abort) (7784ae780) routes fast-abort through
+    // killSessionRun, which aborts the run's AbortController. Assert that live
+    // termination: a fast-abort on an ACP-bound session actually kills its active run.
+    resetSessionRunRegistryForTest();
+    const abortController = new AbortController();
+    registerSessionRun(sessionKey, {
+      startedAt: Date.now(),
       sessionKey,
-      meta: {} as never,
+      agentId: "codex",
+      abortController,
     });
 
     const result = await runStopCommand({
@@ -425,11 +437,8 @@ describe("abort detection", () => {
     });
 
     expect(result.handled).toBe(true);
-    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith({
-      cfg,
-      sessionKey,
-      reason: "fast-abort",
-    });
+    expect(result.aborted).toBe(true);
+    expect(abortController.signal.aborted).toBe(true);
   });
 
   it("ACP cancel failures do not skip queue and lane cleanup", async () => {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -175,6 +175,7 @@ describe("runReplyAgent onAgentRunStart", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey: "test-agent",
         messageProvider: "webchat",
@@ -429,6 +430,7 @@ describe("runReplyAgent block streaming", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey: "test-agent",
         messageProvider: "discord",
@@ -521,6 +523,7 @@ describe("runReplyAgent block streaming", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey: "test-agent",
         messageProvider: "discord",
@@ -594,6 +597,7 @@ describe("runReplyAgent claude-cli routing", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey: "test-agent",
         messageProvider: "webchat",
@@ -677,6 +681,7 @@ describe("runReplyAgent messaging tool suppression", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey,
         messageProvider,
@@ -1060,6 +1065,7 @@ describe("runReplyAgent reminder commitment guard", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey: "test-agent",
         messageProvider: "telegram",
@@ -1237,6 +1243,7 @@ describe("runReplyAgent transient HTTP retry", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "test-agent",
         sessionId: "session",
         sessionKey: "test-agent",
         messageProvider: "telegram",

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -106,7 +106,7 @@ describe("handleCommands gating", () => {
         commandBody: "/config show",
         makeCfg: () =>
           ({
-            commands: { config: false, debug: false, text: true },
+            commands: { config: false, debug: false, text: true, ownerAllowFrom: ["*"] },
             channels: { whatsapp: { allowFrom: ["*"] } },
           }) as RemoteClawConfig,
         expectedText: "/config is disabled",
@@ -116,7 +116,7 @@ describe("handleCommands gating", () => {
         commandBody: "/debug show",
         makeCfg: () =>
           ({
-            commands: { config: false, debug: false, text: true },
+            commands: { config: false, debug: false, text: true, ownerAllowFrom: ["*"] },
             channels: { whatsapp: { allowFrom: ["*"] } },
           }) as RemoteClawConfig,
         expectedText: "/debug is disabled",
@@ -130,6 +130,9 @@ describe("handleCommands gating", () => {
             config: true,
             debug: true,
           }) as Record<string, unknown>;
+          // Authorize the sender (own property) so the command reaches the gate; the
+          // config/debug flags stay inherited to prove prototype flags do not enable.
+          inheritedCommands.ownerAllowFrom = ["*"];
           return {
             commands: inheritedCommands as never,
             channels: { whatsapp: { allowFrom: ["*"] } },
@@ -146,6 +149,9 @@ describe("handleCommands gating", () => {
             config: true,
             debug: true,
           }) as Record<string, unknown>;
+          // Authorize the sender (own property) so the command reaches the gate; the
+          // config/debug flags stay inherited to prove prototype flags do not enable.
+          inheritedCommands.ownerAllowFrom = ["*"];
           return {
             commands: inheritedCommands as never,
             channels: { whatsapp: { allowFrom: ["*"] } },
@@ -239,8 +245,8 @@ describe("extractMessageText", () => {
       },
       {
         message: { role: "assistant", content: "Here [Tool Call: foo (ID: 1)] ok" },
-        // stripDowngradedToolCallText gutted to no-op in RemoteClaw fork
-        expectedText: "Here [Tool Call: foo (ID: 1)] ok",
+        // assistant text is sanitized: stripDowngradedToolCallText strips the [Tool Call: ...] marker
+        expectedText: "Here ok",
       },
     ] as const;
 
@@ -254,7 +260,7 @@ describe("extractMessageText", () => {
 describe("handleCommands /config configWrites gating", () => {
   it("blocks /config set when channel config writes are disabled", async () => {
     const cfg = {
-      commands: { config: true, text: true },
+      commands: { config: true, text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"], configWrites: false } },
     } as RemoteClawConfig;
     const params = buildParams('/config set messages.ackReaction=":)"', cfg);
@@ -359,6 +365,7 @@ describe("handleCommands /allowlist", () => {
     expect(addChannelAllowFromStoreEntryMock).toHaveBeenCalledWith({
       channel: "telegram",
       entry: "789",
+      accountId: "default",
     });
     expect(result.reply?.text).toContain("DM allowlist added");
   });
@@ -453,7 +460,7 @@ describe("handleCommands plugin commands", () => {
     expect(result.ok).toBe(true);
 
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/card", cfg);
@@ -468,7 +475,7 @@ describe("handleCommands plugin commands", () => {
 describe("handleCommands identity", () => {
   it("returns sender details for /whoami", async () => {
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/whoami", cfg, {
@@ -488,7 +495,7 @@ describe("handleCommands identity", () => {
 describe("handleCommands hooks", () => {
   it("triggers hooks for /new with arguments", async () => {
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/new take notes", cfg);
@@ -540,7 +547,7 @@ describe("handleCommands subagents", () => {
 
   it("lists subagents when none exist", async () => {
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/subagents list", cfg);
@@ -565,7 +572,7 @@ describe("handleCommands subagents", () => {
       startedAt: 1000,
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/subagents list", cfg);
@@ -578,12 +585,16 @@ describe("handleCommands subagents", () => {
     expect(result.reply?.text).not.toContain("after a short hard cutoff.");
   });
 
-  it("lists subagents for the current command session over the target session", async () => {
+  it("prefers the command target session over the current command session for native commands", async () => {
+    // Native commands carry an explicit CommandTargetSessionKey and resolve the
+    // subagent requester to it: resolveRequesterSessionKey's preferCommandTarget
+    // defaults to CommandSource === "native" (upstream sync #2298). So the target
+    // session's subagents are listed, not the current command session's.
     addSubagentRunForTests({
       runId: "run-1",
       childSessionKey: "agent:main:subagent:abc",
-      requesterSessionKey: "agent:main:slack:slash:u1",
-      requesterDisplayKey: "agent:main:slack:slash:u1",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "agent:main:main",
       task: "do thing",
       cleanup: "keep",
       createdAt: 1000,
@@ -600,7 +611,7 @@ describe("handleCommands subagents", () => {
       startedAt: 2000,
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/subagents list", cfg, {
@@ -611,8 +622,9 @@ describe("handleCommands subagents", () => {
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("active subagents:");
+    // Target session's subagent is listed; the current command session's is not.
     expect(result.reply?.text).toContain("do thing");
-    expect(result.reply?.text).not.toContain("\n\n2.");
+    expect(result.reply?.text).not.toContain("another thing");
   });
 
   it("formats subagent usage with io and prompt/cache breakdown", async () => {
@@ -638,7 +650,7 @@ describe("handleCommands subagents", () => {
       };
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
       session: { store: storePath },
     } as RemoteClawConfig;
@@ -709,7 +721,7 @@ describe("handleCommands subagents", () => {
   ])("$name", async ({ seedRuns, verboseLevel, expectedText, unexpectedText }) => {
     seedRuns();
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
       session: { mainKey: "main", scope: "per-sender" },
     } as RemoteClawConfig;
@@ -729,7 +741,7 @@ describe("handleCommands subagents", () => {
 
   it("returns help/usage for invalid or incomplete subagents commands", async () => {
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const cases = [
@@ -759,7 +771,7 @@ describe("handleCommands subagents", () => {
       outcome: { status: "ok" },
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
       session: { mainKey: "main", scope: "per-sender" },
     } as RemoteClawConfig;
@@ -783,7 +795,7 @@ describe("handleCommands subagents", () => {
       startedAt: 1000,
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/kill 1", cfg);
@@ -817,7 +829,7 @@ describe("handleCommands subagents", () => {
       outcome: { status: "ok" },
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/kill 1", cfg);
@@ -854,7 +866,7 @@ describe("handleCommands subagents", () => {
       outcome: { status: "ok" },
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/subagents send 1 continue with follow-up details", cfg);
@@ -909,7 +921,7 @@ describe("handleCommands subagents", () => {
       startedAt: 1000,
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
       session: { store: storePath },
     } as RemoteClawConfig;
@@ -969,7 +981,7 @@ describe("handleCommands subagents", () => {
       startedAt: 1000,
     });
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
     } as RemoteClawConfig;
     const params = buildParams("/steer 1 check timer.ts instead", cfg);
@@ -987,7 +999,7 @@ describe("handleCommands subagents", () => {
 describe("handleCommands /tts", () => {
   it("returns status for bare /tts on text command surfaces", async () => {
     const cfg = {
-      commands: { text: true },
+      commands: { text: true, ownerAllowFrom: ["*"] },
       channels: { whatsapp: { allowFrom: ["*"] } },
       messages: { tts: { prefsPath: path.join(testWorkspaceDir, "tts.json") } },
     } as RemoteClawConfig;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { expectInboundContextContract } from "../../../test/helpers/inbound-contract.js";
 import type { RemoteClawConfig } from "../../config/config.js";
+import * as secureRandom from "../../infra/secure-random.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { MsgContext } from "../templating.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -1439,7 +1440,9 @@ describe("createReplyDispatcher", () => {
 
   it("delays block replies after the first when humanDelay is natural", async () => {
     vi.useFakeTimers();
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    // Natural mode draws the random component from generateSecureInt (crypto),
+    // not Math.random — pin it to 0 so the delay is exactly the 800ms floor.
+    const delaySpy = vi.spyOn(secureRandom, "generateSecureInt").mockReturnValue(0);
     const deliver = vi.fn().mockResolvedValue(undefined);
     const dispatcher = createReplyDispatcher({
       deliver,
@@ -1461,7 +1464,7 @@ describe("createReplyDispatcher", () => {
     await dispatcher.waitForIdle();
     expect(deliver).toHaveBeenCalledTimes(2);
 
-    randomSpy.mockRestore();
+    delaySpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -39,7 +39,7 @@ vi.mock("../../../extensions/signal/src/send.js", () => ({
 vi.mock("../../../extensions/slack/src/send.js", () => ({
   sendMessageSlack: mocks.sendMessageSlack,
 }));
-vi.mock("../../telegram/send.js", () => ({
+vi.mock("../../../extensions/telegram/src/send.js", () => ({
   sendMessageTelegram: mocks.sendMessageTelegram,
 }));
 vi.mock("../../../extensions/whatsapp/src/outbound.js", () => ({
@@ -194,7 +194,14 @@ describe("routeReply", () => {
     );
   });
 
-  it("routes directive-only Slack replies when interactive replies are enabled", async () => {
+  it("routes directive-only Slack replies without dropping them", async () => {
+    // Outbound interactive-reply block rendering ([[slack_select: …]] → Block Kit
+    // `blocks`) was removed from the delivery path in the v2026.4.24 upstream sync
+    // (#2762); only the inbound action-id handling in monitor/{slash,events} remains,
+    // and sendMessageSlack now only accepts caller-supplied `blocks`. routeReply
+    // therefore forwards the directive text verbatim to the Slack send layer. This
+    // guards that a directive-only payload is still routed (not dropped by the
+    // empty-reply guard) even with interactiveReplies enabled.
     mocks.sendMessageSlack.mockClear();
     const cfg = {
       channels: {
@@ -211,15 +218,8 @@ describe("routeReply", () => {
     });
     expect(mocks.sendMessageSlack).toHaveBeenCalledWith(
       "channel:C123",
-      "",
-      expect.objectContaining({
-        blocks: [
-          expect.objectContaining({
-            type: "actions",
-            block_id: "remoteclaw_reply_select_1",
-          }),
-        ],
-      }),
+      "[[slack_select: Choose one | Alpha:alpha]]",
+      expect.objectContaining({ cfg }),
     );
   });
 

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -17,7 +17,7 @@ describe("buildBareSessionResetPrompt", () => {
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(cfg, nowMs);
     expect(prompt).toContain(
-      "Current time: Tuesday, March 3rd, 2026 — 9:00 AM (America/New_York) / 2026-03-03 14:00 UTC",
+      "Current time: Tuesday, March 3rd, 2026 - 9:00 AM (America/New_York)\nReference UTC: 2026-03-03 14:00 UTC",
     );
   });
 

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -172,7 +172,8 @@ describe("buildHelpMessage", () => {
       commands: { config: false, debug: false },
     } as unknown as RemoteClawConfig);
     expect(text).toContain("Session");
-    expect(text).toContain("/skill <name> [input]");
+    expect(text).toContain("Options");
+    expect(text).toContain("/verbose on|off");
     expect(text).not.toContain("/config");
     expect(text).not.toContain("/debug");
   });
@@ -188,7 +189,7 @@ describe("buildCommandsMessagePaginated", () => {
     );
     expect(result.text).toContain("ℹ️ Commands (1/");
     expect(result.text).toContain("Session");
-    expect(result.text).toContain("/stop - Stop the current run.");
+    expect(result.text).toContain("/reset - Reset the current session.");
   });
 
   it("includes plugin commands in the paginated list", () => {

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -165,23 +165,19 @@ export const EXTENSIONS_QUARANTINE: string[] = [
 
 /** Currently-failing test files under `src/auto-reply/**` (run by the `test-auto-reply` lane). */
 export const AUTO_REPLY_QUARANTINE: string[] = [
-  "src/auto-reply/command-control.test.ts",
-  "src/auto-reply/heartbeat-filter.test.ts",
-  "src/auto-reply/inbound.test.ts",
-  "src/auto-reply/reply/abort.test.ts",
-  "src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts",
-  "src/auto-reply/reply/commands-core.test.ts",
-  "src/auto-reply/reply/commands-session-lifecycle.test.ts",
-  "src/auto-reply/reply/commands-subagents-focus.test.ts",
-  "src/auto-reply/reply/commands.test.ts",
-  "src/auto-reply/reply/dispatch-from-config.test.ts",
-  "src/auto-reply/reply/followup-runner.channel-bridge.test.ts",
-  "src/auto-reply/reply/reply-flow.test.ts",
-  "src/auto-reply/reply/reply-media-paths.test.ts",
-  "src/auto-reply/reply/reply-plumbing.test.ts",
-  "src/auto-reply/reply/route-reply.test.ts",
-  "src/auto-reply/reply/session-reset-prompt.test.ts",
-  "src/auto-reply/reply/session.test.ts",
-  "src/auto-reply/reply/strip-inbound-meta.test.ts",
-  "src/auto-reply/status.test.ts",
+  // #2782 (auto-reply batch): 8 of the original 19 were un-quarantined (stale tests
+  // fixed test-side). The 11 below remain — most reveal genuine SOURCE bugs (test
+  // synced ahead of source, or feature gutted) that need a separate security-gated
+  // source PR, not a test-side change. Reasons per line.
+  "src/auto-reply/command-control.test.ts", // #2782: auth-UNIT tests vs fork-diverged command-auth.ts (#2824/#2828) — security-sensitive per-assertion reconciliation deferred to a focused PR
+  "src/auto-reply/inbound.test.ts", // #2782: SOURCE bugs — inbound-context.ts drops GroupSystemPrompt CRLF normalization; mentions.ts buildMentionRegexes lacks ReDoS/safe-regex filtering
+  "src/auto-reply/reply/commands-core.test.ts", // #2782: SOURCE gap — emitResetCommandHooks: before_reset hook swallowed on keyless reset + no *.reset.<ts> archive recovery (deferred source hunk from #2662)
+  "src/auto-reply/reply/commands-session-lifecycle.test.ts", // #2782: SOURCE bug — commands-session.ts uses gutted formatThreadBindingDurationLabel (returns "") → empty duration in /session idle+max-age replies
+  "src/auto-reply/reply/commands-subagents-focus.test.ts", // #2782: SOURCE gap — action-focus.ts/action-unfocus.ts lack the Matrix branch (un-ported D.4 EXTRACT; sibling action-agents.ts already has it)
+  "src/auto-reply/reply/dispatch-from-config.test.ts", // #2782: 12 ACP-dispatch tests obsolete (ACP dispatch gutted in 4fd565bf89f) — belongs in a dedicated stale-test-deletion PR, not this ledger-shrink
+  "src/auto-reply/reply/followup-runner.channel-bridge.test.ts", // #2782: premise gutted in #2377 (followup-runner is a no-op; ChannelBridge wiring moved to agent-runner-execution.ts) — port the assertions there
+  "src/auto-reply/reply/reply-media-paths.test.ts", // #2782: not triaged (delegated agent aborted mid-run) — left quarantined pending investigation
+  "src/auto-reply/reply/reply-plumbing.test.ts", // #2782: SOURCE bug — subagents-utils.ts formatRunLabel missing stripInternalRuntimeContext → internal runtime-context info leak into user-facing subagent labels
+  "src/auto-reply/reply/session.test.ts", // #2782: SOURCE bug — session.ts resolveConversationIdFromTargets gutted to ()=>undefined → /new silently suppressed for all ACP-shaped session keys
+  "src/auto-reply/reply/strip-inbound-meta.test.ts", // #2782: SOURCE bug — strip-inbound-meta.ts:219 never re-strips a timestamp prefix exposed after block removal (upstream 98ea8e244f9 fix not synced)
 ];


### PR DESCRIPTION
## What this is

`vitest.quarantine.ts` is a **debt ledger** wired in #2779: it lists test files
excluded from two required CI lanes (`test-extensions`, `test-auto-reply`)
because they were already failing when the lanes were first made required. #2782
tracks shrinking that ledger back to zero.

This PR is the **auto-reply batch**: it works only the 19 `AUTO_REPLY_QUARANTINE`
entries (repo-root `src/auto-reply/**`). It un-quarantines the ones that were
**stale tests** (fixable test-side) and keeps the rest quarantined with an inline
reason. **Test-side changes only** — the sole non-test file touched is
`vitest.quarantine.ts`. `EXTENSIONS_QUARANTINE` (119 entries) is untouched.

**Result: `test-auto-reply` lane is green — 53 files / 599 tests pass, 0 fail.**

## Un-quarantined: 8 of 19 (all stale tests, updated to match current shipped behavior)

Each fix updates the test's expectation/mock to the source's **current** behavior
(a deliberate gut / rebrand / upstream-sync change), proven against the source;
no assertion was weakened to a vacuous pass.

| File | Why it was failing (stale) |
|------|----------------------------|
| `session-reset-prompt.test.ts` | Date format changed upstream (#2829): hyphen + two-line `Reference UTC`. |
| `status.test.ts` | `/skill` gutted (skills marketplace removed); `/stop` chat-command removed (#2134/#2280). Asserts current help/commands output. |
| `heartbeat-filter.test.ts` | Fork gutted `HEARTBEAT_PROMPT` to `""` (#281); heartbeat prompt is now caller-provided. Test uses a resolved-prompt sample. |
| `reply-flow.test.ts` | `getHumanDelay` moved `Math.random` → crypto `generateSecureInt` (v2026.3.31), so the old spy was a no-op → the timing test hung. Spy re-pointed; deterministic. |
| `route-reply.test.ts` | Slack Block Kit outbound renderer removed (v2026.4.24 #2762); Telegram send ported to `extensions/` so the mock path was stale. |
| `abort.test.ts` | ACP-cancel path was gutted; abort now terminates via `killSessionRun` (deliberate, #2343/#2462). Asserts the current termination contract. |
| `agent-runner.misc.runreplyagent.test.ts` | `followupRun.run.agentId` is now a **required** field on the reply path (missing → "Agent failed before reply"). Fixtures updated. |
| `commands.test.ts` | Owner-enforcement is now active for the whatsapp default provider (#2824), so fixtures must authorize the sender; plus native commands now prefer `CommandTargetSessionKey` (#2298). |

## Re-quarantined: 11 of 19 (kept in the ledger with inline reasons)

These are **not** test-side fixable. Most are **dropped-port desyncs**: the fork's
content-only DIFF-SYNCs pulled the *test* files ahead of their *source*
counterparts (or gutted the source), so the test correctly asserts the intended
behavior and the **source** is what's wrong or missing. Fixing them is a source
runtime change → belongs in a separate, security-gated PR, not a test-ledger shrink.

**Reveal a genuine SOURCE bug (see next section):**
`inbound.test.ts`, `reply-plumbing.test.ts`, `strip-inbound-meta.test.ts`,
`session.test.ts`, `commands-session-lifecycle.test.ts`, `commands-core.test.ts`.

**Obsolete premise (feature gutted / not-yet-ported) — the test, not the source, is the debt:**
- `followup-runner.channel-bridge.test.ts` — followup-runner was gutted to a no-op (#2377); the ChannelBridge wiring these 13 tests assert moved to `agent-runner-execution.ts`. The assertions should be ported there (separate test PR).
- `dispatch-from-config.test.ts` — 12 ACP-dispatch tests assert dispatch code gutted in `4fd565bf89f`. Deleting stale-feature tests is an established repo pattern, but 12 deletions belong in a dedicated reviewed PR, not this ledger-shrink.
- `commands-subagents-focus.test.ts` — `action-focus.ts`/`action-unfocus.ts` lack a Matrix branch (deferred D.4 EXTRACT port; sibling `action-agents.ts` already has Matrix).

**Deferred (not re-triaged here):**
- `command-control.test.ts` — pure command-**authorization** unit tests against the fork's deliberately-diverged `command-auth.ts` (#2824/#2828). Reconciling each assertion is security-sensitive and belongs in a focused PR; not weakened here.
- `reply-media-paths.test.ts` — not triaged in this batch; left quarantined.

## Discovered SOURCE bugs (need separate source PRs — not fixed here)

Surfaced while triaging the re-quarantined files. Ordered by severity.

1. **SECURITY / ReDoS — `src/auto-reply/reply/mentions.ts` `buildMentionRegexes`.** Config mention patterns are compiled with a bare `try { new RegExp(p,"i") } catch {}`, which only drops *compile-invalid* patterns, not catastrophic-backtracking ones — `(a+)+$` survives. These regexes run against attacker-controlled inbound text (`matchesMentionPatterns`/`stripMentions`) → a ReDoS DoS vector. Upstream routes this through a safe-regex compiler (`compileConfigRegexes`, rejects `unsafe-nested-repetition`); the fork even ships `src/security/safe-regex.ts` it should use. (Caught by `inbound.test.ts`.)
2. **PRIVACY leak — `src/auto-reply/reply/subagents-utils.ts` `formatRunLabel`.** Emits internal runtime-context markers + a "Keep internal details private." notice verbatim into user-facing subagent labels (shown via `/subagents list`, `/focus`, target resolution); missing `stripInternalRuntimeContext(...)` sanitization. Empirically, `stripInternalRuntimeContext(label).trim() || "subagent"` yields the test's expected `"subagent"`. Label content is agent-controllable. (Caught by `reply-plumbing.test.ts`.)
3. **PRIVACY leak — `src/auto-reply/reply/strip-inbound-meta.ts:219`.** `LEADING_TIMESTAMP_PREFIX_RE` is applied only once, *before* metadata-block removal; a timestamp that becomes leading only *after* a block is stripped survives, so an AI-facing `[Thu 2026-03-12 07:00 UTC]` envelope leaks into user-visible chat. Upstream `98ea8e244f9` shipped test+fix together; the fork synced the test only. Fix: append `.replace(LEADING_TIMESTAMP_PREFIX_RE, "")` at the return. (Caught by `strip-inbound-meta.test.ts`.)
4. **CORRECTNESS regression — `src/auto-reply/reply/session.ts` `resolveConversationIdFromTargets`.** Gutted to `() => undefined` (module deleted in `36923449126`), so `resolveAcpResetBindingContext` is always null → `shouldUseAcpInPlaceReset` is true for **every** ACP-shaped session key → `/new` is silently suppressed for all of them (including unbound / non-ACP-bound keys), when it should be a rare edge. (Caught by `session.test.ts`.)
5. **FUNCTIONAL — `src/auto-reply/reply/inbound-context.ts` `finalizeInboundContext`.** Normalizes `Body`/`RawBody`/… CRLF but **not** `GroupSystemPrompt` (which is live via `get-reply-run.ts`). Upstream's `normalizeTrustedTextField` + the `GroupSystemPrompt` line were dropped in a sync. (Caught by `inbound.test.ts`.)
6. **FUNCTIONAL — `src/auto-reply/reply/commands-core.ts` `emitResetCommandHooks`.** The `before_reset` memory-extraction hook is silently swallowed for keyless resets (unguarded throwing `resolveAgentIdFromSessionKey`), and there is no `readdir`-based `*.reset.<ts>` archive-recovery path — both are live/config-supported behaviors. The #2662 sync updated the test but deferred the source hunk. (Caught by `commands-core.test.ts`.)
7. **UX defect — `src/auto-reply/reply/commands-session.ts`.** Builds `/session idle` / `/session max-age` replies via the **gutted** `formatThreadBindingDurationLabel` Discord stub (returns `""`), shipping a visible empty gap ("set to  for 1 binding"). Should use the middleware-owned `formatDurationCompact`/`formatDurationHuman`. (Caught by `commands-session-lifecycle.test.ts`.)

**Non-blocking advisory:** a *graceful* ACP protocol-level `session/cancel` is a feature gap left by the ACP control-plane-manager gut — the run is still terminated by `killSessionRun`, so this is **not** a bug, just worth tracking.

## Scope

- **Addresses #2782 (auto-reply batch); the 119 `extensions/**` entries remain → #2782 stays OPEN (the extensions/** ledger is not addressed here).**
- `test-auto-reply` lane green; still fails CI on any NEW breakage in the 53 non-quarantined files.
- Known unrelated CI flake: `test-ui-smoke`.

