### PR TITLE
test(matrix): un-quarantine matrix extension tests (#2782)

### DIFF
--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -11,10 +11,77 @@ md.enable("strikethrough");
 
 const { escapeHtml } = md.utils;
 
+/**
+ * File extensions that share TLDs and commonly appear in code/documentation.
+ * markdown-it's linkify auto-links bare tokens like `README.md` or `backup.sh`
+ * into `http://README.md` / `http://backup.sh` (`.md` is Moldova, `.sh` is
+ * Saint Helena), turning innocuous file references in agent output into
+ * clickable external URLs. These extensions suppress that.
+ *
+ * Excluded: .ai, .io, .tv, .fm (popular domain TLDs like x.ai, vercel.io).
+ */
+const FILE_EXTENSIONS_WITH_TLD = new Set([
+  "md", // Markdown (Moldova) - very common in repos
+  "go", // Go language - common in Go projects
+  "py", // Python (Paraguay) - common in Python projects
+  "pl", // Perl (Poland) - common in Perl projects
+  "sh", // Shell (Saint Helena) - common for scripts
+  "am", // Automake files (Armenia)
+  "at", // Assembly (Austria)
+  "be", // Backend files (Belgium)
+  "cc", // C++ source (Cocos Islands)
+]);
+
+/** Detects when markdown-it linkify auto-generated a link from a bare filename (e.g. README.md → http://README.md). */
+function isAutoLinkedFileRef(href: string, label: string): boolean {
+  const stripped = href.replace(/^https?:\/\//i, "");
+  if (stripped !== label) {
+    return false;
+  }
+  const dotIndex = label.lastIndexOf(".");
+  if (dotIndex < 1) {
+    return false;
+  }
+  const ext = label.slice(dotIndex + 1).toLowerCase();
+  if (!FILE_EXTENSIONS_WITH_TLD.has(ext)) {
+    return false;
+  }
+  // Reject if any path segment before the filename contains a dot (looks like a domain).
+  const segments = label.split("/");
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    if (segments[i].includes(".")) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function shouldSuppressAutoLink(
+  tokens: Parameters<NonNullable<typeof md.renderer.rules.link_open>>[0],
+  idx: number,
+): boolean {
+  const token = tokens[idx];
+  if (token?.type !== "link_open" || token.info !== "auto") {
+    return false;
+  }
+  const href = token.attrGet("href") ?? "";
+  const label = tokens[idx + 1]?.type === "text" ? (tokens[idx + 1]?.content ?? "") : "";
+  return Boolean(href && label && isAutoLinkedFileRef(href, label));
+}
+
 md.renderer.rules.image = (tokens, idx) => escapeHtml(tokens[idx]?.content ?? "");
 
 md.renderer.rules.html_block = (tokens, idx) => escapeHtml(tokens[idx]?.content ?? "");
 md.renderer.rules.html_inline = (tokens, idx) => escapeHtml(tokens[idx]?.content ?? "");
+md.renderer.rules.link_open = (tokens, idx, options, _env, self) =>
+  shouldSuppressAutoLink(tokens, idx) ? "" : self.renderToken(tokens, idx, options);
+md.renderer.rules.link_close = (tokens, idx, options, _env, self) => {
+  const openIdx = idx - 2;
+  if (openIdx >= 0 && shouldSuppressAutoLink(tokens, openIdx)) {
+    return "";
+  }
+  return self.renderToken(tokens, idx, options);
+};
 
 export function markdownToMatrixHtml(markdown: string): string {
   const rendered = md.render(markdown ?? "");

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -78,11 +78,21 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/imessage/src/monitor/parse-notification.test.ts",
   "extensions/irc/src/send.test.ts",
   "extensions/line/src/channel.sendPayload.test.ts",
-  "extensions/matrix/src/channel.directory.test.ts",
+  // #2782 (matrix): 4 of 6 un-quarantined (channel.directory/allowlist/handler.body-for-agent
+  // pass as-is on clean CI; format fixed test-side after restoring a dropped source guard — see
+  // PR). The 2 below stay, each needing out-of-scope work:
+  // - manifest: asserts matrix stages `fake-indexeddb` + opts into `bundle.stageRuntimeDependencies`.
+  //   The fork re-architected matrix onto @vector-im/matrix-bot-sdk with filesystem crypto storage
+  //   (no `indexedDB` usage anywhere; the idb-persistence files are orphaned), so the fake-indexeddb
+  //   dep is stale upstream baggage. Whether matrix should opt into runtime-dep STAGING is a separate
+  //   release-surface call complicated by its NATIVE dep (@matrix-org/matrix-sdk-crypto-nodejs) —
+  //   unlike the pure-JS googlechat/policy precedents — so it needs a release-gated PR.
+  // - matrix/monitor/index: asserts the full Pi-era monitor orchestration (thread-binding manager,
+  //   inbound-event deduper, graceful stop-sync/drain-decryptions/wait-for-handlers shutdown,
+  //   cold-start `dropPreStartupMessages` guard, account-aware text limit). The fork gutted all of
+  //   it (index.ts references none of those symbols; 7 mocked modules no longer exist). Reconciling
+  //   is a wholesale test rewrite over correctness-sensitive shutdown paths — separate PR.
   "extensions/matrix/src/manifest.test.ts",
-  "extensions/matrix/src/matrix/format.test.ts",
-  "extensions/matrix/src/matrix/monitor/allowlist.test.ts",
-  "extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts",
   "extensions/matrix/src/matrix/monitor/index.test.ts",
   "extensions/mattermost/channel-plugin-api.test.ts",
   "extensions/mattermost/src/mattermost/interactions.test.ts",


### PR DESCRIPTION
## What

Shrinks the **#2782** quarantine ledger by un-quarantining **4 of the 6** matrix
extension test files in `vitest.quarantine.ts` (the `test-extensions` CI lane).
The other 2 stay quarantined with an inline rationale; **#2782 remains OPEN**
(other channels still have quarantined files).

## Per-file disposition

| File | Bucket | Disposition |
|------|--------|-------------|
| `channel.directory.test.ts` | passes as-is | **Un-quarantined** — green on clean CI config (was a local Node-26/dev-only flake) |
| `matrix/monitor/allowlist.test.ts` | passes as-is | **Un-quarantined** — green, no change |
| `matrix/monitor/handler.body-for-agent.test.ts` | passes as-is | **Un-quarantined** — green, no change |
| `matrix/format.test.ts` | **real SOURCE regression** | **Un-quarantined** — required restoring a dropped guard in `format.ts` (see below) |
| `manifest.test.ts` | stale + release-surface | **LEFT QUARANTINED** — see below |
| `matrix/monitor/index.test.ts` | gutted upstream orchestration | **LEFT QUARANTINED** — see below |

## ⚠️ SOURCE change — please review

**`extensions/matrix/src/matrix/format.ts`** — the fork's simplified `format.ts`
had dropped the auto-link-suppression guard that upstream ships. markdown-it
`linkify` was turning bare file references in agent output (`README.md`,
`backup.sh`) into clickable external URLs (`http://README.md` — `.md` is Moldova,
`.sh` is Saint Helena) — a mild phishing / typosquat surface. Restored a
self-contained `isAutoLinkedFileRef` + `link_open`/`link_close` renderer guard,
ported from the **telegram** adapter's existing local implementation. Explicit
markdown links and real URLs are unaffected.

- **Security relevance:** content-rendering / output-sanitization; **not** an
  auth/token, webhook, allowlist/authz, proxy, or sender-filter path. Flagged
  for the independent Polish/security pass regardless.

## Left quarantined (out of scope — documented inline in the ledger)

- **`manifest.test.ts`** — asserts matrix ships `fake-indexeddb` and opts into
  `remoteclaw.bundle.stageRuntimeDependencies`. The fork re-architected matrix
  onto `@vector-im/matrix-bot-sdk` with **filesystem** crypto storage — there is
  no `indexedDB` usage anywhere and the `idb-persistence` files are orphaned, so
  the `fake-indexeddb` dep is stale upstream baggage. Whether matrix should opt
  into runtime-dep **staging** is a separate release-surface decision complicated
  by its **native** `@matrix-org/matrix-sdk-crypto-nodejs` dep (unlike the pure-JS
  googlechat/policy precedents). Needs a release-gated PR.
- **`matrix/monitor/index.test.ts`** — asserts the full Pi-era monitor
  orchestration (thread-binding manager, inbound-event deduper, graceful
  stop-sync / drain-decryptions / wait-for-handlers shutdown, cold-start
  `dropPreStartupMessages` guard, account-aware text limit). The fork gutted all
  of it: `index.ts` references **none** of those symbols and **7** of the mocked
  modules no longer exist. Reconciling is a wholesale test rewrite over
  correctness-sensitive shutdown paths (some gutted behaviors — graceful shutdown
  draining, inbound dedup — could be real regressions), so it needs its own
  triage PR rather than a green-the-lane rewrite.

## Verification

- `pnpm check` — green (oxfmt clean, tsgo clean, oxlint 0/0, all fork gates pass)
- Matrix subset (`vitest.extensions.config.ts extensions/matrix/`) — **25 files /
  116 tests green** (manifest + index correctly excluded)
- The 4 un-quarantined files run and pass explicitly (4 files / 16 tests)

Part of #2782 (do not close — other channels remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
