### PR TITLE
test(groupA): un-quarantine nextcloud-talk, mattermost, imessage extension tests (#2782)

### DIFF
--- a/extensions/imessage/src/accounts.ts
+++ b/extensions/imessage/src/accounts.ts
@@ -13,7 +13,13 @@ export type ResolvedIMessageAccount = {
   configured: boolean;
 };
 
-const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("imessage");
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("imessage", {
+  // Top-level channels.imessage.cliPath/dbPath configure the implicit "default"
+  // account, so it must appear alongside any named accounts.
+  implicitDefaultAccount: {
+    channelKeys: ["cliPath", "dbPath"],
+  },
+});
 export const listIMessageAccountIds = listAccountIds;
 export const resolveDefaultIMessageAccountId = resolveDefaultAccountId;
 
@@ -40,7 +46,9 @@ export function resolveIMessageAccount(params: {
   cfg: RemoteClawConfig;
   accountId?: string | null;
 }): ResolvedIMessageAccount {
-  const accountId = normalizeAccountId(params.accountId);
+  const accountId = normalizeAccountId(
+    params.accountId ?? resolveDefaultIMessageAccountId(params.cfg),
+  );
   const baseEnabled = params.cfg.channels?.imessage?.enabled !== false;
   const merged = mergeIMessageAccountConfig(params.cfg, accountId);
   const accountEnabled = merged.enabled !== false;

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "remoteclaw/plugin-sdk/text-runtime";
+import { stripImessageLengthPrefixedUtf8Text } from "./strip-imsg-length-prefixed-text.js";
 import type { IMessagePayload } from "./types.js";
 
 function isOptionalString(value: unknown): value is string | null | undefined {
@@ -87,5 +88,17 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
     return null;
   }
 
-  return message;
+  // The imsg RPC can wrap text/reply_to_text in a length-delimited field
+  // wrapper; strip it so downstream consumers see the plain UTF-8 payload.
+  return {
+    ...message,
+    text:
+      typeof message.text === "string"
+        ? stripImessageLengthPrefixedUtf8Text(message.text)
+        : message.text,
+    reply_to_text:
+      typeof message.reply_to_text === "string"
+        ? stripImessageLengthPrefixedUtf8Text(message.reply_to_text)
+        : message.reply_to_text,
+  };
 }

--- a/extensions/mattermost/channel-plugin-api.test.ts
+++ b/extensions/mattermost/channel-plugin-api.test.ts
@@ -15,14 +15,17 @@ const importEnv = {
 } satisfies NodeJS.ProcessEnv;
 
 describe("mattermost bundled api seam", () => {
-  it("loads the narrow channel plugin api in direct smoke", async () => {
+  // The fork exposes the bundled Mattermost plugin value via the
+  // `channel-plugin-runtime.ts` seam (there is no `channel-plugin-api.ts` /
+  // `mattermostSetupPlugin` — those upstream seams were consolidated away).
+  it("loads the channel plugin runtime seam in direct smoke", async () => {
     const { stdout } = await execFileAsync(
       process.execPath,
       [
         "--import",
         "tsx",
         "-e",
-        'const mod = await import("./extensions/mattermost/channel-plugin-api.ts"); process.stdout.write(JSON.stringify({keys:Object.keys(mod).sort(), id: mod.mattermostPlugin.id, setupId: mod.mattermostSetupPlugin.id}));',
+        'const mod = await import("./extensions/mattermost/channel-plugin-runtime.ts"); process.stdout.write(JSON.stringify({keys:Object.keys(mod).sort(), id: mod.mattermostPlugin.id}));',
       ],
       {
         cwd: repoRoot,
@@ -31,8 +34,6 @@ describe("mattermost bundled api seam", () => {
       },
     );
 
-    expect(stdout).toBe(
-      '{"keys":["mattermostPlugin","mattermostSetupPlugin"],"id":"mattermost","setupId":"mattermost"}',
-    );
+    expect(stdout).toBe('{"keys":["mattermostPlugin"],"id":"mattermost"}');
   }, 45_000);
 });

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -7,9 +7,9 @@ import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 
 describe("deliverMattermostReplyPayload", () => {
   it("passes agent-scoped mediaLocalRoots when sending media paths", async () => {
-    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousStateDir = process.env.REMOTECLAW_STATE_DIR;
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-mm-state-"));
-    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.REMOTECLAW_STATE_DIR = stateDir;
 
     try {
       const sendMessage = vi.fn(async () => undefined);
@@ -53,9 +53,9 @@ describe("deliverMattermostReplyPayload", () => {
       );
     } finally {
       if (previousStateDir === undefined) {
-        delete process.env.OPENCLAW_STATE_DIR;
+        delete process.env.REMOTECLAW_STATE_DIR;
       } else {
-        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        process.env.REMOTECLAW_STATE_DIR = previousStateDir;
       }
       await fs.rm(stateDir, { recursive: true, force: true });
     }

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -65,7 +65,10 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
   pairing: {
     idLabel: "nextcloudUserId",
     normalizeAllowEntry: (entry) =>
-      entry.replace(/^(nextcloud-talk|nc-talk|nc):/i, "").toLowerCase(),
+      entry
+        .trim()
+        .replace(/^(nextcloud-talk|nc-talk|nc):/i, "")
+        .toLowerCase(),
     notifyApproval: async ({ id }) => {
       console.log(`[nextcloud-talk] User ${id} approved for pairing`);
     },
@@ -129,7 +132,11 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
         policy: account.config.dmPolicy,
         allowFrom: account.config.allowFrom ?? [],
         policyPathSuffix: "dmPolicy",
-        normalizeEntry: (raw) => raw.replace(/^(nextcloud-talk|nc-talk|nc):/i, "").toLowerCase(),
+        normalizeEntry: (raw) =>
+          raw
+            .trim()
+            .replace(/^(nextcloud-talk|nc-talk|nc):/i, "")
+            .toLowerCase(),
       });
     },
     collectWarnings: ({ account, cfg }) => {

--- a/extensions/nextcloud-talk/src/room-info.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.test.ts
@@ -4,9 +4,13 @@ import { resolveNextcloudTalkRoomKind, __testing } from "./room-info.js";
 const fetchWithSsrFGuard = vi.hoisted(() => vi.fn());
 const readFileSync = vi.hoisted(() => vi.fn());
 
-vi.mock("../runtime-api.js", () => {
+// Source imports `fetchWithSsrFGuard` from the plugin-sdk barrel, not the local
+// `../runtime-api.js` re-export — mock the module the source actually resolves.
+vi.mock("remoteclaw/plugin-sdk/nextcloud-talk", () => {
   return vi
-    .importActual<typeof import("../runtime-api.js")>("../runtime-api.js")
+    .importActual<typeof import("remoteclaw/plugin-sdk/nextcloud-talk")>(
+      "remoteclaw/plugin-sdk/nextcloud-talk",
+    )
     .then((actual) => ({
       ...actual,
       fetchWithSsrFGuard,

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -107,9 +107,16 @@ export async function resolveNextcloudTalkRoomKind(params: {
         return undefined;
       }
 
-      const payload = (await response.json()) as {
-        ocs?: { data?: { type?: number | string } };
-      };
+      let payload: { ocs?: { data?: { type?: number | string } } };
+      try {
+        payload = (await response.json()) as {
+          ocs?: { data?: { type?: number | string } };
+        };
+      } catch {
+        // Produce a stable, Node-version-independent error instead of leaking
+        // the engine-specific JSON SyntaxError text.
+        throw new Error("Nextcloud Talk room info failed: malformed JSON response");
+      }
       const type = coerceRoomType(payload.ocs?.data?.type);
       const kind = resolveRoomKindFromType(type);
       roomCache.set(key, { fetchedAt: Date.now(), kind });

--- a/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
+++ b/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
@@ -11,25 +11,26 @@ const hoisted = vi.hoisted(() => ({
   convertMarkdownTables: vi.fn((text: string) => text),
   record: vi.fn(),
   resolveNextcloudTalkAccount: vi.fn(),
-  ssrfPolicyFromPrivateNetworkOptIn: vi.fn(() => undefined),
   generateNextcloudTalkSignature: vi.fn(() => ({
     random: "r",
     signature: "s",
   })),
-  mockFetchGuard: vi.fn(),
 }));
 
-vi.mock("./send.runtime.js", () => {
-  return {
-    convertMarkdownTables: hoisted.convertMarkdownTables,
-    fetchWithSsrFGuard: hoisted.mockFetchGuard,
-    generateNextcloudTalkSignature: hoisted.generateNextcloudTalkSignature,
-    getNextcloudTalkRuntime: () => createSendCfgThreadingRuntime(hoisted),
-    resolveNextcloudTalkAccount: hoisted.resolveNextcloudTalkAccount,
-    resolveMarkdownTableMode: hoisted.resolveMarkdownTableMode,
-    ssrfPolicyFromPrivateNetworkOptIn: hoisted.ssrfPolicyFromPrivateNetworkOptIn,
-  };
-});
+// The fork's send.ts imports helpers directly from the real modules (there is no
+// `./send.runtime.js` barrel), reads config/markdown/activity off the runtime
+// object, and calls the global `fetch` directly.
+vi.mock("./runtime.js", () => ({
+  getNextcloudTalkRuntime: () => createSendCfgThreadingRuntime(hoisted),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveNextcloudTalkAccount: hoisted.resolveNextcloudTalkAccount,
+}));
+
+vi.mock("./signature.js", () => ({
+  generateNextcloudTalkSignature: hoisted.generateNextcloudTalkSignature,
+}));
 
 const { sendMessageNextcloudTalk, sendReactionNextcloudTalk } = await import("./send.js");
 
@@ -69,16 +70,10 @@ describe("nextcloud-talk send cfg threading", () => {
 
   beforeEach(() => {
     vi.stubGlobal("fetch", fetchMock);
-    // Route the SSRF guard mock through the global fetch mock.
-    hoisted.mockFetchGuard.mockImplementation(async (p: { url: string; init?: RequestInit }) => {
-      const response = await globalThis.fetch(p.url, p.init);
-      return { response, release: async () => {}, finalUrl: p.url };
-    });
     hoisted.loadConfig.mockReset();
     hoisted.resolveMarkdownTableMode.mockClear();
     hoisted.convertMarkdownTables.mockClear();
     hoisted.record.mockReset();
-    hoisted.ssrfPolicyFromPrivateNetworkOptIn.mockClear();
     hoisted.generateNextcloudTalkSignature.mockClear();
     hoisted.resolveNextcloudTalkAccount.mockReset();
     hoisted.resolveNextcloudTalkAccount.mockReturnValue(defaultAccount);
@@ -86,7 +81,6 @@ describe("nextcloud-talk send cfg threading", () => {
 
   afterEach(() => {
     fetchMock.mockReset();
-    hoisted.mockFetchGuard.mockReset();
     vi.unstubAllGlobals();
   });
 

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -157,11 +157,20 @@ export async function sendMessageNextcloudTalk(
     console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
   }
 
-  getNextcloudTalkRuntime().channel.activity.record({
-    channel: "nextcloud-talk",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
+  // Activity recording is best-effort: the message has already been sent, so a
+  // recording failure (e.g. runtime store not initialized) must not fail the
+  // send. Re-throw any other error.
+  try {
+    getNextcloudTalkRuntime().channel.activity.record({
+      channel: "nextcloud-talk",
+      accountId: account.accountId,
+      direction: "outbound",
+    });
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== "Nextcloud Talk runtime not initialized") {
+      throw error;
+    }
+  }
 
   return { messageId, roomToken, timestamp };
 }

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -67,10 +67,21 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/feishu/src/monitor.reaction.test.ts",
   "extensions/feishu/src/send.reply-fallback.test.ts",
   "extensions/googlechat/src/monitor.webhook-routing.test.ts",
-  "extensions/imessage/src/accounts.test.ts",
+  // #2782 (imessage): accounts + parse-notification un-quarantined via SOURCE fixes — accounts.ts
+  // restores the createAccountListHelpers `implicitDefaultAccount` options + `defaultAccount`
+  // resolution; parse-notification.ts restores stripImessageLengthPrefixedUtf8Text. The 2 below
+  // stay, each needing out-of-scope work:
+  // - deliver: the fork gutted the sentText/echoText send-result contract (send.ts returns only
+  //   {messageId}); test asserts the actual media-echo placeholder + post-send-only remember
+  //   (#47830, no pre-send full-text remember). Restoring is a multi-module outbound/self-chat-echo
+  //   subsystem change — separate PR.
+  // - inbound-processing: SECURITY-sensitive — the dmPolicy access-control + echo/self-chat
+  //   detection ORDER diverged from upstream (fork does access-before-echo; tests expect
+  //   echo/self-chat-before-access) AND `dmPolicy:"open"` with an empty allowlist blocks where the
+  //   tests expect allow; reconciling touches shared src/security/dm-policy-shared authz — separate
+  //   security-reviewed PR.
   "extensions/imessage/src/monitor/deliver.test.ts",
   "extensions/imessage/src/monitor/inbound-processing.test.ts",
-  "extensions/imessage/src/monitor/parse-notification.test.ts",
   "extensions/irc/src/send.test.ts",
   "extensions/line/src/channel.sendPayload.test.ts",
   // #2782 (matrix): 4 of 6 un-quarantined (channel.directory/allowlist/handler.body-for-agent
@@ -89,14 +100,20 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   //   is a wholesale test rewrite over correctness-sensitive shutdown paths — separate PR.
   "extensions/matrix/src/manifest.test.ts",
   "extensions/matrix/src/matrix/monitor/index.test.ts",
-  "extensions/mattermost/channel-plugin-api.test.ts",
+  // #2782 (mattermost): channel-plugin-api + reply-delivery un-quarantined (test-side — retarget
+  // the bundled-seam smoke test to channel-plugin-runtime.ts since the fork consolidated away
+  // channel-plugin-api.ts/mattermostSetupPlugin; rebrand OPENCLAW_STATE_DIR→REMOTECLAW_STATE_DIR).
+  // The 2 below stay, each needing out-of-scope work:
+  // - interactions: 2/47 assert an un-ported post-threading feature — forwarding the fetched `post`
+  //   (with root_id) to resolveSessionKey (positional→object signature change), handleInteraction,
+  //   and dispatchButtonClick for thread-scoped session keys; spans interactions.ts + monitor.ts
+  //   session-key resolution — multi-file, separate PR.
+  // - monitor-auth: SECURITY (authz) — normalizeMattermostAllowEntry lowercases `accessGroup:Ops`
+  //   entries, but the test expects case-preserved (upstream parseAccessGroupAllowFromEntry). The
+  //   access-group allowlist-normalization semantics need a security-reviewed source change —
+  //   separate PR. (The file's other two tests also carry a stale mock target + sync/async drift.)
   "extensions/mattermost/src/mattermost/interactions.test.ts",
   "extensions/mattermost/src/mattermost/monitor-auth.test.ts",
-  "extensions/mattermost/src/mattermost/reply-delivery.test.ts",
-  "extensions/nextcloud-talk/src/channel.core.test.ts",
-  "extensions/nextcloud-talk/src/monitor.replay.test.ts",
-  "extensions/nextcloud-talk/src/room-info.test.ts",
-  "extensions/nextcloud-talk/src/send.cfg-threading.test.ts",
   "extensions/nostr/src/channel.outbound.test.ts",
   "extensions/signal/src/accounts.test.ts",
   "extensions/signal/src/client.test.ts",


### PR DESCRIPTION
## Summary

Group A of the #2782 un-quarantine effort: the three **KEPT** channel-infrastructure directories **nextcloud-talk**, **mattermost**, and **imessage**. Of the 12 targeted quarantined test files, **8 are un-quarantined** (they now pass under the real `vitest.extensions.config.ts` lane) and **4 stay quarantined** with inline-documented rationale, each deferred to a separate (security-reviewed where noted) PR.

This PR intentionally does **not** close #2782 — it is one group of a multi-group effort. `Refs #2782` only.

## Per-file triage

| File | Bucket | Disposition |
|------|--------|-------------|
| `nextcloud-talk/src/channel.core.test.ts` | REAL SOURCE REGRESSION | **Un-quarantined** — SOURCE fix in `channel.ts` (see below) |
| `nextcloud-talk/src/monitor.replay.test.ts` | STALE QUARANTINE (passes as-is) | **Un-quarantined** — no change needed |
| `nextcloud-talk/src/room-info.test.ts` | STALE TEST + REAL SOURCE REGRESSION | **Un-quarantined** — test retargets dead `../runtime-api.js` mock → `remoteclaw/plugin-sdk/nextcloud-talk`; SOURCE fix in `room-info.ts` |
| `nextcloud-talk/src/send.cfg-threading.test.ts` | STALE TEST + REAL SOURCE REGRESSION | **Un-quarantined** — test drops the dead `./send.runtime.js` barrel mock for real `./runtime.js`/`./accounts.js`/`./signature.js`; SOURCE fix in `send.ts` |
| `mattermost/channel-plugin-api.test.ts` | STALE TEST | **Un-quarantined** — retarget subprocess seam to `channel-plugin-runtime.ts` (fork consolidated away `channel-plugin-api.ts`/`mattermostSetupPlugin`) |
| `mattermost/src/mattermost/reply-delivery.test.ts` | STALE TEST | **Un-quarantined** — rebrand `OPENCLAW_STATE_DIR` → `REMOTECLAW_STATE_DIR` (4×) |
| `mattermost/src/mattermost/interactions.test.ts` | REAL SOURCE REGRESSION | **LEFT QUARANTINED** — 2/47 assert an un-ported post-threading feature (forward fetched `post` w/ `root_id` through `resolveSessionKey` [positional→object signature], `handleInteraction`, `dispatchButtonClick`); spans `interactions.ts` + `monitor.ts`. Multi-file, out of scope |
| `mattermost/src/mattermost/monitor-auth.test.ts` | REAL SOURCE REGRESSION (**SECURITY/authz**) | **LEFT QUARANTINED** — `normalizeMattermostAllowEntry` lowercases `accessGroup:Ops`; test expects case-preserved (upstream `parseAccessGroupAllowFromEntry`). Access-group allowlist-normalization semantics need a security-reviewed source change |
| `imessage/src/accounts.test.ts` | REAL SOURCE REGRESSION | **Un-quarantined** — SOURCE fix in `accounts.ts` (see below) |
| `imessage/src/monitor/deliver.test.ts` | REAL SOURCE REGRESSION | **LEFT QUARANTINED** — fork gutted the `sentText`/`echoText` send-result contract (`send.ts` returns only `{messageId}`); restoring is a multi-module outbound/self-chat-echo change. Separate PR |
| `imessage/src/monitor/inbound-processing.test.ts` | REAL SOURCE REGRESSION (**SECURITY**) | **LEFT QUARANTINED** — `dmPolicy` access-control + echo/self-chat detection **order** diverged from upstream (fork does access-before-echo; tests expect echo/self-chat-before-access), and `dmPolicy:"open"` + empty allowlist blocks where tests expect allow. Touches shared `src/security/dm-policy-shared` authz. Separate security-reviewed PR |
| `imessage/src/monitor/parse-notification.test.ts` | REAL SOURCE REGRESSION | **Un-quarantined** — SOURCE fix in `parse-notification.ts` (see below) |

## SOURCE changes (⚠ flagged for review)

All five are **fork-regression restorations** — behavior upstream had that the fork dropped during sync. Minimal scope, `pnpm check` clean.

1. **`nextcloud-talk/src/channel.ts`** — add `.trim()` to the `normalizeAllowEntry` (pairing) and `normalizeEntry` (DM allowlist) lambdas. **SECURITY-ADJACENT (authz):** the allowlist/pairing normalizer fails **closed** without it, and the sibling `policy.ts` already trims — this restores fork-internal consistency. Please give this an independent authz look.
2. **`nextcloud-talk/src/room-info.ts`** — wrap the `response.json()` parse in try/catch to emit a stable, Node-version-independent `"Nextcloud Talk room info failed: malformed JSON response"` (upstream funneled this through `readProviderJsonResponse`, which the fork dropped). Robustness only.
3. **`nextcloud-talk/src/send.ts`** — make `activity.record()` best-effort: the message is already sent, so a *"Nextcloud Talk runtime not initialized"* recording failure must not fail the send. The catch is **narrow** — it re-throws every other error. Robustness only.
4. **`imessage/src/accounts.ts`** — restore `createAccountListHelpers("imessage", { implicitDefaultAccount: { channelKeys: ["cliPath", "dbPath"] } })` (so top-level `channels.imessage.cliPath/dbPath` synthesize the implicit `default` account) and resolve the configured default in `resolveIMessageAccount` (`params.accountId ?? resolveDefaultIMessageAccountId(params.cfg)`). Account-resolution correctness.
5. **`imessage/src/monitor/parse-notification.ts`** — restore `stripImessageLengthPrefixedUtf8Text` on `text`/`reply_to_text` (typeof-string-guarded) so downstream consumers see plain UTF-8. Text-parsing correctness.

## Verification

- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates): **green**.
- Each channel run under the real lane config with the edited quarantine (`vitest run --config vitest.extensions.config.ts extensions/<ch>`):
  - nextcloud-talk: **6 files / 22 tests** pass
  - mattermost: **22 files / 209 tests** pass
  - imessage: **16 files / 119 tests** pass
- `vitest.quarantine.ts`: only the 8 un-quarantined lines removed; the 4 kept entries annotated with why; no other channel's lines touched.

Scope: only the 12 targeted test files (+ their source, where a real regression was flagged) and the nextcloud-talk/mattermost/imessage quarantine lines were changed.
