### PR TITLE
test(zalouser): un-quarantine zalouser extension tests (#2782)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,6 +73,8 @@ const pluginSdkSubpaths = [
   "routing",
   "runtime-config-snapshot",
   "secret-ref-runtime",
+  "temp-path",
+  "dangerous-name-runtime",
 ] as const;
 
 export default defineConfig({

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -135,11 +135,14 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/zalo/runtime-api.test.ts",
   "extensions/zalo/src/monitor.webhook.test.ts",
   "extensions/zalo/src/token.test.ts",
-  "extensions/zalouser/src/channel.directory.test.ts",
-  "extensions/zalouser/src/channel.sendpayload.test.ts",
-  "extensions/zalouser/src/channel.test.ts",
-  "extensions/zalouser/src/monitor.group-gating.test.ts",
-  "extensions/zalouser/src/security-audit.test.ts",
+  // #2782 (zalouser): channel.directory + security-audit un-quarantined (they passed once the
+  // `temp-path` + `dangerous-name-runtime` plugin-sdk subpaths — imported by zalouser source via
+  // the bare `remoteclaw/plugin-sdk/*` specifier — were added to the vitest.config.ts resolve-alias
+  // mirror; a test-harness resolution gap, not a product-source change). The 3 below stay: each
+  // needs a SOURCE change to the outbound / DM-routing / authz paths (see PR for details).
+  "extensions/zalouser/src/channel.sendpayload.test.ts", // #2782: SOURCE regression — channel.ts outbound (sendText/sendPayload) never passes textMode:"markdown" + resolved textChunkMode/textChunkLimit, and double-chunks long text at the sendPayload layer instead of passing through once (send.ts already implements passthrough markdown chunking; the caller wiring was lost)
+  "extensions/zalouser/src/channel.test.ts", // #2782: SOURCE regression — same root as channel.sendpayload: channel.ts sendText omits textMode/textChunkMode/textChunkLimit
+  "extensions/zalouser/src/monitor.group-gating.test.ts", // #2782: 3 SOURCE regressions — (a) deliverZalouserReply outer-chunks + omits textMode/chunk opts (same passthrough root); (b) open-policy non-command DMs are dropped before dispatch (resolveAgentRoute never reached); (c) SECURITY: monitor.ts processMessage group-match (~L321) omits allowNameMatching, so a mutable group NAME always matches config entries → group-allowlist bypass by name impersonation even without dangerouslyAllowNameMatching — needs a security-reviewed fix
 ];
 
 /** Currently-failing test files under `src/auto-reply/**` (run by the `test-auto-reply` lane). */


### PR DESCRIPTION
Shrinks the **#2782** quarantine ledger for the `zalouser` channel. Un-quarantines **2 of 5** files; the other 3 reveal **real source regressions** in core paths (one **security-relevant**) and stay quarantined for a dedicated, security-reviewed source PR — the same "one PR per channel" pattern used for telegram/slack/feishu/whatsapp. **#2782 stays open** (other channels remain).

## Per-file triage

| File | Bucket | Disposition |
|---|---|---|
| `channel.directory.test.ts` | test-harness gap | **Un-quarantined** — passes once the plugin-sdk aliases are wired (below) |
| `security-audit.test.ts` | test-harness gap | **Un-quarantined** — same |
| `channel.sendpayload.test.ts` | real SOURCE regression | **Left quarantined** — outbound passthrough/markdown wiring lost |
| `channel.test.ts` | real SOURCE regression | **Left quarantined** — same root |
| `monitor.group-gating.test.ts` | real SOURCE regression (incl. **security**) | **Left quarantined** — 3 root causes, one is a group-allowlist bypass |

## The only change in this PR (test-harness, not product source)

`vitest.config.ts` — added `temp-path` and `dangerous-name-runtime` to the `pluginSdkSubpaths` resolve-alias mirror. Both are **real files** (`src/plugin-sdk/*.ts`) that zalouser source imports via the bare `remoteclaw/plugin-sdk/*` specifier, and both resolve fine under `tsconfig.json`'s `remoteclaw/plugin-sdk/*` wildcard (so `tsgo` passes) — but the vitest alias list is an explicit manual mirror and was missing them. zalouser is the only consumer of these two subpaths via the bare specifier, so the gap was invisible while its tests were quarantined. Adding the aliases lets the 2 files load and pass. **No product source is modified; safe by construction** — these specifiers previously resolved to nothing, so no passing test can depend on their absence.

> Note (out of scope, not fixed here): the same two subpaths are also absent from `package.json` `exports` and `tsconfig.plugin-sdk.dts.json`. That only matters for the published/dts artifact, not the `test-extensions` CI lane — flagging for separate follow-up.

## Discovered SOURCE regressions (left quarantined — NOT fixed here)

These need a focused source PR (the third is security-sensitive and must get an independent review); reproduce by deleting the three ledger lines and running the lane.

1. **Outbound markdown + chunk passthrough lost** (`channel.ts`, and `monitor.ts` `deliverZalouserReply`). `sendText`/`sendPayload`/deliver pass only `{ profile, isGroup }` and chunk long text at the outer layer, so long markdown is sent as **2 calls** and never carries `textMode:"markdown"` / `textChunkMode` / `textChunkLimit`. `send.ts` `sendMessageZalouser` **already implements** passthrough markdown chunking internally — the caller wiring is what regressed (the machinery is currently vestigial). Non-security. Fails `channel.sendpayload.test.ts` (5), `channel.test.ts` (1), and 1 in `monitor.group-gating.test.ts`.
2. **Open-policy non-command DMs dropped before dispatch** (`monitor.ts` `processMessage`). With `dmPolicy:"open"`, a plain DM never reaches `resolveAgentRoute` (0 route/send calls). Fails 2 in `monitor.group-gating.test.ts` (`routes DM messages with direct peer kind`, `reuses the legacy DM session key`).
3. **🔒 SECURITY — group-allowlist bypass via mutable group-name impersonation** (`monitor.ts` `processMessage`, ~L321). `buildZalouserGroupCandidates` is called **without** `allowNameMatching`, so the incoming message's mutable `groupName` is **always** a match candidate against `channels.zalouser.groups`. `isDangerousNameMatchingEnabled` is imported but never applied at this enforcement site (it's only used at startup, L767, to resolve name→id when the flag is on). Effect: a hostile group whose **display name** equals a trusted group entry (e.g. `"Trusted Team"`) passes the allowlist **even without** `dangerouslyAllowNameMatching`. Fails `does not accept a different group id by matching only the mutable group name by default` (expects 0 dispatches, gets 1). The audit warning (`security-audit.ts`) is correct; the **enforcement** path is not. Likely fix: thread `allowNameMatching: isDangerousNameMatchingEnabled(account.config)` into the `buildZalouserGroupCandidates` calls at ~L321 and ~L219 — **security review required**.

## Verification
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/zalouser/` → **12 files / 82 tests pass** (was 10/77; +2 files = the un-quarantined pair, +5 tests). The 3 staying files remain excluded.
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) → **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
