### PR TITLE
fix(slack): restore GroupSpace in slash-command session ctx (#2958)

### DIFF
--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -13,6 +13,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./slash-dispatch.runtime.js", () => {
   return {
+    createReplyPrefixOptions: vi.fn(() => ({
+      responsePrefix: undefined,
+      enableSlackInteractiveReplies: undefined,
+      responsePrefixContextProvider: () => ({}),
+    })),
     deliverSlackSlashReplies: vi.fn(async () => {}),
     dispatchReplyWithDispatcher: (...args: unknown[]) => mocks.dispatchMock(...args),
     finalizeInboundContext: (...args: unknown[]) => mocks.finalizeInboundContextMock(...args),

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -517,7 +517,15 @@ function responseTexts(mock: ReturnType<typeof vi.fn>): unknown[] {
   );
 }
 
-describe("Slack native command argument menus", () => {
+// FORK-SYNC: skipped — this suite asserts upstream's arg-menu registration shape, which the
+// fork diverged from: upstream registers the action listener by RegExp and suffixes per-arg
+// action_ids, while slash.ts registers the bare string constant SLACK_COMMAND_ARG_ACTION_ID
+// ("remoteclaw_cmdarg") for every arg (see slash.ts registerArgAction / action_id usages).
+// Its beforeAll therefore throws "Missing arg-menu action handler" and fails the whole file.
+// Reconciling is a correctness-sensitive source change across the arg-menu subsystem — out of
+// scope here, tracked in #2782. Skipping it in-file (rather than quarantining the file) keeps
+// the other 11 tests running in CI, including the #2958 GroupSpace regression guard.
+describe.skip("Slack native command argument menus", () => {
   let harness: ReturnType<typeof createArgMenusHarness>;
   let usageHandler: (args: unknown) => Promise<void>;
   let reportHandler: (args: unknown) => Promise<void>;

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -592,6 +592,7 @@ export async function registerSlackMonitorSlashCommands(params: {
                 : `slack:group:${command.channel_id}`,
           }) ?? (isDirectMessage ? senderName : roomLabel),
         GroupSubject: isRoomish ? roomLabel : undefined,
+        GroupSpace: ctx.teamId || undefined,
         GroupSystemPrompt: groupSystemPrompt,
         UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
         SenderName: senderName,

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -141,8 +141,13 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   // #2782 (slack): monitor.tool-result un-quarantined (test-side: the ack-reaction test
   // needs statusReactions disabled to exercise the direct one-shot react path — status
   // reactions now supersede it when enabled; pairing assertion updated to the shared
-  // fenced buildPairingReply format). The 4 below stay, each out of scope for a test-side
-  // un-quarantine (see PR for details):
+  // fenced buildPairingReply format).
+  // #2958 (slack): slash un-quarantined — its ctx-payload GroupSpace SOURCE regression is fixed
+  // and the createReplyPrefixOptions mock gap closed, so 11 of its 32 tests now run in CI
+  // (including the GroupSpace regression guard). The remaining arg-menu divergence is skipped
+  // in-file via `describe.skip` with rationale (slash.test.ts) rather than darkening the whole
+  // file here — narrower debt, still tracked by #2782.
+  // The 3 below stay, each out of scope for a test-side un-quarantine (see PR for details):
   // - client: proxy-agent support was gutted (no client-options.ts); restoring needs new
   //   plugin-sdk fetch-runtime helpers (resolveEnvHttpProxyUrl / resolveActiveManagedProxyTlsOptions)
   //   that don't exist in the fork — a network-egress SOURCE change for a separate security-gated PR.
@@ -151,13 +156,8 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   //   SOURCE change with blast radius on non-quarantined send tests (unfurl_links on every payload).
   // - dispatch.preview-fallback: obsolete premise — dispatch.ts finalizes previews via inline
   //   chat.update now, not finalizeSlackPreviewEdit (which is dead code); the test needs a rewrite.
-  // - slash: createReplyPrefixOptions mock gap (test-side, fixable) is not enough — slash.ts also
-  //   dropped GroupSpace:ctx.teamId from the ctx payload (SOURCE regression; the message path still
-  //   sets it) AND the arg-menu subsystem (21 tests) diverged from upstream (action_id suffixing
-  //   removed, RegExp→string listener) needing a large, correctness-sensitive reconciliation.
   "extensions/slack/src/client.test.ts",
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
-  "extensions/slack/src/monitor/slash.test.ts",
   "extensions/slack/src/send.identity-fallback.test.ts",
   "extensions/telegram/src/bot-message-context.audio-transcript.test.ts",
   "extensions/telegram/src/bot-message-context.body.test.ts",


### PR DESCRIPTION
Closes #2958

## Problem

The Slack slash-command inbound path omitted `GroupSpace` from the context payload it persists, while the Slack message path sets it. `ctx.teamId` was resolved at `slash.ts` but passed only to `resolveAgentRoute` — never into the `finalizeInboundContext(...)` payload that `recordInboundSessionMetaSafe` persists.

Slash-initiated sessions therefore carried an unset group `space`, which propagates to spawned subagents (`agentGroupSpace`) and gateway group inheritance — inconsistent group session identity between the slash and message entry points.

This is a metadata/consistency fix, **not** an isolation or authorization boundary: the session key already incorporates `teamId`.

## Fix

One line in `extensions/slack/src/monitor/slash.ts`, mirroring the message path (`message-handler/prepare.ts:749`):

```ts
GroupSpace: ctx.teamId || undefined,
```

## Test coverage

The regression guard already existed (`slash.test.ts` — "calls recordSessionMetaFromInbound after dispatching a slash command" asserts `GroupSpace === "T1"`), but the whole file was **file-level quarantined**, so it ran in no CI job. Two separate blockers kept it dark:

1. **`createReplyPrefixOptions` mock gap (test-side).** `slash.test-harness.ts` mocked `slash-dispatch.runtime.js` with 8 of the module's 9 exports. The missing one is called by `slash.ts` before dispatch, so it threw and 6 tests failed for reasons unrelated to this bug. Adding it leaves **exactly one** failure — `expected undefined to be 'T1'` at the `GroupSpace` assertion — which confirms the test genuinely detects this defect rather than passing incidentally.

2. **Arg-menu suite divergence (out of scope).** Its `beforeAll` throws `Missing arg-menu action handler`: the fork registers the bare string constant `SLACK_COMMAND_ARG_ACTION_ID` (`"remoteclaw_cmdarg"`) for every arg, where upstream used a RegExp listener with per-arg `action_id` suffixing. Reconciling that is a correctness-sensitive source change across the arg-menu subsystem. It is skipped in-file with rationale — matching the existing `FORK-SYNC` `it.skip` precedent in `extensions/slack/src/format.test.ts` — rather than darkening the entire file.

Net effect: **11 of 32 tests now run in CI (was 0)**, including the `GroupSpace` guard. The remaining arg-menu debt is narrower, documented at the suite, and still tracked by #2782 — one line comes off the quarantine ledger.

## Verification

| Gate | Result |
|---|---|
| `slash.test.ts` before fix (mock gap closed, source untouched) | 1 failed — the `GroupSpace` assertion — 10 passed |
| `slash.test.ts` after fix | **11 passed**, 21 skipped, exit 0 |
| Full `test-extensions` lane (`vitest.extensions.config.ts`) | **455 files, 4314 passed**, 22 skipped, exit 0 |
| `pnpm check` (format + lint + tsgo, incl. rebrand/lobster/CSS gates) | clean, exit 0 |

## Note for follow-up (not in this PR)

A principle re-scan across every channel's `finalizeInboundContext` call site found the **same defect shape in Mattermost**: `mattermost/monitor.ts` sets `GroupSpace: teamId` on the message path, but `mattermost/slash-http.ts` has `teamId` in scope and sets `GroupSubject` while omitting `GroupSpace`. Left untouched here to keep this PR scoped to #2958; worth its own issue. Every other channel either sets it or has no group-space concept.