### PR TITLE
test(slack): un-quarantine slack extension tests (#2782)

### DIFF
--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -517,6 +517,9 @@ describe("monitorSlackProvider tool results", () => {
   });
 
   it("reacts to mention-gated room messages when ackReaction is enabled", async () => {
+    (slackTestState.config as { messages: Record<string, unknown> }).messages.statusReactions = {
+      enabled: false,
+    };
     replyMock.mockResolvedValue(undefined);
     const client = getSlackClient();
     if (!client) {
@@ -555,7 +558,7 @@ describe("monitorSlackProvider tool results", () => {
     expect(upsertPairingRequestMock).toHaveBeenCalled();
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock.mock.calls[0]?.[1]).toContain("Your Slack user id: U1");
-    expect(sendMock.mock.calls[0]?.[1]).toContain("Pairing code: PAIRCODE");
+    expect(sendMock.mock.calls[0]?.[1]).toContain("Pairing code:\n```\nPAIRCODE\n```");
   });
 
   it("does not resend pairing code when a request is already pending", async () => {

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -100,8 +100,24 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/nostr/src/channel.outbound.test.ts",
   "extensions/signal/src/accounts.test.ts",
   "extensions/signal/src/client.test.ts",
+  // #2782 (slack): monitor.tool-result un-quarantined (test-side: the ack-reaction test
+  // needs statusReactions disabled to exercise the direct one-shot react path — status
+  // reactions now supersede it when enabled; pairing assertion updated to the shared
+  // fenced buildPairingReply format). The 4 below stay, each out of scope for a test-side
+  // un-quarantine (see PR for details):
+  // - client: proxy-agent support was gutted (no client-options.ts); restoring needs new
+  //   plugin-sdk fetch-runtime helpers (resolveEnvHttpProxyUrl / resolveActiveManagedProxyTlsOptions)
+  //   that don't exist in the fork — a network-egress SOURCE change for a separate security-gated PR.
+  // - send.identity-fallback: send.ts dropped upstream's Slack Web API error-enrichment
+  //   (needed/granted/accepted detail) + the unfurl_links:false payload default; restoring is a
+  //   SOURCE change with blast radius on non-quarantined send tests (unfurl_links on every payload).
+  // - dispatch.preview-fallback: obsolete premise — dispatch.ts finalizes previews via inline
+  //   chat.update now, not finalizeSlackPreviewEdit (which is dead code); the test needs a rewrite.
+  // - slash: createReplyPrefixOptions mock gap (test-side, fixable) is not enough — slash.ts also
+  //   dropped GroupSpace:ctx.teamId from the ctx payload (SOURCE regression; the message path still
+  //   sets it) AND the arg-menu subsystem (21 tests) diverged from upstream (action_id suffixing
+  //   removed, RegExp→string listener) needing a large, correctness-sensitive reconciliation.
   "extensions/slack/src/client.test.ts",
-  "extensions/slack/src/monitor.tool-result.test.ts",
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
   "extensions/slack/src/monitor/slash.test.ts",
   "extensions/slack/src/send.identity-fallback.test.ts",


### PR DESCRIPTION
## Summary

Shrinks the #2782 quarantine ledger (`vitest.quarantine.ts`) by **un-quarantining 1 of the 5 slack extension test files** via **test-side-only** fixes. The other 4 are left quarantined because each needs a source change or a test rewrite that is out of scope for a test-side un-quarantine — root causes documented per-file below (and inline in the ledger).

Ledger #2782 is intentionally left **open** for the remaining channels (note: it appears to have been closed by the umbrella batch already — see the PR checklist; this PR does not carry a closing keyword and must not re-close it).

## Per-file outcome

| File | Bucket | Outcome |
|------|--------|---------|
| `monitor.tool-result.test.ts` | STALE TEST (×2) | ✅ **UN-QUARANTINED** (test-only) |
| `client.test.ts` | REAL SOURCE REGRESSION | ⛔ LEFT QUARANTINED |
| `send.identity-fallback.test.ts` | REAL SOURCE REGRESSION | ⛔ LEFT QUARANTINED |
| `monitor/message-handler/dispatch.preview-fallback.test.ts` | STALE TEST (obsolete premise) | ⛔ LEFT QUARANTINED |
| `monitor/slash.test.ts` | MIXED (stale mock + source regression + subsystem divergence) | ⛔ LEFT QUARANTINED |

### ✅ `monitor.tool-result.test.ts` — un-quarantined (test-only, no source change)
2 stale assertions, both matching intentional current fork behavior:
- **ack-reaction test** — asserted the one-shot `reactions.add`, but `prepare.ts` now defers the ack to the **status-reactions** system unless `statusReactions.enabled === false`. Fix: the test disables `statusReactions` so the direct one-shot react path (the behavior it means to verify) is exercised.
- **pairing test** — asserted the old inline `Pairing code: PAIRCODE`; the shared `buildPairingReply` now emits a fenced block. Fix: assertion updated to the fenced format.

Result: `extensions/slack/` lane green — **63 files, 514 passed, 1 skipped**; `monitor.tool-result.test.ts` = 24/24.

## Left quarantined — discovered issues (no fix applied; for separate handling)

**No source changes are made in this PR.** The following were *discovered* during triage and need their own PRs:

- ⚠️ **`client.test.ts` — SOURCE (network-egress / security-relevant).** The fork's `extensions/slack/src/client.ts` (40 lines) dropped the proxy-agent support upstream keeps in `client-options.ts` (`resolveSlackProxyAgent` + `NO_PROXY` handling + managed-proxy CA trust). Restoring needs new plugin-sdk `fetch-runtime` helpers (`resolveEnvHttpProxyUrl`, `resolveActiveManagedProxyTlsOptions`) that don't exist in the fork's plugin-sdk. → separate security-gated PR.
- ⚠️ **`send.identity-fallback.test.ts` — SOURCE.** `send.ts` dropped upstream's Slack Web API error-enrichment (`formatSlackWebApiErrorMessage`/`enrichSlackWebApiError` → the `(needed: …; granted: …; accepted: …)` detail) and the `unfurl_links: false` payload default. Restoring has **blast radius** — `unfurl_links` lands on every payload and 3 non-quarantined send tests (`channel`/`send.upload`/`send.blocks`) assert payloads. (Same shape as the feishu "send.ts lost the error-diagnostics wrap" note.) Also: the test mocks `logVerbose` on `plugin-sdk/runtime-env`, but `send.ts` imports it from `src/globals.js` (a stale mock-target). → separate SOURCE PR.
- **`dispatch.preview-fallback.test.ts` — obsolete premise.** The test asserts `finalizeSlackPreviewEdit` is called during dispatch, but `dispatch.ts` now finalizes previews via inline `ctx.app.client.chat.update(...)`; `finalizeSlackPreviewEdit` (`preview-finalize.ts`) is **dead code** (no source importer). It also carried two now-fixed-in-isolation staleness layers (an incomplete `text-runtime` mock missing `normalizeOptionalString`; a mock targeting the **deleted** `../reply.runtime.js` instead of the canonical `src/auto-reply/dispatch.js` + `reply-dispatcher.js`). Needs a rewrite against the `chat.update` flow. → separate test-rewrite PR.
- ⚠️ **`slash.test.ts` — MIXED (slash-command path, security-relevant).** Three independent issues:
  1. *(test-side, fixable)* The slash harness mock (`slash.test-harness.ts`) omits `createReplyPrefixOptions`, which `slash.ts` imports from the mocked `slash-dispatch.runtime.js` barrel → the allow→dispatch path throws (silently swallowed) so 5 dispatch tests get 0 calls and 1 test hangs 120s.
  2. **SOURCE regression:** `slash.ts` dropped `GroupSpace: ctx.teamId || undefined` from the slash ctx payload — the fork's own message path still sets it (`prepare.ts:749`), upstream sets it (L688), and `GroupSpace` is a live session-metadata field (`metadata.ts`, `groups.ts`, `inbound-meta.ts`).
  3. **Subsystem divergence:** the "native command argument menus" describe (21 tests, currently all skipped by a failing `beforeAll`) asserts upstream's suffixed action_ids (`remoteclaw_cmdarg_0_0`) + RegExp listener; the fork emits only the exact `remoteclaw_cmdarg` and registers a string listener — a large, correctness-sensitive reconciliation (and the fork's arg-menu design needs validation).
  → separate PR (with security review for the `GroupSpace`/slash-path changes).

## Testing
- `extensions/slack/` via `vitest.extensions.config.ts`: 63 files / 514 passed / 1 skipped.
- `monitor.tool-result.test.ts` explicitly under the real config: 24/24.
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates): pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)