### PR TITLE
fix(auto-reply): 5 kept-layer correctness fixes + un-quarantine paired tests

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.messages.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.messages.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+
+describe("formatThreadBindingDurationLabel (#2932)", () => {
+  it("formats a millisecond duration as a compact label", () => {
+    expect(formatThreadBindingDurationLabel(2 * 60 * 60 * 1000)).toBe("2h");
+    expect(formatThreadBindingDurationLabel(90 * 60 * 1000)).toBe("1h30m");
+    expect(formatThreadBindingDurationLabel(45 * 1000)).toBe("45s");
+  });
+
+  it("returns an empty string for missing/zero durations", () => {
+    expect(formatThreadBindingDurationLabel(0)).toBe("");
+    expect(formatThreadBindingDurationLabel(undefined)).toBe("");
+    expect(formatThreadBindingDurationLabel(null)).toBe("");
+  });
+});

--- a/extensions/discord/src/monitor/thread-bindings.messages.ts
+++ b/extensions/discord/src/monitor/thread-bindings.messages.ts
@@ -1,5 +1,10 @@
+import { formatDurationCompact } from "../../../../src/infra/format-time/format-duration.js";
+
+// Compact duration label for /session idle + max-age confirmations (e.g. "24h"). See #2932.
+export const formatThreadBindingDurationLabel = (durationMs?: number | null): string =>
+  formatDurationCompact(durationMs) ?? "";
+
 // Gutted in RemoteClaw fork (Middleware Boundary Principle) — thread-bindings-messages removed
-export const formatThreadBindingDurationLabel = (..._args: unknown[]) => "" as string;
 export const resolveThreadBindingFarewellText = (..._args: unknown[]) => "" as string;
 export const resolveThreadBindingIntroText = (..._args: unknown[]) => "" as string;
 export const resolveThreadBindingThreadName = (..._args: unknown[]) => "" as string;

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveAgentIdFromSessionKeyOrNull } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAllowlistCommand } from "./commands-allowlist.js";
@@ -35,6 +36,41 @@ import { routeReply } from "./route-reply.js";
 let HANDLERS: CommandHandler[] | null = null;
 
 export type ResetCommandAction = "new" | "reset";
+
+// The reset flow archives the previous transcript to `<file>.reset.<ts>` before before_reset
+// reads it. Recover the most recent archive so an archived reset still extracts memory (#2931).
+async function findArchivedResetTranscript(sessionFile: string): Promise<string | null> {
+  const dir = path.dirname(sessionFile);
+  const prefix = `${path.basename(sessionFile)}.reset.`;
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return null;
+  }
+  const latest = entries
+    .filter((name) => name.startsWith(prefix))
+    .toSorted()
+    .at(-1);
+  return latest ? path.join(dir, latest) : null;
+}
+
+async function readResetTranscript(
+  sessionFile: string,
+): Promise<{ sessionFile: string; content: string }> {
+  try {
+    return { sessionFile, content: await fs.readFile(sessionFile, "utf-8") };
+  } catch (readErr: unknown) {
+    if ((readErr as { code?: unknown })?.code !== "ENOENT") {
+      throw readErr;
+    }
+    const archived = await findArchivedResetTranscript(sessionFile);
+    if (!archived) {
+      throw readErr;
+    }
+    return { sessionFile: archived, content: await fs.readFile(archived, "utf-8") };
+  }
+}
 
 export async function emitResetCommandHooks(params: {
   action: ResetCommandAction;
@@ -91,9 +127,11 @@ export async function emitResetCommandHooks(params: {
     void (async () => {
       try {
         const messages: unknown[] = [];
-        if (sessionFile) {
-          const content = await fs.readFile(sessionFile, "utf-8");
-          for (const line of content.split("\n")) {
+        let resolvedSessionFile = sessionFile;
+        if (resolvedSessionFile) {
+          const transcript = await readResetTranscript(resolvedSessionFile);
+          resolvedSessionFile = transcript.sessionFile;
+          for (const line of transcript.content.split("\n")) {
             if (!line.trim()) {
               continue;
             }
@@ -110,9 +148,9 @@ export async function emitResetCommandHooks(params: {
           logVerbose("before_reset: no session file available, firing hook with empty messages");
         }
         await hookRunner.runBeforeReset(
-          { sessionFile, messages, reason: params.action },
+          { sessionFile: resolvedSessionFile, messages, reason: params.action },
           {
-            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+            agentId: resolveAgentIdFromSessionKeyOrNull(params.sessionKey) ?? "main",
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/inbound-context.test.ts
+++ b/src/auto-reply/reply/inbound-context.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { finalizeInboundContext } from "./inbound-context.js";
+
+describe("finalizeInboundContext GroupSystemPrompt normalization (#2930)", () => {
+  it("normalizes CRLF/CR to LF without rewriting trusted [Assistant]/System: markers", () => {
+    const out = finalizeInboundContext({
+      Body: "hello",
+      GroupSystemPrompt: "[Assistant] room guidance\r\nSystem: owner instruction\rmore",
+    } as MsgContext);
+
+    expect(out.GroupSystemPrompt).toBe(
+      "[Assistant] room guidance\nSystem: owner instruction\nmore",
+    );
+  });
+
+  it("leaves a missing (non-string) GroupSystemPrompt untouched", () => {
+    const out = finalizeInboundContext({ Body: "hi" } as MsgContext);
+    expect(out.GroupSystemPrompt).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -55,6 +55,12 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
     normalized.UntrustedContext = normalizedUntrusted;
   }
 
+  if (typeof normalized.GroupSystemPrompt === "string") {
+    // Trusted operator config: normalize newlines only. Do NOT sanitizeInboundSystemTags —
+    // its [Assistant]/System: markers must be preserved verbatim (#2930).
+    normalized.GroupSystemPrompt = normalizeInboundTextNewlines(normalized.GroupSystemPrompt);
+  }
+
   const chatType = normalizeChatType(normalized.ChatType);
   if (chatType && (opts.forceChatType || normalized.ChatType !== chatType)) {
     normalized.ChatType = chatType;

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { stripStructuralPrefixes } from "./mentions.js";
+import type { MsgContext } from "../templating.js";
+import { buildMentionRegexes, stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
 describe("stripStructuralPrefixes", () => {
   it("returns empty string for undefined input at runtime", () => {
@@ -16,5 +17,22 @@ describe("stripStructuralPrefixes", () => {
 
   it("passes through plain text", () => {
     expect(stripStructuralPrefixes("just a message")).toBe("just a message");
+  });
+});
+
+describe("mention-pattern ReDoS safety (#2927)", () => {
+  it("buildMentionRegexes drops catastrophic-backtracking and invalid patterns, keeps safe ones", () => {
+    const regexes = buildMentionRegexes({
+      messages: { groupChat: { mentionPatterns: ["\\bbot\\b", "(a+)+$", "(invalid"] } },
+    });
+    expect(regexes).toHaveLength(1);
+    expect(regexes[0]?.test("bot")).toBe(true);
+  });
+
+  it("stripMentions ignores an unsafe configured pattern instead of running it", () => {
+    const stripped = stripMentions(`bot ${"a".repeat(30)}!`, {} as MsgContext, {
+      messages: { groupChat: { mentionPatterns: ["\\bbot\\b", "(a+)+$"] } },
+    });
+    expect(stripped).toBe(`${"a".repeat(30)}!`);
   });
 });

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -2,6 +2,7 @@ import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import type { RemoteClawConfig } from "../../config/config.js";
+import { compileSafeRegex } from "../../security/safe-regex.js";
 import { escapeRegExp } from "../../utils.js";
 import type { MsgContext } from "../templating.js";
 
@@ -65,13 +66,7 @@ export function buildMentionRegexes(cfg: RemoteClawConfig | undefined, agentId?:
     return [...cached];
   }
   const compiled = patterns
-    .map((pattern) => {
-      try {
-        return new RegExp(pattern, "i");
-      } catch {
-        return null;
-      }
-    })
+    .map((pattern) => compileSafeRegex(pattern, "i"))
     .filter((value): value is RegExp => Boolean(value));
   mentionRegexCompileCache.set(cacheKey, compiled);
   if (mentionRegexCompileCache.size > MAX_MENTION_REGEX_COMPILE_CACHE_KEYS) {
@@ -158,11 +153,9 @@ export function stripMentions(
     ...(providerMentions?.stripPatterns?.({ ctx, cfg, agentId }) ?? []),
   ]);
   for (const p of patterns) {
-    try {
-      const re = new RegExp(p, "gi");
+    const re = compileSafeRegex(p, "gi");
+    if (re) {
       result = result.replace(re, " ");
-    } catch {
-      // ignore invalid regex
     }
   }
   if (providerMentions?.stripMentions) {

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -216,7 +216,13 @@ export function stripInboundMetadata(text: string): string {
     result.push(line);
   }
 
-  return result.join("\n").replace(/^\n+/, "").replace(/\n+$/, "");
+  // Re-strip a leading timestamp envelope that only becomes leading after the
+  // metadata blocks above are removed (e.g. backfilled CLI history). See #2928.
+  return result
+    .join("\n")
+    .replace(/^\n+/, "")
+    .replace(/\n+$/, "")
+    .replace(LEADING_TIMESTAMP_PREFIX_RE, "");
 }
 
 export function stripLeadingInboundMetadata(text: string): string {

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -165,19 +165,19 @@ export const EXTENSIONS_QUARANTINE: string[] = [
 
 /** Currently-failing test files under `src/auto-reply/**` (run by the `test-auto-reply` lane). */
 export const AUTO_REPLY_QUARANTINE: string[] = [
-  // #2782 (auto-reply batch): 8 of the original 19 were un-quarantined (stale tests
-  // fixed test-side). The 11 below remain — most reveal genuine SOURCE bugs (test
-  // synced ahead of source, or feature gutted) that need a separate security-gated
-  // source PR, not a test-side change. Reasons per line.
+  // #2782 (auto-reply batch): 10 of the original 19 are now un-quarantined (8 stale tests
+  // fixed test-side; strip-inbound-meta + commands-core after fixing #2928/#2931). The 9
+  // below remain — most reveal genuine SOURCE bugs (test synced ahead of source, or feature
+  // gutted) that need a separate security-gated source PR, not a test-side change. Reasons
+  // per line. inbound + commands-session-lifecycle had their named SOURCE bug fixed in the
+  // #2927/#2930/#2932 PR but stay here on UNRELATED pre-existing fails (see per-line notes).
   "src/auto-reply/command-control.test.ts", // #2782: auth-UNIT tests vs fork-diverged command-auth.ts (#2824/#2828) — security-sensitive per-assertion reconciliation deferred to a focused PR
-  "src/auto-reply/inbound.test.ts", // #2782: SOURCE bugs — inbound-context.ts drops GroupSystemPrompt CRLF normalization; mentions.ts buildMentionRegexes lacks ReDoS/safe-regex filtering
-  "src/auto-reply/reply/commands-core.test.ts", // #2782: SOURCE gap — emitResetCommandHooks: before_reset hook swallowed on keyless reset + no *.reset.<ts> archive recovery (deferred source hunk from #2662)
-  "src/auto-reply/reply/commands-session-lifecycle.test.ts", // #2782: SOURCE bug — commands-session.ts uses gutted formatThreadBindingDurationLabel (returns "") → empty duration in /session idle+max-age replies
+  "src/auto-reply/inbound.test.ts", // #2782: #2927+#2930 SOURCE bugs FIXED (paired asserts pass; focused specs live in mentions.test.ts + inbound-context.test.ts); file stays quarantined on UNRELATED pre-existing fails — normalizeMentionText rebrand-expectation test, provider-dock mention strip, resolveGroupRequireMention (groups.js) — out of the fix PR's 5-file scope
+  "src/auto-reply/reply/commands-session-lifecycle.test.ts", // #2782: #2932 duration-label FIXED (Discord label asserts pass; focused spec in extensions/discord/src/monitor/thread-bindings.messages.test.ts); file stays quarantined on UNRELATED pre-existing fails — Telegram binding path + "unavailable outside discord/telegram" (commands-session.ts) — out of the fix PR's 5-file scope
   "src/auto-reply/reply/commands-subagents-focus.test.ts", // #2782: SOURCE gap — action-focus.ts/action-unfocus.ts lack the Matrix branch (un-ported D.4 EXTRACT; sibling action-agents.ts already has it)
   "src/auto-reply/reply/dispatch-from-config.test.ts", // #2782: 12 ACP-dispatch tests obsolete (ACP dispatch gutted in 4fd565bf89f) — belongs in a dedicated stale-test-deletion PR, not this ledger-shrink
   "src/auto-reply/reply/followup-runner.channel-bridge.test.ts", // #2782: premise gutted in #2377 (followup-runner is a no-op; ChannelBridge wiring moved to agent-runner-execution.ts) — port the assertions there
   "src/auto-reply/reply/reply-media-paths.test.ts", // #2782: not triaged (delegated agent aborted mid-run) — left quarantined pending investigation
   "src/auto-reply/reply/reply-plumbing.test.ts", // #2782: SOURCE bug — subagents-utils.ts formatRunLabel missing stripInternalRuntimeContext → internal runtime-context info leak into user-facing subagent labels
   "src/auto-reply/reply/session.test.ts", // #2782: SOURCE bug — session.ts resolveConversationIdFromTargets gutted to ()=>undefined → /new silently suppressed for all ACP-shaped session keys
-  "src/auto-reply/reply/strip-inbound-meta.test.ts", // #2782: SOURCE bug — strip-inbound-meta.ts:219 never re-strips a timestamp prefix exposed after block removal (upstream 98ea8e244f9 fix not synced)
 ];


### PR DESCRIPTION
Five real fork-carried correctness regressions in RemoteClaw's **kept** channel/messaging + auto-reply layer (the fork gutted the execution engine but kept this layer). Each was filed from a triage pass; every premise was re-confirmed against live source at this branch's base before fixing. One file per bug, plus the paired quarantined tests.

## Bugs

### #2927 — ReDoS-unsafe mention-pattern compile (LOW, security-adjacent) 🔒
- **Symptom:** `buildMentionRegexes` / `stripMentions` in `src/auto-reply/reply/mentions.ts` compiled operator-configured mention patterns with bare `new RegExp(...)`. A catastrophic-backtracking pattern (e.g. `(a+)+$`) compiles fine, then runs against every inbound group message — one crafted message can stall the single-threaded gateway (event-loop DoS).
- **Fix:** route both compiles through the existing `compileSafeRegex(source, flags)` guard in `src/security/safe-regex.ts` (rejects nested-repetition / invalid patterns → `null`). Valid patterns behave exactly as before; unsafe/invalid ones are dropped, not run.
- **Test:** paired asserts in `inbound.test.ts` now pass (unsafe pattern filtered; safe pattern still matches). Focused spec added to `src/auto-reply/reply/mentions.test.ts` (CI-enforced).

### #2928 — inbound timestamp-envelope leak (LOW)
- **Symptom:** `stripInboundMetadata` (`src/auto-reply/reply/strip-inbound-meta.ts`) stripped the `[Day YYYY-MM-DD HH:MM tz]` prefix once, *before* removing metadata blocks. When the timestamp sat after a block (backfilled CLI history), it became leading only after block removal and was never re-stripped → the AI-facing envelope surfaced in user-visible chat history.
- **Fix:** re-apply `.replace(LEADING_TIMESTAMP_PREFIX_RE, "")` to the final return (mirrors upstream `98ea8e244f9`). Non-timestamp brackets are untouched.
- **Test:** un-quarantined `src/auto-reply/reply/strip-inbound-meta.test.ts` — now fully green.

### #2930 — GroupSystemPrompt CRLF not normalized (LOW)
- **Symptom:** `finalizeInboundContext` (`src/auto-reply/reply/inbound-context.ts`) normalized newlines on 9 fields but skipped `GroupSystemPrompt`, so a CRLF-authored group prompt passed stray `\r` through to the agent system prompt.
- **Fix:** apply `normalizeInboundTextNewlines` to `GroupSystemPrompt` when it's a string. Deliberately **not** `sanitizeInboundSystemTags` — it is trusted operator config and its `[Assistant]`/`System:` markers must be preserved verbatim (newline-only transform).
- **Test:** paired assert in `inbound.test.ts` now passes. Focused spec added to `src/auto-reply/reply/inbound-context.test.ts` (CI-enforced).

### #2931 — before_reset hook dropped on keyless / archived resets (MEDIUM) 🔒
- **Symptom:** in `emitResetCommandHooks` (`src/auto-reply/reply/commands-core.ts`) the `before_reset` memory-extraction hook ran inside a swallow-all try/catch. Two paths silently skipped it: (a) a keyless/non-`agent:` session key made `resolveAgentIdFromSessionKey` **throw**; (b) the transcript was already archived to `<file>.reset.<ts>`, so the direct read hit `ENOENT` with no recovery. Users on memory plugins silently lost pre-reset extraction.
- **Fix:** (a) `resolveAgentIdFromSessionKeyOrNull(...) ?? "main"` — keyless keys fall back to `"main"` instead of throwing; (b) on `ENOENT`, `readdir` the transcript dir for the most recent `<basename>.reset.<ts>` archive and read that (its path is what the hook receives). Non-ENOENT read errors still propagate; the common (present, readable) path is unchanged.
- **Test:** un-quarantined `src/auto-reply/reply/commands-core.test.ts` — now fully green (main fallback + archive recovery).

### #2932 — empty `/session` duration label (LOW)
- **Symptom:** `formatThreadBindingDurationLabel` in `extensions/discord/src/monitor/thread-bindings.messages.ts` was a gutted stub returning `""`, so `/session idle` / `/session max-age` replies showed a blank where the duration should be (reachable on Discord and Telegram bound sessions).
- **Fix:** implement it via `formatDurationCompact(ms)` from `src/infra/format-time/format-duration.ts` (the discord extension already imports from `src/…`). The other three stubs in that file stay gutted.
- **Test:** paired Discord asserts in `commands-session-lifecycle.test.ts` now pass. Focused spec added to `extensions/discord/src/monitor/thread-bindings.messages.test.ts` (CI-enforced).

## Un-quarantine + a scoping note

The CI quarantine ledger (`vitest.quarantine.ts`) is **file-level**, and two of the paired files carry additional **pre-existing failures unrelated to these bugs** (proven by a baseline run: with original source both files failed 6 tests each = my paired tests + the same unrelated ones; my fixes flip exactly the paired tests green and leave the unrelated set unchanged):

- **`inbound.test.ts`** — unrelated fails: a `normalizeMentionText` rebrand-expectation test (`"open​claw"` → expects `"remoteclaw"`), a provider-dock mention-strip test, and two `resolveGroupRequireMention` tests (`groups.js`).
- **`commands-session-lifecycle.test.ts`** — unrelated fails: the Telegram binding path and the "unavailable outside discord/telegram" branch (`commands-session.ts`).

Fixing those needs out-of-scope source (`groups.js`, `commands-session.ts`) or a test-only rebrand correction — outside this PR's 5-file mandate — so those two files **stay quarantined** (ledger comments updated to say the named bug is fixed but the file is held on unrelated fails). To keep all 5 fixes CI-enforced anyway, I un-quarantined the two files that go **fully green** (#2928, #2931) and added three focused, deterministic specs for #2927 / #2930 / #2932.

## Verification
- `pnpm check` (oxfmt + tsgo + oxlint + fork gates): **pass**
- auto-reply lane (`vitest.auto-reply.config.ts`, full config): **56 files / 630 tests pass**
- extensions lane (`vitest.extensions.config.ts`, full config): **383 files / 3557 pass, 1 skipped**
- Standalone gates (rebrand-leakage, no-zombie-imports, stub-debt, obsolescence-audit, throwing-stub-callers, src/extension import boundaries): **pass**
- `test-ui-smoke` (Vite/Playwright) is a known non-blocking CI flake unrelated to this change.

## Review focus
Two hunks are security/behavior-sensitive and warrant a close read:
- **#2927** — mention compilation now routes through `compileSafeRegex` (the safe-regex guard).
- **#2931** — reset-hook emission: `"main"` fallback + `readdir` archive recovery.

Closes #2927
Closes #2928
Closes #2930
Closes #2931
Closes #2932

🤖 Generated with [Claude Code](https://claude.com/claude-code)
