### PR TITLE
test(feishu): un-quarantine feishu extension tests (#2782)

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -469,7 +469,9 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockSendMessageFeishu).toHaveBeenCalledWith(
       expect.objectContaining({
         to: "chat:oc-dm",
-        text: expect.stringContaining("Pairing code: ABCDEFGH"),
+        // Pairing code is rendered inside a fenced code block (see buildPairingReply),
+        // so assert the code itself rather than an inline "Pairing code: <code>" string.
+        text: expect.stringContaining("ABCDEFGH"),
         accountId: "default",
       }),
     );

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -18,7 +18,7 @@ const wsClientCtorMock = vi.hoisted(() =>
   }),
 );
 const proxyAgentCtorMock = vi.hoisted(() =>
-  vi.fn(function createAmbientNodeProxyAgent() {
+  vi.fn(function httpsProxyAgent() {
     return { proxied: true };
   }),
 );
@@ -144,17 +144,6 @@ beforeAll(async () => {
     EventDispatcher: vi.fn(),
     defaultHttpInstance: mockBaseHttpInstance,
   }));
-  vi.doMock("@remoteclaw/proxyline", () => ({
-    createAmbientNodeProxyAgent: proxyAgentCtorMock,
-    hasAmbientNodeProxyConfigured: vi.fn(() =>
-      Boolean(
-        process.env.HTTPS_PROXY ??
-        process.env.https_proxy ??
-        process.env.HTTP_PROXY ??
-        process.env.http_proxy,
-      ),
-    ),
-  }));
 
   ({
     createFeishuClient,
@@ -190,6 +179,9 @@ beforeEach(() => {
       EventDispatcher: vi.fn() as never,
       defaultHttpInstance: mockBaseHttpInstance as never,
     },
+    // The source resolves ws proxy agents via the injectable `HttpsProxyAgent`
+    // (https-proxy-agent) seam, so route the proxy-agent spy through it.
+    HttpsProxyAgent: proxyAgentCtorMock as never,
   });
 });
 
@@ -221,7 +213,6 @@ afterAll(() => {
   vi.doUnmock("./runtime.js");
   vi.doUnmock("./subagent-hooks.js");
   vi.doUnmock("@larksuiteoapi/node-sdk");
-  vi.doUnmock("@remoteclaw/proxyline");
   vi.resetModules();
 });
 
@@ -359,14 +350,13 @@ describe("createFeishuClient HTTP timeout", () => {
 });
 
 describe("createFeishuWSClient proxy handling", () => {
-  it("passes heartbeat wsConfig defaults to Lark.WSClient", async () => {
+  it("does not pass a wsConfig heartbeat override to Lark.WSClient", async () => {
     await createFeishuWSClient(baseAccount);
 
+    // The fork's createFeishuWSClient does not set a wsConfig heartbeat; it relies
+    // on the Lark SDK defaults. Asserting undefined documents the actual behavior.
     const options = firstWsClientOptions();
-    expect(options.wsConfig).toEqual({
-      PingInterval: 30,
-      PingTimeout: 3,
-    });
+    expect(options.wsConfig).toBeUndefined();
   });
 
   it("does not set a ws proxy agent when proxy env is absent", async () => {

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -81,8 +81,12 @@ describe("Feishu monitor startup preflight", () => {
     });
 
     try {
-      await Promise.resolve();
-      await Promise.resolve();
+      // monitorFeishuProvider awaits a lazy dynamic import of monitor.account.js
+      // before the first probe. On the first test in this file that import is cold
+      // (resolves on a macrotask, not a microtask), so poll with real timers via
+      // vi.waitFor. alpha's probe blocks on probesReleased, so beta/gamma never
+      // start while we wait.
+      await vi.waitFor(() => expect(started).toContain("alpha"));
 
       expect(started).toEqual(["alpha"]);
       expect(maxInFlight).toBe(1);
@@ -192,7 +196,7 @@ describe("Feishu monitor startup preflight", () => {
     });
 
     try {
-      await Promise.resolve();
+      await vi.waitFor(() => expect(started).toContain("alpha"));
       expect(started).toEqual(["alpha"]);
 
       abortController.abort();

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -8,8 +8,32 @@ vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
 }));
 
-vi.mock("./client.js", () => ({}));
-vi.mock("./runtime.js", () => ({}));
+vi.mock("./client.js", () => ({
+  // monitorSingleAccount builds an event dispatcher (registerEventHandlers calls
+  // .register()) before the webhook transport starts; the webhook path never uses
+  // createFeishuWSClient, so a minimal dispatcher stub is enough.
+  createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
+}));
+vi.mock("./runtime.js", () => ({
+  // registerEventHandlers resolves the inbound debounce config from the runtime
+  // before the webhook transport starts. No inbound events are dispatched in these
+  // HTTP-guard tests, so a minimal runtime stub (matching monitor.startup.test.ts)
+  // is enough.
+  getFeishuRuntime: () => ({
+    channel: {
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: () => ({
+          enqueue: async () => {},
+          flushKey: async () => {},
+        }),
+      },
+      text: {
+        hasControlCommand: () => false,
+      },
+    },
+  }),
+}));
 
 vi.mock("@larksuiteoapi/node-sdk", () => ({
   adaptDefault: vi.fn(
@@ -74,6 +98,7 @@ function buildConfig(params: {
             webhookPort: params.port,
             webhookPath: params.path,
             verificationToken: params.verificationToken,
+            encryptKey: "encrypt_key", // pragma: allowlist secret
           },
         },
       },

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
-const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -15,7 +14,6 @@ vi.mock("./media.js", () => ({
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
-  sendStructuredCardFeishu: sendStructuredCardFeishuMock,
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -35,7 +33,6 @@ function resetOutboundMocks() {
   vi.clearAllMocks();
   sendMessageFeishuMock.mockResolvedValue({ messageId: "text_msg" });
   sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
-  sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
   sendMediaFeishuMock.mockResolvedValue({ messageId: "media_msg" });
 }
 
@@ -135,7 +132,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
       accountId: "main",
     });
 
-    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         to: "chat_1",
         text: "| a | b |\n| - | - |",
@@ -210,7 +207,7 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
     );
   });
 
-  it("forwards replyToId to sendStructuredCardFeishu when renderMode=card", async () => {
+  it("forwards replyToId to sendMarkdownCardFeishu when renderMode=card", async () => {
     await sendText({
       cfg: {
         channels: {
@@ -225,7 +222,7 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
       accountId: "main",
     });
 
-    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_reply_target",
       }),

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -10,7 +10,7 @@ vi.mock("./client.js", () => ({
 const DEFAULT_CREDS = { appId: "cli_123", appSecret: "secret" } as const; // pragma: allowlist secret
 const DEFAULT_SUCCESS_RESPONSE = {
   code: 0,
-  data: { pingBotInfo: { botName: "TestBot", botID: "ou_abc123" } },
+  bot: { bot_name: "TestBot", open_id: "ou_abc123" },
 } as const;
 const DEFAULT_SUCCESS_RESULT = {
   ok: true,
@@ -20,7 +20,7 @@ const DEFAULT_SUCCESS_RESULT = {
 } as const;
 const BOT1_RESPONSE = {
   code: 0,
-  data: { pingBotInfo: { botName: "Bot1", botID: "ou_1" } },
+  bot: { bot_name: "Bot1", open_id: "ou_1" },
 } as const;
 
 afterAll(() => {
@@ -140,9 +140,9 @@ describe("probeFeishu", () => {
     await probeFeishu(DEFAULT_CREDS);
 
     expect(requestFn).toHaveBeenCalledWith({
-      method: "POST",
-      url: "/open-apis/bot/v1/remoteclaw_bot/ping",
-      data: { needBotInfo: true },
+      method: "GET",
+      url: "/open-apis/bot/v3/info",
+      data: {},
       timeout: FEISHU_PROBE_REQUEST_TIMEOUT_MS,
     });
   });
@@ -268,10 +268,10 @@ describe("probeFeishu", () => {
     });
   });
 
-  it("handles response with pingBotInfo in data", async () => {
+  it("handles response with bot info nested under data", async () => {
     setupClient({
       code: 0,
-      data: { pingBotInfo: { botName: "DataBot", botID: "ou_data" } },
+      data: { bot: { bot_name: "DataBot", open_id: "ou_data" } },
     });
 
     await expectDefaultSuccessResult(DEFAULT_CREDS, {

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -63,14 +63,13 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/discord/src/monitor/thread-bindings.lifecycle.test.ts",
   "extensions/discord/src/monitor/threading.starter.test.ts",
   "extensions/discord/src/voice-message.test.ts",
-  "extensions/feishu/src/bot.test.ts",
-  "extensions/feishu/src/client.test.ts",
+  // #2782 (feishu): media/monitor.reaction/send.reply-fallback remain — each needs a
+  // separate SOURCE change (see PR for un-quarantine of the other 6, which were stale
+  // tests fixed test-side). media.ts dropped content-type→file_type routing + download
+  // header metadata; monitor.account.ts lacks receive-layer early-event dedup; send.ts
+  // lost the thread-reply-fallback safety guard + Feishu error-diagnostics wrap.
   "extensions/feishu/src/media.test.ts",
   "extensions/feishu/src/monitor.reaction.test.ts",
-  "extensions/feishu/src/monitor.startup.test.ts",
-  "extensions/feishu/src/monitor.webhook-security.test.ts",
-  "extensions/feishu/src/outbound.test.ts",
-  "extensions/feishu/src/probe.test.ts",
   "extensions/feishu/src/send.reply-fallback.test.ts",
   "extensions/googlechat/src/monitor.webhook-routing.test.ts",
   "extensions/imessage/src/accounts.test.ts",


### PR DESCRIPTION
## What

Shrinks the **#2782** quarantine ledger for the **feishu** channel: un-quarantines **6 of 9** feishu extension test files from the `test-extensions` lane by fixing them **test-side only** (no source changes). The remaining **3** each need a separate **SOURCE** change and are **left quarantined** with a root-cause report below for focused follow-up PRs.

Direction for every file was confirmed against upstream `27ae826f65` (the fork rewrote/simplified the source; the quarantined tests were synced ahead or only rebranded).

> **#2782 stays OPEN** — other channels and the 3 feishu source-regression files remain. No closing keyword used.

## Per-file result (all 9)

| File | Bucket | Fix |
|------|--------|-----|
| `probe.test.ts` | STALE TEST | ✅ Assert the fork's real `GET /open-apis/bot/v3/info` probe + `bot.bot_name`/`open_id` response. Fork rewrote probe.ts from upstream `POST …/openclaw_bot/ping` (pingBotInfo); test was only rebranded. |
| `client.test.ts` | STALE TEST | ✅ Route the proxy-agent spy through the source's real `HttpsProxyAgent` seam (test mocked nonexistent `@remoteclaw/proxyline`); drop the `wsConfig` heartbeat assertion the fork never sets. |
| `outbound.test.ts` | STALE TEST | ✅ Assert `sendMarkdownCardFeishu` (fork gutted `sendStructuredCardFeishu`; `renderMode=card` → single markdown-card path). Old mock was inert. |
| `bot.test.ts` | STALE TEST | ✅ Pairing code renders in a fenced code block (`buildPairingReply`, upstream-identical) → assert the code, not an inline `Pairing code: <code>`. |
| `monitor.startup.test.ts` | FLAKY / TIMING | ✅ `vi.waitFor` the first sequential probe (provider awaits a cold dynamic import that resolves on a macrotask; fixed microtask ticks were racy). |
| `monitor.webhook-security.test.ts` | STALE TEST | ✅ Add now-required `encryptKey` fixture (source + config-schema require it for webhook mode, **matching upstream**) + minimal `createEventDispatcher`/`getFeishuRuntime` mocks so the webhook monitor starts. |
| `media.test.ts` | **LEFT QUARANTINED** (source) | ⛔ Needs `media.ts` source fix — see below. |
| `monitor.reaction.test.ts` | **LEFT QUARANTINED** (source) | ⛔ 5/6 failures are test-side; 1 needs a `monitor.account.ts` source port — see below. |
| `send.reply-fallback.test.ts` | **LEFT QUARANTINED** (source, SECURITY/SAFETY) | ⛔ Needs `send.ts` source fix — see below. |

## SOURCE changes in this PR

**None.** This PR is purely test-side (6 test files) + the `vitest.quarantine.ts` feishu lines. No `src/` or feishu source files were modified.

## Left-quarantined — discovered SOURCE regressions (for separate, focused PRs)

These stay in the ledger because making them pass requires source changes, not test changes. Root causes below so a follow-up can act directly. **Do not weaken these tests to green them** — the assertions are correct; the fork source lags upstream.

### 1. `send.reply-fallback.test.ts` — ⚠️ SECURITY / SAFETY (needs independent security review)
`extensions/feishu/src/send.ts` lost two behaviors present upstream (`27ae826f65`):
- **Thread-reply fallback guard (safety).** When a `replyInThread: true` reply targets a withdrawn/deleted message, upstream **throws** `"Feishu thread reply failed: reply target is unavailable and cannot safely fall back to a top-level send."`. The fork instead **falls back to a top-level `create`**, i.e. a message intended for a thread is posted to the whole chat — a message-leak / disclosure risk. (fails at test lines 222, 247)
- **Error-diagnostics wrap.** Direct-send (`create`) rejections propagate the raw axios error instead of the structured `Feishu send failed: {"http_status":…,"feishu_code":…,"feishu_log_id":…,"feishu_troubleshooter":…}`. (fails at line 83)
- **Note:** the diagnostics helpers already exist in the fork (`comment-shared.ts`: `requestFeishuApi`/`createFeishuApiError`) — they're just not wired into `send.ts`. Upstream wires them + adds an `allowTopLevelReplyFallback` param + the thread guard.

### 2. `media.test.ts` — SOURCE (non-security)
`extensions/feishu/src/media.ts` is a simplification that dropped two behaviors the test still asserts:
- **Content-type → `file_type` routing** (line 209): `sendMediaFeishu` routes by filename extension only and ignores `loaded.contentType`, so remote `video/mp4` with a generic filename sends `file_type=stream` instead of `mp4`/`msg_type=media`.
- **Download header metadata** (line 578): `downloadMessageResourceFeishu` returns bare `{ buffer }`, discarding `response.headers` — `result.contentType`/`fileName` are `undefined` (the result type already declares these optional fields).
- Env note (lines 372/397, test-side): the temp-path isolation helper realpaths only the tmp root, so on macOS (`/tmp`→`/private/tmp`) it fails while passing on Linux CI. A follow-up can make the comparison symmetric.

### 3. `monitor.reaction.test.ts` — SOURCE (low-security) + mostly test-side
- **5 of 6** failures are test-side: the tests spy the high-level dedup wrappers (`hasProcessedFeishuMessage`, …) but the fork's inline debounce calls the low-level primitives (`hasRecordedMessage`, `tryRecordMessagePersistent`, …) directly; redirect the mock seam.
- **1** failure (line 658, "drops duplicate inbound events") needs a **source port**: the fork receive handler (`monitor.account.ts`) enqueues without receive-layer early-event dedup (upstream extracted this into a `monitor.message-handler.ts` that doesn't exist in the fork). Low-security (duplicate/redelivery suppression, not auth). Because the file can't go green without that port, the whole file is left quarantined.

## Verification
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/` → **31 files / 311 tests pass**, stable across 3 runs; the 3 still-quarantined files correctly do not run.
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) → **pass**.
- Only feishu quarantine lines touched; no other channel's ledger entries changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
