### PR TITLE
test(slack): cover assistant DM message_changed rehydration + self-event filter (#2425)

### DIFF
--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -62,6 +62,26 @@ function makeChangedEvent(overrides?: { channel?: string; user?: string }) {
   };
 }
 
+function makeAssistantChangedEvent(overrides?: { user?: string }) {
+  const user = overrides?.user ?? "UREAL123";
+  return {
+    type: "message",
+    subtype: "message_changed",
+    channel: "D1",
+    channel_type: "im",
+    user: "U_BOT",
+    message: {
+      ts: "123.456",
+      thread_ts: "123.000",
+      user: "U_BOT",
+      text: "assistant wrapped user text",
+      metadata: { event_payload: { user } },
+    },
+    previous_message: { ts: "123.456", user: "U_BOT" },
+    event_ts: "123.789",
+  };
+}
+
 function makeDeletedEvent(overrides?: { channel?: string; user?: string }) {
   return {
     type: "message",
@@ -175,6 +195,42 @@ describe("registerSlackMessageEvents", () => {
   it.each(cases)("$name", async ({ input, calls }) => {
     await runMessageCase(input);
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
+  });
+
+  it("rehydrates assistant DM message_changed events with a metadata user as inbound messages", async () => {
+    const { handleSlackMessage } = await invokeRegisteredHandler({
+      eventName: "message",
+      overrides: { dmPolicy: "open" },
+      event: makeAssistantChangedEvent(),
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    expect(handleSlackMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "D1",
+        channel_type: "im",
+        user: "UREAL123",
+        text: "assistant wrapped user text",
+        ts: "123.456",
+        thread_ts: "123.000",
+      }),
+      { source: "message" },
+    );
+    expect(messageQueueMock).not.toHaveBeenCalled();
+  });
+
+  it("drops self-authored message_changed events without assistant sender metadata", async () => {
+    const { handleSlackMessage } = await invokeRegisteredHandler({
+      eventName: "message",
+      overrides: { dmPolicy: "open" },
+      event: {
+        ...makeAssistantChangedEvent(),
+        message: { ts: "123.456", user: "U_BOT", text: "preview edit" },
+      },
+    });
+
+    expect(handleSlackMessage).not.toHaveBeenCalled();
+    expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
   it("passes regular message events to the message handler", async () => {

--- a/extensions/slack/src/monitor/provider-support.self-filter.test.ts
+++ b/extensions/slack/src/monitor/provider-support.self-filter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { shouldSkipRemoteClawSlackSelfEvent } from "./provider-support.js";
+
+// The Bolt app is created with `ignoreSelf: false` and a global middleware that
+// calls `shouldSkipRemoteClawSlackSelfEvent` (see createSlackBoltApp). Dropping
+// every self-attributed event would swallow the assistant DM `message_changed`
+// edits that carry a real human sender in `metadata.event_payload.user`, so the
+// self-filter is deliberately scoped: it skips genuine bot noise but keeps the
+// message_changed passthrough. These cases pin that scoping.
+const CONTEXT = { botUserId: "U_BOT", botId: "B_BOT" };
+
+describe("shouldSkipRemoteClawSlackSelfEvent", () => {
+  it("skips self-authored reaction_added events", () => {
+    expect(
+      shouldSkipRemoteClawSlackSelfEvent({
+        context: CONTEXT,
+        event: { type: "reaction_added", user: "U_BOT" },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps self-authored message_changed events (assistant DM edit passthrough)", () => {
+    expect(
+      shouldSkipRemoteClawSlackSelfEvent({
+        context: CONTEXT,
+        event: { type: "message", subtype: "message_changed", user: "U_BOT" },
+      }),
+    ).toBe(false);
+  });
+
+  it("skips self-authored plain message events", () => {
+    expect(
+      shouldSkipRemoteClawSlackSelfEvent({
+        context: CONTEXT,
+        event: { type: "message", user: "U_BOT" },
+      }),
+    ).toBe(true);
+  });
+
+  it("skips bot_message events authored by our own bot_id", () => {
+    expect(
+      shouldSkipRemoteClawSlackSelfEvent({
+        context: CONTEXT,
+        event: { type: "message", user: "U_OTHER" },
+        message: { subtype: "bot_message", bot_id: "B_BOT" },
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

**Closes #2425.**

### The bug (inlined — no external context needed)
Slack's **Assistant** API does not deliver a real human's DM as a normal `message` event. Instead it delivers it as a `message_changed` event **attributed to the bot's own user id** (the assistant "wraps" the user's text). The real human sender is buried in `message.metadata.event_payload.user` (or, in some payload shapes, `message.blocks[].elements[].user_id`). Because the top-level and `message.user` fields point at the bot, the fork's ingress path was treating these as self-events and dropping them as `sender-not-allowlisted` — silently losing **~50%** of real user messages in Assistant DMs.

The upstream OpenClaw fix is two commits:
- `893a18ff5c` — *accept assistant dm message edits* (extract the real sender from `metadata.event_payload.user`, rehydrate the `message_changed` as an inbound `message`).
- `2a4fa8ffe8` — *scope assistant self-event bypass* (the Bolt app runs with `ignoreSelf: false` + a global self-filter that skips genuine bot noise **but keeps** self `message_changed` so the assistant-edit passthrough survives).

### The gap this PR closes
**The fix is already present in the fork** — it was carried in by the routine v5.27 content-only upstream sync (the fix commit is an ancestor of the fork's frozen upstream endpoint):
- `extensions/slack/src/monitor/events/messages.ts` — `resolveAssistantMessageChangedSender` / `isSelfAttributedMessageChange` / `resolveAssistantMessageChangedInbound`, wired into `registerSlackMessageEvents`.
- `extensions/slack/src/monitor/provider-support.ts` — `ignoreSelf: false` + `app.use(...)` calling the (rebrand-renamed) exported `shouldSkipRemoteClawSlackSelfEvent`.

But the sync **dropped the paired tests**: the fork's `messages.test.ts` covered only the `message_changed` *authorization* branch (dmPolicy), not the assistant-DM *extraction* path, and `shouldSkipRemoteClawSlackSelfEvent` had **zero** test references. This PR ports those dropped tests so the already-present fix is locked in against regression, and so the tests *prove* the synced source behaves correctly.

## Changes (test-only — no source touched)

**`extensions/slack/src/monitor/events/messages.test.ts`** — adds a `makeAssistantChangedEvent` helper + 2 cases:
- *rehydrates assistant DM `message_changed` events with a metadata user as inbound messages* — the real sender (`UREAL123`) is extracted from `metadata.event_payload.user` and delivered to `handleSlackMessage` as an `im` message; no system event enqueued.
- *drops self-authored `message_changed` events without assistant sender metadata* — a genuine bot preview-edit (no `event_payload`) is dropped; neither the message handler nor the system-event queue fires.

**`extensions/slack/src/monitor/provider-support.self-filter.test.ts`** (new) — 4 cases pinning `shouldSkipRemoteClawSlackSelfEvent` scoping:
- self `reaction_added` → **skip** (`true`)
- self `message_changed` → **KEEP** (`false`) — the assistant-edit passthrough
- self plain `message` → **skip** (`true`)
- `bot_message` from our own `bot_id` → **skip** (`true`)

## Verification
- `pnpm install --frozen-lockfile` (fresh worktree).
- Slack extension tests under `vitest.extensions.config.ts`: **16 passed** (10 pre-existing + 6 new) — all 6 new cases pass **against the unmodified fork source**, confirming the synced source matches the upstream fix.
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates): **green**.
- Only `*.test.ts` files changed; no source `.ts` under `extensions/slack/src/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
