### PR TITLE
test(groupC): un-quarantine synology-chat, nostr, line, irc, googlechat, diagnostics-otel, acpx extension tests (#2782)

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1190,6 +1190,27 @@ export function createDiagnosticsOtelService(): RemoteClawPluginService {
             case "run.attempt":
               recordRunAttempt(evt);
               return;
+            case "run.completed":
+              recordRunCompleted(evt);
+              return;
+            case "model.call.completed":
+              recordModelCallCompleted(evt);
+              return;
+            case "model.call.error":
+              recordModelCallError(evt);
+              return;
+            case "tool.execution.completed":
+              recordToolExecutionCompleted(evt);
+              return;
+            case "tool.execution.error":
+              recordToolExecutionError(evt);
+              return;
+            case "exec.process.completed":
+              recordExecProcessCompleted(evt);
+              return;
+            case "log.record":
+              recordLogRecord?.(evt);
+              return;
             case "diagnostic.heartbeat":
               recordHeartbeat(evt);
               return;

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -79,11 +79,17 @@ export async function sendMessageIrc(
     transient.quit("sent");
   }
 
-  runtime.channel.activity.record({
-    channel: "irc",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
+  try {
+    runtime.channel.activity.record({
+      channel: "irc",
+      accountId: account.accountId,
+      direction: "outbound",
+    });
+  } catch {
+    // Activity metrics are best-effort: an uninitialized/unavailable runtime
+    // store must not fail an otherwise-successful send. Restores the upstream
+    // `recordIrcOutboundActivity` try/catch guard dropped during fork sync.
+  }
 
   return {
     messageId: makeIrcMessageId(),

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -12,6 +12,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./nostr-bus.js", () => ({
   DEFAULT_RELAYS: ["wss://relay.example.com"],
   startNostrBus: mocks.startNostrBus,
+  // `channel.ts` imports `normalizePubkey` from `./nostr-bus.js` (which
+  // re-exports it from `./nostr-key-utils.js`), so the mock must expose it here.
+  normalizePubkey: mocks.normalizePubkey,
 }));
 
 vi.mock("./nostr-key-utils.js", () => ({

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -5,14 +5,11 @@ vi.mock("./webhook-handler.js", () => ({
   createWebhookHandler: vi.fn(() => vi.fn()),
 }));
 
-vi.mock("zod", () => ({
-  z: {
-    object: vi.fn(() => ({
-      passthrough: vi.fn(() => ({ _type: "zod-schema" })),
-    })),
-  },
-}));
-
+// NOTE: `zod` is intentionally NOT mocked. `channel.ts` only needs
+// `z.object({}).passthrough()`, but importing it transitively pulls in the core
+// config schema (`src/config/zod-schema.*`), which uses `z.string()`, `z.union()`,
+// etc. A partial `zod` stub broke that transitive import ("z.string is not a
+// function"); the real module satisfies every call site.
 const { createSynologyChatPlugin } = await import("./channel.js");
 
 describe("createSynologyChatPlugin", () => {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -173,14 +173,14 @@ export function createSynologyChatPlugin() {
         const trimmed = target.trim();
         if (!trimmed) return undefined;
         // Strip common prefixes
-        return trimmed.replace(/^synology[-_]?chat:/i, "").trim();
+        return trimmed.replace(/^synology(?:[-_]?chat)?:/i, "").trim();
       },
       targetResolver: {
         looksLikeId: (id: string) => {
           const trimmed = id?.trim();
           if (!trimmed) return false;
           // Synology Chat user IDs are numeric
-          return /^\d+$/.test(trimmed) || /^synology[-_]?chat:/i.test(trimmed);
+          return /^\d+$/.test(trimmed) || /^synology(?:[-_]?chat)?:/i.test(trimmed);
         },
         hint: "<userId>",
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,6 +76,8 @@ const pluginSdkSubpaths = [
   "ssrf-policy",
   "temp-path",
   "dangerous-name-runtime",
+  "webhook-request-guards",
+  "webhook-targets",
 ] as const;
 
 export default defineConfig({

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -42,11 +42,19 @@
 
 /** Currently-failing test files under `extensions/**` (run by the `test-extensions` lane). */
 export const EXTENSIONS_QUARANTINE: string[] = [
+  // #2782 (acpx): manifest.test.ts reads `extensions/acpx/package.json`, but that
+  // file does not exist in the fork (untracked; no build step generates it — the
+  // `test-extensions` CI lane runs no `pnpm build`), so it ENOENTs on clean CI
+  // too. acpx's own AGENTS.md documents `package.json` as a required, hand-
+  // maintained file, so its absence is a fork-integrity gap the test correctly
+  // catches; creating it is out of scope (would break `pnpm install
+  // --frozen-lockfile` without a coordinated pnpm-lock importer). The pinned deps
+  // it asserts DO live in the tracked `npm-shrinkwrap.json` — retargeting the test
+  // there is a viable alternative iff package.json is deemed intentionally absent.
   "extensions/acpx/src/manifest.test.ts",
   "extensions/bluebubbles/src/account-resolve.test.ts",
   "extensions/bluebubbles/src/attachments.test.ts",
   "extensions/bluebubbles/src/monitor-normalize.test.ts",
-  "extensions/diagnostics-otel/src/service.test.ts",
   "extensions/discord/src/monitor.test.ts",
   "extensions/discord/src/monitor.tool-result.sends-status-replies-responseprefix.test.ts",
   "extensions/discord/src/monitor/auto-presence.test.ts",
@@ -66,12 +74,17 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/feishu/src/media.test.ts",
   "extensions/feishu/src/monitor.reaction.test.ts",
   "extensions/feishu/src/send.reply-fallback.test.ts",
-  "extensions/googlechat/src/monitor.webhook-routing.test.ts",
   "extensions/imessage/src/accounts.test.ts",
   "extensions/imessage/src/monitor/deliver.test.ts",
   "extensions/imessage/src/monitor/inbound-processing.test.ts",
   "extensions/imessage/src/monitor/parse-notification.test.ts",
-  "extensions/irc/src/send.test.ts",
+  // #2782 (line): channel.sendPayload.test.ts — 8/12 pass; the 4 failures are a
+  // SOURCE gap (not a test fix). channel.ts `sendPayload` has no LINE video-media
+  // handling: `sendMediaMessages()` drops mediaKind/previewImageUrl/trackingId/
+  // durationMs, and the quick-reply inline media loop always emits `type:"image"`
+  // (never `type:"video"`) and never rejects video without previewImageUrl. That
+  // is a media-path feature to implement + verify, not reverse-engineer from the
+  // tests — separate PR.
   "extensions/line/src/channel.sendPayload.test.ts",
   // #2782 (matrix): 4 of 6 un-quarantined (channel.directory/allowlist/handler.body-for-agent
   // pass as-is on clean CI; format fixed test-side after restoring a dropped source guard — see
@@ -97,7 +110,6 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/nextcloud-talk/src/monitor.replay.test.ts",
   "extensions/nextcloud-talk/src/room-info.test.ts",
   "extensions/nextcloud-talk/src/send.cfg-threading.test.ts",
-  "extensions/nostr/src/channel.outbound.test.ts",
   "extensions/signal/src/accounts.test.ts",
   "extensions/signal/src/client.test.ts",
   "extensions/slack/src/client.test.ts",
@@ -105,7 +117,6 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
   "extensions/slack/src/monitor/slash.test.ts",
   "extensions/slack/src/send.identity-fallback.test.ts",
-  "extensions/synology-chat/src/channel.test.ts",
   "extensions/telegram/src/bot-message-context.audio-transcript.test.ts",
   "extensions/telegram/src/bot-message-context.body.test.ts",
   "extensions/telegram/src/bot-message-context.dm-threads.test.ts",


### PR DESCRIPTION
## Summary

Triages the 7 **groupC** entries in the `test-extensions` quarantine ledger
(`vitest.quarantine.ts`, tracked by #2782). **5 of 7 are un-quarantined** (now
green on the clean-CI lane); **line + acpx stay quarantined** with in-ledger
notes explaining why.

This **shrinks the #2782 quarantine ledger** but does **not** close it — other
channels remain quarantined.

## Per-file triage

| File | Bucket | Disposition |
|------|--------|-------------|
| `extensions/nostr/src/channel.outbound.test.ts` | Stale test (moved import) | **Un-quarantined** — mock `normalizePubkey` on `./nostr-bus.js` (source now imports it from there; it re-exports from `./nostr-key-utils.js`). Test-only. |
| `extensions/synology-chat/src/channel.test.ts` | Stale test + source regression | **Un-quarantined** — drop incomplete `vi.mock("zod")` stub (broke the transitive config-schema import: *"z.string is not a function"*) **and** a source regex fix (below). |
| `extensions/irc/src/send.test.ts` | Real source regression | **Un-quarantined** — source try/catch guard (below). |
| `extensions/googlechat/src/monitor.webhook-routing.test.ts` | Test-harness resolution gap | **Un-quarantined** — vitest resolve-mirror addition (below). |
| `extensions/diagnostics-otel/src/service.test.ts` | Real source regression | **Un-quarantined** — 7 dropped subscription `switch` cases re-wired (below). |
| `extensions/line/src/channel.sendPayload.test.ts` | Large source gap | **LEFT QUARANTINED** — 8/12 pass; the 4 failures need a LINE video-media source feature (see below). |
| `extensions/acpx/src/manifest.test.ts` | Structural / fork-integrity | **LEFT QUARANTINED** — reads a `package.json` that doesn't exist in the fork (see below). |

Per-channel results after the fix (full channel subsets, lane config):
`diagnostics-otel` 22✓ · `googlechat` 14✓ · `irc` 48✓ · `nostr` 274✓ ·
`synology-chat` 54✓. `pnpm check` (format + typecheck + lint + fork gates): **pass**.

## ⚠️ SOURCE changes (please review)

All three are regressions dropped during fork sync; the quarantined tests were
right and the code was wrong.

1. **`extensions/diagnostics-otel/src/service.ts`** — *touches secret-redaction
   + data-egress; please security-review.* The event-subscription `switch` had
   lost 7 cases while their handler functions stayed **defined but dead**:
   `run.completed`, `model.call.completed`, `model.call.error`,
   `tool.execution.completed`, `tool.execution.error`, `exec.process.completed`,
   `log.record`. Re-wiring them restores OTLP log/span/content export. The
   redaction, content-capture-gating (off by default), no-command-text and
   no-source-path behaviours are all asserted by the (now-passing) tests. This
   also fixes the two restart tests, which were failing only as a cascade
   (earlier tests threw before their `service.stop()` cleanup, leaking listeners).

2. **`extensions/irc/src/send.ts`** — *non-security.* Restore the try/catch
   around the best-effort `runtime.channel.activity.record(...)` call so a
   metrics-recording failure can't fail an otherwise-successful send. This is the
   upstream `recordIrcOutboundActivity` guard, dropped in a sync.

3. **`extensions/synology-chat/src/channel.ts`** — *non-security
   (target-prefix parsing).* Restore the optional-`chat` group in the target
   regex — `/^synology[-_]?chat:/i` → `/^synology(?:[-_]?chat)?:/i` — in both
   `normalizeTarget` and `looksLikeId`, so the short `synology:` prefix
   normalizes (upstream parity).

## Test-harness change (shared file — flagged)

**`vitest.config.ts`** — added `webhook-request-guards` and `webhook-targets` to
the plugin-sdk resolve-alias mirror so `googlechat/src/monitor-routing.ts`
resolves under vitest. Both are real `src/plugin-sdk/*.ts` files already resolved
by the tsconfig `remoteclaw/plugin-sdk/*` wildcard in the production build and
typecheck — this is purely a test-harness resolution gap (same pattern as the
prior zalouser un-quarantine). It's the one change outside the strict
test-file/source set; it is additive-only and can't affect production.

## Left quarantined (out of scope — reasoned in `vitest.quarantine.ts`)

- **line** — `channel.sendPayload.test.ts`: `sendPayload` has no LINE video-media
  handling (`sendMediaMessages()` drops `mediaKind`/`previewImageUrl`/
  `trackingId`/`durationMs`; the quick-reply inline loop always emits
  `type:"image"`, never `type:"video"`, and never rejects video without a
  preview). That's a media-path feature to implement + verify, not
  reverse-engineer from tests. Upstream has a different line structure, so no
  clean port reference exists. Separate PR.
- **acpx** — `manifest.test.ts` reads `extensions/acpx/package.json`, which is
  **absent** in the fork (untracked; no build step generates it, and the
  `test-extensions` lane runs no `pnpm build`), so it ENOENTs on clean CI too.
  acpx's own `AGENTS.md` documents `package.json` as a required hand-maintained
  file → its absence is a fork-integrity gap. Creating it would break
  `pnpm install --frozen-lockfile` without a coordinated pnpm-lock importer. The
  pinned deps it asserts do live in the tracked `npm-shrinkwrap.json`;
  retargeting the test there is a viable alternative iff `package.json` is deemed
  intentionally absent. Separate handling.

Part of #2782 (keeps it open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
