### PR TITLE
test(voice-call): un-quarantine voice-call extension tests (#2782)

### DIFF
--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -103,7 +103,6 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
   if (ctx.processedEventIds.has(dedupeKey)) {
     return;
   }
-  ctx.processedEventIds.add(dedupeKey);
 
   let call = findCall({
     activeCalls: ctx.activeCalls,
@@ -142,6 +141,7 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
           reason: "hangup-bot",
         })
         .catch((err) => {
+          ctx.rejectedProviderCallIds.delete(pid);
           const message = formatErrorMessage(err);
           console.warn(`[voice-call] Failed to reject inbound call ${pid}:`, message);
         });
@@ -176,7 +176,14 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
     }
   }
 
-  call.processedEventIds.push(dedupeKey);
+  // Don't burn the replay/dedupe key for events that could not be meaningfully
+  // applied yet: an as-yet-unknown call returns above without committing, and a
+  // retryable `call.error` stays replayable so a later retry can resolve it.
+  const shouldCommitReplayKey = !(event.type === "call.error" && event.retryable);
+  if (shouldCommitReplayKey) {
+    ctx.processedEventIds.add(dedupeKey);
+    call.processedEventIds.push(dedupeKey);
+  }
 
   switch (event.type) {
     case "call.initiated":

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ const pluginSdkSubpaths = [
   "account-id",
   "account-resolution",
   "allow-from",
+  "browser-security-runtime",
   "channel-lifecycle",
   "core",
   "channel-config-helpers",

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -122,13 +122,17 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/telegram/src/sequential-key.test.ts",
   "extensions/twitch/src/config.test.ts",
   "extensions/twitch/src/token.test.ts",
-  "extensions/voice-call/src/manager.inbound-allowlist.test.ts",
-  "extensions/voice-call/src/manager/events.test.ts",
-  "extensions/voice-call/src/providers/plivo.test.ts",
-  "extensions/voice-call/src/providers/telnyx.test.ts",
-  "extensions/voice-call/src/providers/twilio.test.ts",
-  "extensions/voice-call/src/runtime.test.ts",
-  "extensions/voice-call/src/webhook-security.test.ts",
+  // #2782 (voice-call): 7 of 8 voice-call files un-quarantined. 5 (runtime, plivo, telnyx,
+  // twilio, webhook-security) failed only because the plugin-sdk `browser-security-runtime`
+  // subpath was missing from the vitest resolver alias list — a test-config gap, fixed in
+  // vitest.config.ts. The other 2 (manager/events, manager.inbound-allowlist) are paired to a
+  // small manager/events.ts SOURCE fix (dedupe-key deferral + rejected-inbound retry, both
+  // matching upstream). webhook.test.ts remains: its 5 failures need a SOURCE change to the
+  // pre-auth webhook pipeline (webhook.ts) — a signature-presence 401 before readBody, the
+  // shared pre-auth body cap (WEBHOOK_BODY_READ_DEFAULTS.preAuth, 70KB→413), and a per-source-IP
+  // in-flight limiter (createWebhookInFlightLimiter →429; its absence causes the 120s hang) —
+  // plus 2 reliability fails (stale stream-disconnect hangup, barge-in clear during a pending
+  // initial message). Security-gated (webhook auth + DoS); deferred to a focused source PR.
   "extensions/voice-call/src/webhook.test.ts",
   "extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts",
   "extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts",


### PR DESCRIPTION
Un-quarantines **7 of 8** quarantined `extensions/voice-call/**` test files, shrinking the #2782 `test-extensions` quarantine ledger. `webhook.test.ts` is deliberately **left quarantined** (needs a separate security-gated source PR — see below).

`#2782` is **not** closed — other channels remain quarantined.

## Per-file triage

| File | Bucket | What was done |
|------|--------|---------------|
| `providers/twilio.test.ts` | Test-config (resolver alias) | `twilio.ts` imports `remoteclaw/plugin-sdk/browser-security-runtime`, which was missing from the vitest resolver alias list → suite failed to load. Added the alias. |
| `webhook-security.test.ts` | Test-config (resolver alias) | Same missing alias (direct import). The webhook-security **source** verification logic itself is correct — all 51 Group-A tests pass once resolution works. |
| `providers/plivo.test.ts` | Test-config (resolver alias) | Transitively loads `webhook-security.ts` → same alias fix. |
| `providers/telnyx.test.ts` | Test-config (resolver alias) | Transitively loads `webhook-security.ts` → same alias fix. |
| `runtime.test.ts` | Test-config (resolver alias) | Transitively loads the providers → same alias fix. |
| `manager/events.test.ts` | **Real regression (source)** | Paired to a `manager/events.ts` fix: **dedupe-key deferral** — `processEvent` eagerly committed the replay key at the top, burning it for as-yet-unknown calls and for retryable `call.error` events. Now committed only after the call resolves and only when not a retryable error. |
| `manager.inbound-allowlist.test.ts` | **Real regression (source, security-relevant)** | Paired to a `manager/events.ts` fix: the rejected-inbound hangup catch handler now deletes the `providerCallId` from `rejectedProviderCallIds` so a **transient provider failure can be retried** by a later event. |
| `webhook.test.ts` | **LEFT QUARANTINED — real security regression (large)** | See below. |

## ⚠️ Source changes (for review)

Two files beyond the test files were touched. Both are flagged for review:

1. **`vitest.config.ts`** — *test-config only, not product source.* Added `"browser-security-runtime"` to the `pluginSdkSubpaths` alias list. The source module `src/plugin-sdk/browser-security-runtime.ts` already exists and is listed in `scripts/lib/plugin-sdk-entrypoints.json`; it was simply never aliased for test resolution. This is consistent with **9 other** subpaths already aliased-but-not-`package.json`-exported in the fork (e.g. `account-resolution`, `allow-from`, `runtime`, `json-store`). Zero behavior change; it only makes a currently-unresolvable import resolve.

2. **`extensions/voice-call/src/manager/events.ts`** — product source, both changes port upstream `27ae826f65` behavior the fork had regressed:
   - **dedupe-key deferral** (reliability): removed the eager `processedEventIds.add` at the top; commit the key after the call resolves, gated by `shouldCommitReplayKey = !(event.type === "call.error" && event.retryable)`.
   - **rejected-inbound retry** (🔒 **SECURITY-RELEVANT** — unauthorized-inbound-caller rejection / allowlist-authz path): the hangup `.catch` now calls `ctx.rejectedProviderCallIds.delete(pid)`. This is **hardening only** — it ensures an unauthorized inbound call still gets hung up after a transient provider failure. No authz check is weakened; the `shouldAcceptInbound` allowlist decision is unchanged.

## `webhook.test.ts` — why it stays quarantined

Its 5 failures require a substantial, security-critical source port to `webhook.ts` (fork is 487 lines vs upstream's 934), out of scope for a test-side un-quarantine:

- **Pre-auth signature-presence 401** before `readBody` — fork reads the body first and only 401s after `verifyWebhook`. Needs a provider-specific `verifyPreAuthWebhookHeaders` (getting the header detection wrong risks rejecting valid webhooks *or* accepting forged ones).
- **Shared pre-auth body cap** (`WEBHOOK_BODY_READ_DEFAULTS.preAuth`, 70KB→**413**) — fork's `MAX_WEBHOOK_BODY_BYTES` is 1 MB, so the 70KB probe returns 200.
- **Per-source-IP in-flight limiter** (`createWebhookInFlightLimiter` →**429**) — absent in the fork; its absence is what makes the "limits concurrent pre-auth requests" test hang for 120s.
- Plus 2 reliability fails: stale stream-disconnect hangup, and barge-in clear firing during a pending outbound initial message.

The dependency (`src/plugin-sdk/webhook-request-guards.ts`) exists in the fork but is likewise unaliased. This is a webhook-auth + DoS-hardening cluster → deferred to a focused, security-gated source PR.

## Verification

- `extensions/voice-call/` via `vitest.extensions.config.ts` (real lane config, quarantine active): **23 files / 147 tests pass**; `webhook.test.ts` correctly excluded.
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates): **pass**.
