### PR TITLE
test(groupB): un-quarantine zalo, bluebubbles, twitch, signal extension tests (#2782)

### DIFF
--- a/extensions/signal/src/accounts.ts
+++ b/extensions/signal/src/accounts.ts
@@ -14,7 +14,11 @@ export type ResolvedSignalAccount = {
   config: SignalAccountConfig;
 };
 
-const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("signal");
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("signal", {
+  implicitDefaultAccount: {
+    channelKeys: ["account"],
+  },
+});
 export const listSignalAccountIds = listAccountIds;
 export const resolveDefaultSignalAccountId = resolveDefaultAccountId;
 
@@ -37,7 +41,9 @@ export function resolveSignalAccount(params: {
   cfg: RemoteClawConfig;
   accountId?: string | null;
 }): ResolvedSignalAccount {
-  const accountId = normalizeAccountId(params.accountId);
+  const accountId = normalizeAccountId(
+    params.accountId ?? resolveDefaultSignalAccountId(params.cfg),
+  );
   const baseEnabled = params.cfg.channels?.signal?.enabled !== false;
   const merged = mergeSignalAccountConfig(params.cfg, accountId);
   const accountEnabled = merged.enabled !== false;

--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -3,13 +3,22 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const fetchWithTimeoutMock = vi.fn();
 const resolveFetchMock = vi.fn();
 
-vi.mock("remoteclaw/plugin-sdk/fetch-runtime", () => ({
-  resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
-}));
+// client.ts imports these directly from the repo-root `src/` tree, not from the
+// `remoteclaw/plugin-sdk/*` barrels, so the mocks must target the same specifiers
+// the source uses — otherwise the real fetch runs (ECONNREFUSED).
+vi.mock("../../../src/infra/fetch.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../src/infra/fetch.js")>(
+    "../../../src/infra/fetch.js",
+  );
+  return {
+    ...actual,
+    resolveFetch: (...args: unknown[]) => resolveFetchMock(...args),
+  };
+});
 
-vi.mock("remoteclaw/plugin-sdk/core", async () => {
-  const actual = await vi.importActual<typeof import("remoteclaw/plugin-sdk/core")>(
-    "remoteclaw/plugin-sdk/core",
+vi.mock("../../../src/infra/secure-random.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../src/infra/secure-random.js")>(
+    "../../../src/infra/secure-random.js",
   );
   return {
     ...actual,
@@ -17,9 +26,15 @@ vi.mock("remoteclaw/plugin-sdk/core", async () => {
   };
 });
 
-vi.mock("remoteclaw/plugin-sdk/text-runtime", () => ({
-  fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
-}));
+vi.mock("../../../src/utils/fetch-timeout.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../src/utils/fetch-timeout.js")>(
+    "../../../src/utils/fetch-timeout.js",
+  );
+  return {
+    ...actual,
+    fetchWithTimeout: (...args: unknown[]) => fetchWithTimeoutMock(...args),
+  };
+});
 
 let signalRpcRequest: typeof import("./client.js").signalRpcRequest;
 

--- a/extensions/twitch/src/config.ts
+++ b/extensions/twitch/src/config.ts
@@ -1,3 +1,8 @@
+import {
+  listCombinedAccountIds,
+  normalizeAccountId,
+  resolveNormalizedAccountEntry,
+} from "remoteclaw/plugin-sdk/account-resolution";
 import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/twitch";
 import type { TwitchAccountConfig } from "./types.js";
 
@@ -25,14 +30,19 @@ export function getAccountConfig(
   }
 
   const cfg = coreConfig as RemoteClawConfig;
+  const normalizedAccountId = normalizeAccountId(accountId);
   const twitch = cfg.channels?.twitch;
   // Access accounts via unknown to handle union type (single-account vs multi-account)
   const twitchRaw = twitch as Record<string, unknown> | undefined;
   const accounts = twitchRaw?.accounts as Record<string, TwitchAccountConfig> | undefined;
 
   // For default account, check base-level config first
-  if (accountId === DEFAULT_ACCOUNT_ID) {
-    const accountFromAccounts = accounts?.[DEFAULT_ACCOUNT_ID];
+  if (normalizedAccountId === DEFAULT_ACCOUNT_ID) {
+    const accountFromAccounts = resolveNormalizedAccountEntry(
+      accounts,
+      DEFAULT_ACCOUNT_ID,
+      normalizeAccountId,
+    );
 
     // Base-level properties that can form an implicit default account
     const baseLevel = {
@@ -76,11 +86,12 @@ export function getAccountConfig(
   }
 
   // For non-default accounts, only check accounts object
-  if (!accounts || !accounts[accountId]) {
+  const account = resolveNormalizedAccountEntry(accounts, normalizedAccountId, normalizeAccountId);
+  if (!account) {
     return null;
   }
 
-  return accounts[accountId] as TwitchAccountConfig | null;
+  return account;
 }
 
 /**
@@ -94,13 +105,6 @@ export function listAccountIds(cfg: RemoteClawConfig): string[] {
   const twitchRaw = twitch as Record<string, unknown> | undefined;
   const accountMap = twitchRaw?.accounts as Record<string, unknown> | undefined;
 
-  const ids: string[] = [];
-
-  // Add explicit accounts
-  if (accountMap) {
-    ids.push(...Object.keys(accountMap));
-  }
-
   // Add implicit "default" if base-level config exists and "default" not already present
   const hasBaseLevelConfig =
     twitchRaw &&
@@ -108,9 +112,10 @@ export function listAccountIds(cfg: RemoteClawConfig): string[] {
       typeof twitchRaw.accessToken === "string" ||
       typeof twitchRaw.channel === "string");
 
-  if (hasBaseLevelConfig && !ids.includes(DEFAULT_ACCOUNT_ID)) {
-    ids.push(DEFAULT_ACCOUNT_ID);
-  }
-
-  return ids;
+  return listCombinedAccountIds({
+    configuredAccountIds: Object.keys(accountMap ?? {}).map((accountId) =>
+      normalizeAccountId(accountId),
+    ),
+    implicitAccountId: hasBaseLevelConfig ? DEFAULT_ACCOUNT_ID : undefined,
+  });
 }

--- a/extensions/twitch/src/token.ts
+++ b/extensions/twitch/src/token.ts
@@ -9,6 +9,7 @@
  * 2. Environment variable: REMOTECLAW_TWITCH_ACCESS_TOKEN (default account only)
  */
 
+import { resolveNormalizedAccountEntry } from "remoteclaw/plugin-sdk/account-resolution";
 import {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
@@ -59,10 +60,8 @@ export function resolveTwitchToken(
 
   // Get merged account config (handles both simplified and multi-account patterns)
   const twitchCfg = cfg?.channels?.twitch;
-  const accountCfg =
-    accountId === DEFAULT_ACCOUNT_ID
-      ? (twitchCfg?.accounts?.[DEFAULT_ACCOUNT_ID] as Record<string, unknown> | undefined)
-      : (twitchCfg?.accounts?.[accountId] as Record<string, unknown> | undefined);
+  const accounts = twitchCfg?.accounts as Record<string, Record<string, unknown>> | undefined;
+  const accountCfg = resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
 
   // For default account, also check base-level config
   let token: string | undefined;

--- a/extensions/zalo/runtime-api.test.ts
+++ b/extensions/zalo/runtime-api.test.ts
@@ -22,7 +22,7 @@ describe("zalo runtime api", () => {
         "--import",
         "tsx",
         "-e",
-        'const runtimeApi = await import("./extensions/zalo/runtime-api.ts"); process.stdout.write(runtimeApi.zaloPlugin.id);',
+        'const runtimeApi = await import("./extensions/zalo/index.ts"); process.stdout.write(runtimeApi.default.id);',
       ],
       {
         cwd: repoRoot,

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -43,6 +43,17 @@
 /** Currently-failing test files under `extensions/**` (run by the `test-extensions` lane). */
 export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/acpx/src/manifest.test.ts",
+  // #2782 (groupB): 3 bluebubbles files stay, each out of this ledger-shrink's scope:
+  // - account-resolve: asserts an `allowPrivateNetworkConfig` field that the fork-authored
+  //   resolveBlueBubblesServerAccount (no parity at 27ae826f65) never emits and nothing consumes;
+  //   whether that SSRF/private-network flag should exist is a product decision, not a test fix.
+  // - attachments: fails to load — `Cannot find package 'remoteclaw/plugin-sdk/request-url'`. It IS a
+  //   real product subpath (src/plugin-sdk/request-url.ts exists) merely missing from the
+  //   vitest.config.ts resolve-alias mirror (needs `"request-url"` in pluginSdkSubpaths, like the
+  //   zalouser temp-path precedent); a harness fix outside this PR's allowed file set.
+  // - monitor-normalize: 2 fails want participant extraction from message-level `handles` /
+  //   `participantHandles`; extractChatContext only reads `participants`, and `participantHandles`
+  //   was never in the fork's history (feature-add, no parity) — separate source PR.
   "extensions/bluebubbles/src/account-resolve.test.ts",
   "extensions/bluebubbles/src/attachments.test.ts",
   "extensions/bluebubbles/src/monitor-normalize.test.ts",
@@ -98,8 +109,6 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/nextcloud-talk/src/room-info.test.ts",
   "extensions/nextcloud-talk/src/send.cfg-threading.test.ts",
   "extensions/nostr/src/channel.outbound.test.ts",
-  "extensions/signal/src/accounts.test.ts",
-  "extensions/signal/src/client.test.ts",
   "extensions/slack/src/client.test.ts",
   "extensions/slack/src/monitor.tool-result.test.ts",
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
@@ -117,8 +126,6 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/telegram/src/bot-message-dispatch.test.ts",
   "extensions/telegram/src/format.wrap-md.test.ts",
   "extensions/telegram/src/sequential-key.test.ts",
-  "extensions/twitch/src/config.test.ts",
-  "extensions/twitch/src/token.test.ts",
   "extensions/voice-call/src/manager.inbound-allowlist.test.ts",
   "extensions/voice-call/src/manager/events.test.ts",
   "extensions/voice-call/src/providers/plivo.test.ts",
@@ -129,7 +136,16 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/voice-call/src/webhook.test.ts",
   "extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts",
   "extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts",
-  "extensions/zalo/runtime-api.test.ts",
+  // #2782 (groupB): 2 zalo files stay, each out of this ledger-shrink's scope:
+  // - monitor.webhook: test expects registerZaloWebhookTarget to auto-register a plugin HTTP route
+  //   into registry.httpRoutes, but the fork only registers a route when opts.route is passed (API
+  //   changed); the resulting un-cleaned target also flips the "400 for non-object payloads" test to
+  //   401 (ambiguous-secret state leak). Webhook-ingress test rewrite — separate PR.
+  // - token: `uses configured defaultAccount token` is a real fork regression (token.ts dropped
+  //   `normalizeAccountId(accountId ?? config?.defaultAccount)`), but the file ALSO asserts that a
+  //   symlinked token file is REJECTED by throw; the shared tryReadSecretFileSync swallows that
+  //   rejection (returns undefined, never throws), so the file can't go green without a
+  //   src/infra/secret-file.ts change outside this PR's file set.
   "extensions/zalo/src/monitor.webhook.test.ts",
   "extensions/zalo/src/token.test.ts",
   // #2782 (zalouser): channel.directory + security-audit un-quarantined (they passed once the


### PR DESCRIPTION
Shrinks the #2782 quarantine ledger (the `test-extensions` CI-lane debt list) by
un-quarantining **5 of the 10** group-B files (channels: zalo, bluebubbles, twitch,
signal). Each un-quarantined file now runs green under `vitest.extensions.config.ts`;
the other 5 stay quarantined with per-line triage notes for out-of-scope reasons.

**#2782 stays OPEN** — other channels remain quarantined; no closing keyword used.

## Per-file outcome (all 10)

| File | Bucket | Disposition |
|------|--------|-------------|
| `signal/src/client.test.ts` | stale test (mock target) | **UN-Q** — re-pointed the 3 `vi.mock` specifiers to the repo-root `src/*` paths the source actually imports (`infra/fetch`, `utils/fetch-timeout`, `infra/secure-random`); the `remoteclaw/plugin-sdk/*` barrels were never the import site, so the real `fetch` ran (ECONNREFUSED). Test-only. |
| `signal/src/accounts.test.ts` | real SOURCE regression | **UN-Q** — SOURCE fix (below). |
| `twitch/src/config.test.ts` | real SOURCE regression | **UN-Q** — SOURCE fix (below). |
| `twitch/src/token.test.ts` | real SOURCE regression | **UN-Q** — SOURCE fix (below). |
| `zalo/runtime-api.test.ts` | stale test (deleted file) | **UN-Q** — the fork removed `extensions/zalo/runtime-api.ts` (entry is now `index.ts`); re-pointed the subprocess import to `./extensions/zalo/index.ts` and read `default.id`. Test-only. |
| `zalo/src/token.test.ts` | regression + shared-infra | **LEFT-Q** — `defaultAccount` token resolution is a real regression, but the file also asserts symlinked-token-file rejection **by throw**, which the shared `tryReadSecretFileSync` swallows (returns `undefined`). Can't go green without an out-of-scope `src/infra/secret-file.ts` change. |
| `zalo/src/monitor.webhook.test.ts` | API-changed + risky | **LEFT-Q** — test expects `registerZaloWebhookTarget` to auto-register a plugin HTTP route into `registry.httpRoutes`; the fork only registers when `opts.route` is passed (API changed), and the un-cleaned target also flips the "400 for non-object payloads" test to 401. Webhook-ingress test rewrite — separate PR. |
| `bluebubbles/src/account-resolve.test.ts` | stale / unconsumed field | **LEFT-Q** — asserts `allowPrivateNetworkConfig`, which the fork-authored `resolveBlueBubblesServerAccount` never emits and nothing consumes (no `27ae826f65` parity). A product decision on the SSRF/private-network return shape, not a test fix. |
| `bluebubbles/src/attachments.test.ts` | missing harness | **LEFT-Q** — `Cannot find package 'remoteclaw/plugin-sdk/request-url'`: a real product subpath (`src/plugin-sdk/request-url.ts` exists) missing from the `vitest.config.ts` resolve-alias mirror. One-line harness fix outside this PR's allowed file set. |
| `bluebubbles/src/monitor-normalize.test.ts` | feature-add | **LEFT-Q** — 2 fails want participant extraction from message-level `handles`/`participantHandles`; source `extractChatContext` reads only `participants`, and `participantHandles` was never in the fork's history (feature-add, no parity). Separate source PR. |

## SOURCE changes — flagged for review (restore dropped upstream behavior vs `27ae826f65`)

- **`twitch/src/config.ts` + `twitch/src/token.ts` — ⚠️ SECURITY-relevant (account-id normalization / authz).**
  The fork's `getAccountConfig` / `listAccountIds` / `resolveTwitchToken` looked accounts up with raw
  `accounts[accountId]` and listed raw `Object.keys(...)`, dropping upstream's `normalizeAccountId` +
  `resolveNormalizedAccountEntry` + `listCombinedAccountIds`. Regression re-introduced (a) prototype-chain
  reads (`accounts["inherited"]` on an `Object.create(...)` map) and (b) no control-char/ANSI stripping or
  case-normalization on account ids used for resolution/listing. Restored the upstream helpers (imported
  from `remoteclaw/plugin-sdk/account-resolution`, which is already in the vitest alias mirror). **Please
  security-review.**
- **`signal/src/accounts.ts` — account routing (low-risk).**
  Restored the dropped `createAccountListHelpers("signal", { implicitDefaultAccount: { channelKeys: ["account"] } })`
  (top-level `account` implies a `default` account in `listSignalAccountIds`) and the
  `?? resolveDefaultSignalAccountId(cfg)` fallback in `resolveSignalAccount` (honor configured
  `defaultAccount` when `accountId` is omitted).

## Discovered issues (reported, not fixed here)

1. **`extensions/zalo/src/token.ts`** dropped upstream `normalizeAccountId(accountId ?? config?.defaultAccount)`
   → configured `defaultAccount` is ignored for token selection. Left unfixed because the same file's symlink
   test can't pass without #2 below.
2. **Shared infra (security):** `src/infra/secret-file.ts` `tryReadSecretFileSync` returns `undefined` for **all**
   `loadSecretFileSync` failures — including `rejectSymlink` — silently converting a symlinked-secret-file
   rejection into an empty secret instead of throwing. `loadSecretFileSync` *does* detect the symlink; the
   `try*` wrapper swallows it. Affects every channel's token-file read.
3. **`vitest.config.ts`** resolve-alias mirror is missing `"request-url"` in `pluginSdkSubpaths` (blocks
   `bluebubbles/attachments.test.ts`); matches the zalouser `temp-path`/`dangerous-name-runtime` precedent.

## Verification

- Un-quarantined 5 via `vitest.extensions.config.ts`: **5 files, 29 tests — all green.**
- All 4 touched channel subsets via the real config: **33 files, 463 tests — all green** (still-quarantined
  files correctly excluded — "No test files found" when run explicitly).
- `pnpm check` (oxfmt + tsgo + oxlint): **PASS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
