### PR TITLE
chore(#2060-residual): add --thinking CLI flag + backfill 3 dropped tests

### DIFF
--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -197,6 +197,14 @@ describe("formatCliCommand", () => {
     ).toBe("remoteclaw --container demo gateway status --deep");
   });
 
+  it("ignores unsafe container hints", () => {
+    // A hint carrying shell metacharacters fails CONTAINER_HINT_RE, so no
+    // --container is injected and the command is returned unchanged.
+    expect(
+      formatCliCommand("remoteclaw doctor", { REMOTECLAW_CONTAINER_HINT: "demo; rm -rf /" }),
+    ).toBe("remoteclaw doctor");
+  });
+
   it("preserves both --container and --profile hints", () => {
     expect(
       formatCliCommand("remoteclaw doctor", {

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -103,6 +103,13 @@ describe("registerAgentCommands", () => {
     expect(deps).toEqual({ deps: true });
   });
 
+  it("forwards the --thinking level to the agent command", async () => {
+    await runCli(["agent", "--message", "hi", "--thinking", "high"]);
+
+    const [options] = commandCall(agentCliCommandMock);
+    expect((options as { thinking?: string }).thinking).toBe("high");
+  });
+
   it("runs agents add and computes hasFlags based on explicit options", async () => {
     await runCli(["agents", "add", "alpha"]);
     const [alphaOptions, alphaRuntime, alphaFlags] = commandCall(agentsAddCommandMock, 0);

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -27,6 +27,10 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-id <id>", "Use an explicit session id")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
+    .option(
+      "--thinking <level>",
+      "Thinking level: off|minimal|low|medium|high|xhigh|adaptive|max where supported",
+    )
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
       "--channel <channel>",

--- a/src/infra/network-discovery-display.test.ts
+++ b/src/infra/network-discovery-display.test.ts
@@ -1,0 +1,82 @@
+import os from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
+import {
+  inspectBestEffortPrimaryTailnetIPv4,
+  pickBestEffortPrimaryLanIPv4,
+  resolveBestEffortGatewayBindHostForDisplay,
+} from "./network-discovery-display.js";
+
+describe("network discovery display", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockInterfaceDiscoveryThrows(message = "interface discovery failed") {
+    vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+      throw new Error(message);
+    });
+  }
+
+  describe("pickBestEffortPrimaryLanIPv4", () => {
+    it("returns the primary LAN IPv4 when discovery succeeds", () => {
+      vi.spyOn(os, "networkInterfaces").mockReturnValue(
+        makeNetworkInterfacesSnapshot({
+          lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+          en0: [{ address: "192.168.1.50", family: "IPv4" }],
+        }),
+      );
+
+      expect(pickBestEffortPrimaryLanIPv4()).toBe("192.168.1.50");
+    });
+
+    it("returns undefined when interface discovery throws", () => {
+      mockInterfaceDiscoveryThrows();
+
+      expect(pickBestEffortPrimaryLanIPv4()).toBeUndefined();
+    });
+  });
+
+  describe("inspectBestEffortPrimaryTailnetIPv4", () => {
+    it("returns the primary tailnet IPv4 without a warning when discovery succeeds", () => {
+      vi.spyOn(os, "networkInterfaces").mockReturnValue(
+        makeNetworkInterfacesSnapshot({
+          utun1: [{ address: "100.88.1.5", family: "IPv4" }],
+        }),
+      );
+
+      expect(inspectBestEffortPrimaryTailnetIPv4()).toEqual({ tailnetIPv4: "100.88.1.5" });
+    });
+
+    it("formats a prefixed warning when discovery throws", () => {
+      mockInterfaceDiscoveryThrows();
+
+      expect(inspectBestEffortPrimaryTailnetIPv4({ warningPrefix: "tailnet check" })).toEqual({
+        tailnetIPv4: undefined,
+        warning: "tailnet check: interface discovery failed.",
+      });
+    });
+
+    it("omits the warning when discovery throws but no prefix is provided", () => {
+      mockInterfaceDiscoveryThrows();
+
+      expect(inspectBestEffortPrimaryTailnetIPv4()).toEqual({ tailnetIPv4: undefined });
+    });
+  });
+
+  describe("resolveBestEffortGatewayBindHostForDisplay", () => {
+    it("falls back to the tailnet loopback host with a warning when discovery throws", async () => {
+      mockInterfaceDiscoveryThrows();
+
+      const result = await resolveBestEffortGatewayBindHostForDisplay({
+        bindMode: "tailnet",
+        warningPrefix: "bind check",
+      });
+
+      expect(result).toEqual({
+        bindHost: "127.0.0.1",
+        warning: "bind check: interface discovery failed.",
+      });
+    });
+  });
+});

--- a/src/infra/network-interfaces.test.ts
+++ b/src/infra/network-interfaces.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { makeNetworkInterfacesSnapshot } from "../test-helpers/network-interfaces.js";
+import {
+  listExternalInterfaceAddresses,
+  pickMatchingExternalInterfaceAddress,
+  readNetworkInterfaces,
+  safeNetworkInterfaces,
+  type NetworkInterfacesSnapshot,
+} from "./network-interfaces.js";
+
+describe("readNetworkInterfaces", () => {
+  it("returns the injected provider's snapshot", () => {
+    const snapshot = makeNetworkInterfacesSnapshot({
+      en0: [{ address: "192.168.1.50", family: "IPv4" }],
+    });
+    expect(readNetworkInterfaces(() => snapshot)).toBe(snapshot);
+  });
+});
+
+describe("safeNetworkInterfaces", () => {
+  it("returns the snapshot when the provider succeeds", () => {
+    const snapshot = makeNetworkInterfacesSnapshot({
+      en0: [{ address: "192.168.1.50", family: "IPv4" }],
+    });
+    expect(safeNetworkInterfaces(() => snapshot)).toBe(snapshot);
+  });
+
+  it("returns undefined when the provider throws", () => {
+    expect(
+      safeNetworkInterfaces(() => {
+        throw new Error("interface discovery failed");
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("listExternalInterfaceAddresses", () => {
+  it("returns an empty list for an undefined snapshot", () => {
+    expect(listExternalInterfaceAddresses(undefined)).toEqual([]);
+  });
+
+  it("skips internal interfaces and returns name/address/family for external ones", () => {
+    const snapshot = makeNetworkInterfacesSnapshot({
+      lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+      en0: [
+        { address: "192.168.1.50", family: "IPv4" },
+        { address: "fe80::1", family: "IPv6" },
+      ],
+    });
+
+    expect(listExternalInterfaceAddresses(snapshot)).toEqual([
+      { name: "en0", address: "192.168.1.50", family: "IPv4" },
+      { name: "en0", address: "fe80::1", family: "IPv6" },
+    ]);
+  });
+
+  it("filters by family and trims addresses, skipping blank ones", () => {
+    const snapshot = makeNetworkInterfacesSnapshot({
+      en0: [
+        { address: "  ", family: "IPv4" },
+        { address: " 10.0.0.9 ", family: "IPv4" },
+        { address: "fe80::2", family: "IPv6" },
+      ],
+    });
+
+    expect(listExternalInterfaceAddresses(snapshot, "IPv4")).toEqual([
+      { name: "en0", address: "10.0.0.9", family: "IPv4" },
+    ]);
+  });
+
+  it("normalizes numeric interface families and skips unknown ones", () => {
+    // os.networkInterfaces() historically reported family as a number (4/6);
+    // the module normalizes those and drops anything it cannot classify.
+    const snapshot = {
+      en0: [
+        { address: "192.168.1.7", family: 4, internal: false },
+        { address: "203.0.113.9", family: 7, internal: false },
+      ],
+    } as unknown as NetworkInterfacesSnapshot;
+
+    expect(listExternalInterfaceAddresses(snapshot)).toEqual([
+      { name: "en0", address: "192.168.1.7", family: "IPv4" },
+    ]);
+  });
+});
+
+describe("pickMatchingExternalInterfaceAddress", () => {
+  const snapshot = makeNetworkInterfacesSnapshot({
+    lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+    eth0: [{ address: "10.0.0.5", family: "IPv4" }],
+    en0: [{ address: "192.168.1.50", family: "IPv4" }],
+  });
+
+  it("prefers addresses from preferredNames in order", () => {
+    expect(
+      pickMatchingExternalInterfaceAddress(snapshot, {
+        family: "IPv4",
+        preferredNames: ["en0", "eth0"],
+      }),
+    ).toBe("192.168.1.50");
+  });
+
+  it("falls back to the first external address when no preferred name matches", () => {
+    expect(pickMatchingExternalInterfaceAddress(snapshot, { family: "IPv4" })).toBe("10.0.0.5");
+  });
+
+  it("applies the matches predicate", () => {
+    expect(
+      pickMatchingExternalInterfaceAddress(snapshot, {
+        family: "IPv4",
+        matches: (address) => address.startsWith("192."),
+      }),
+    ).toBe("192.168.1.50");
+  });
+
+  it("returns undefined when nothing matches the requested family", () => {
+    expect(pickMatchingExternalInterfaceAddress(snapshot, { family: "IPv6" })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Two small, independent, additive residuals from a divergence-reconciliation audit (#2060). No behavior trade-offs, no source-logic risk. PART A touches one source file (`register.agent.ts`) plus its test; PART B is test-only.

## A — surface the existing `--thinking` plumbing on the `agent` CLI command

The gateway already accepts a `thinking` level end-to-end, but the CLI never let you set it:

- `src/commands/agent-via-gateway.ts` forwards `thinking: opts.thinking` in the gateway `agent` request.
- `AgentCliOpts` already declares `thinking?: string`.
- The gateway request schema (`src/gateway/protocol/schema/agent.ts`) already accepts `thinking` as `Type.Optional(Type.String())` — `xhigh` and the other levels are accepted, so **no schema change**.

…but `src/cli/program/register.agent.ts` registered no `--thinking` option, so the field was accepted-and-forwarded yet unreachable from the CLI. This adds:

```ts
.option(
  "--thinking <level>",
  "Thinking level: off|minimal|low|medium|high|xhigh|adaptive|max where supported",
)
```

The command action already passes the parsed `opts` straight into `agentCliCommand`, so the value flows with no other wiring. Scoped to `--thinking` only — `--model` / `--session-key` are deliberately **not** added, because `agent-via-gateway.ts` does not read them and they would be inert. A `register.agent` test asserts the parsed value reaches the command.

## B — backfill 3 dropped tests for live-but-untested fork source (test-only)

Each module is already live in the fork; only the tests were dropped in an upstream sync. These lock in existing behavior — **no source change**.

1. **`src/cli/profile.test.ts` — unsafe container-hint rejection (security-relevant).** The `formatCliCommand` suite had 3 of 4 container-hint cases; the missing one asserts that a hint carrying shell metacharacters (`REMOTECLAW_CONTAINER_HINT="demo; rm -rf /"`) fails `CONTAINER_HINT_RE` and leaves the command unchanged (no `--container` injection).
2. **`src/infra/network-discovery-display.test.ts` (new).** Covers the best-effort error branches of `pickBestEffortPrimaryLanIPv4` / `inspectBestEffortPrimaryTailnetIPv4` / `resolveBestEffortGatewayBindHostForDisplay` (interface-discovery throw → `undefined` / warning / fallback host), plus success paths. Uses the existing `src/test-helpers/network-interfaces.ts` snapshot helper and the established `vi.spyOn(os, "networkInterfaces")` pattern.
3. **`src/infra/network-interfaces.test.ts` (new).** The module (`safeNetworkInterfaces`, `listExternalInterfaceAddresses`, `pickMatchingExternalInterfaceAddress`, `readNetworkInterfaces` — consumed by `src/gateway/net.ts` + `src/infra/tailnet.ts`) had no test file. Adds focused coverage of internal-interface filtering, address trimming / blank-skip, family filtering + numeric-family normalization, and preferred-name selection.

All four files run in the core `test` unit lane (`vitest.unit.config.ts` includes `src/cli/**` and `src/infra/**`, and excludes neither).

## Verification

- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates): green.
- Full unit lane (`vitest.unit.config.ts`): 9794 passed / 42 skipped, 0 failed.
- The 4 changed/new test files pass against unmodified source (55 tests).

Closes #2935
Closes #2936
