### PR TITLE
fix(discord): fall back to default gateway URL on transient metadata errors (#2966)

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -8,6 +8,7 @@ import type { DiscordAccountConfig } from "../../../../src/config/types.js";
 import { danger } from "../../../../src/globals.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
+import { normalizeDiscordGatewayInfoTimeoutMs } from "./timeouts.js";
 
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
@@ -61,30 +62,89 @@ function isTransientDiscordGatewayResponse(status: number, body: string): boolea
   );
 }
 
+/**
+ * Carries the transient verdict on the error itself so callers can branch on it without re-sniffing
+ * the message.
+ *
+ * `name` is deliberately left as the inherited "Error": `provider.ts`'s #2692 gateway-rejection guard
+ * and `src/infra/unhandled-rejections.ts` both classify these by MESSAGE, and the latter special-cases
+ * `name === "AbortError"`. Renaming would silently re-route both.
+ */
+class DiscordGatewayMetadataError extends Error {
+  readonly transient: boolean;
+
+  constructor(message: string, options: { transient: boolean; cause?: unknown }) {
+    super(message, { cause: options.cause });
+    this.transient = options.transient;
+  }
+}
+
 function createGatewayMetadataError(params: {
   detail: string;
   transient: boolean;
   cause?: unknown;
-}): Error {
+}): DiscordGatewayMetadataError {
   if (params.transient) {
-    return new Error("Failed to get gateway information from Discord: fetch failed", {
-      cause: params.cause ?? new Error(params.detail),
-    });
+    return new DiscordGatewayMetadataError(
+      "Failed to get gateway information from Discord: fetch failed",
+      { transient: true, cause: params.cause ?? new Error(params.detail) },
+    );
   }
-  return new Error(`Failed to get gateway information from Discord: ${params.detail}`, {
-    cause: params.cause,
-  });
+  return new DiscordGatewayMetadataError(
+    `Failed to get gateway information from Discord: ${params.detail}`,
+    { transient: false, cause: params.cause },
+  );
 }
 
-async function fetchDiscordGatewayInfo(params: {
+function isTransientGatewayMetadataError(error: unknown): boolean {
+  return error instanceof DiscordGatewayMetadataError && error.transient;
+}
+
+/**
+ * Bound `run` by `timeoutMs`, aborting it on expiry and rejecting with a transient metadata error.
+ *
+ * The abort alone is not enough: a caller-supplied `fetchImpl` may ignore the signal, so the race is
+ * what guarantees the deadline.
+ */
+async function runWithGatewayMetadataTimeout<T>(params: {
+  timeoutMs: number;
+  run: (signal: AbortSignal) => Promise<T>;
+}): Promise<T> {
+  const controller = new AbortController();
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      controller.abort();
+      reject(
+        createGatewayMetadataError({
+          detail: `Discord API /gateway/bot timed out after ${params.timeoutMs}ms`,
+          transient: true,
+        }),
+      );
+    }, params.timeoutMs);
+  });
+  const runPromise = params.run(controller.signal);
+  // Once the timeout wins the race, the abort rejects the in-flight fetch with nobody listening.
+  // Attaching a handler marks it handled without consuming the rejection the race still sees.
+  runPromise.catch(() => {});
+  try {
+    return await Promise.race([runPromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+async function readDiscordGatewayInfo(params: {
   token: string;
   fetchImpl: DiscordGatewayFetch;
   fetchInit?: DiscordGatewayFetchInit;
+  signal: AbortSignal;
 }): Promise<APIGatewayBotInfo> {
   let response: DiscordGatewayMetadataResponse;
   try {
     response = await params.fetchImpl(DISCORD_GATEWAY_BOT_URL, {
       ...params.fetchInit,
+      signal: params.signal,
       headers: {
         ...params.fetchInit?.headers,
         Authorization: `Bot ${params.token}`,
@@ -136,6 +196,18 @@ async function fetchDiscordGatewayInfo(params: {
   }
 }
 
+function fetchDiscordGatewayInfo(params: {
+  token: string;
+  fetchImpl: DiscordGatewayFetch;
+  fetchInit?: DiscordGatewayFetchInit;
+  timeoutMs: number;
+}): Promise<APIGatewayBotInfo> {
+  return runWithGatewayMetadataTimeout({
+    timeoutMs: params.timeoutMs,
+    run: (signal) => readDiscordGatewayInfo({ ...params, signal }),
+  });
+}
+
 function createGatewayPlugin(params: {
   options: {
     reconnect: { maxAttempts: number };
@@ -145,21 +217,51 @@ function createGatewayPlugin(params: {
   fetchImpl: DiscordGatewayFetch;
   fetchInit?: DiscordGatewayFetchInit;
   wsAgent?: HttpsProxyAgent<string>;
+  runtime: RuntimeEnv;
+  gatewayInfoTimeoutMs: number;
 }): GatewayPlugin {
   class SafeGatewayPlugin extends GatewayPlugin {
+    /** True while `gatewayInfo` holds the default-URL fallback rather than a real /gateway/bot payload. */
+    private usedFallbackGatewayInfo = false;
+
     constructor() {
       super(params.options);
     }
 
     override async registerClient(client: Parameters<GatewayPlugin["registerClient"]>[0]) {
-      if (!this.gatewayInfo) {
-        this.gatewayInfo = await fetchDiscordGatewayInfo({
-          token: client.options.token,
-          fetchImpl: params.fetchImpl,
-          fetchInit: params.fetchInit,
-        });
+      // Re-enter on a fallback so the next attempt gets a real payload instead of pinning the
+      // default URL for the process lifetime.
+      if (!this.gatewayInfo || this.usedFallbackGatewayInfo) {
+        this.gatewayInfo = await this.resolveGatewayInfo(client.options.token);
       }
       return super.registerClient(client);
+    }
+
+    private async resolveGatewayInfo(token: string): Promise<APIGatewayBotInfo> {
+      try {
+        const gatewayInfo = await fetchDiscordGatewayInfo({
+          token,
+          fetchImpl: params.fetchImpl,
+          fetchInit: params.fetchInit,
+          timeoutMs: params.gatewayInfoTimeoutMs,
+        });
+        this.usedFallbackGatewayInfo = false;
+        return gatewayInfo;
+      } catch (error) {
+        // A bad/revoked token (401/403), a 429, or a proxy interstitial on a 2xx never resolves by
+        // retrying — keep those fatal so provider.ts's #2692 guard still classifies them.
+        if (!isTransientGatewayMetadataError(error)) {
+          throw error;
+        }
+        this.usedFallbackGatewayInfo = true;
+        params.runtime.log?.(
+          `discord: gateway metadata lookup failed transiently, connecting to ${DEFAULT_DISCORD_GATEWAY_URL} and refreshing metadata on the next attempt: ${formatErrorMessage(error)}`,
+        );
+        // `shards` / `session_start_limit` are omitted deliberately: Carbon's non-sharded
+        // GatewayPlugin reads only `url` off gatewayInfo (its `connect()` defaults to this very
+        // URL); the rest is ShardingPlugin's, which this fork does not use.
+        return { url: DEFAULT_DISCORD_GATEWAY_URL } as APIGatewayBotInfo;
+      }
     }
 
     override createWebSocket(url: string) {
@@ -179,6 +281,9 @@ export function createDiscordGatewayPlugin(params: {
 }): GatewayPlugin {
   const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
   const proxy = params.discordConfig?.proxy?.trim();
+  const gatewayInfoTimeoutMs = normalizeDiscordGatewayInfoTimeoutMs(
+    params.discordConfig?.gatewayInfoTimeoutMs,
+  );
   const options = {
     reconnect: { maxAttempts: 50 },
     intents,
@@ -189,6 +294,8 @@ export function createDiscordGatewayPlugin(params: {
     return createGatewayPlugin({
       options,
       fetchImpl: (input, init) => fetch(input, init as RequestInit),
+      runtime: params.runtime,
+      gatewayInfoTimeoutMs,
     });
   }
 
@@ -203,12 +310,16 @@ export function createDiscordGatewayPlugin(params: {
       fetchImpl: (input, init) => undiciFetch(input, init),
       fetchInit: { dispatcher: fetchAgent },
       wsAgent,
+      runtime: params.runtime,
+      gatewayInfoTimeoutMs,
     });
   } catch (err) {
     params.runtime.error?.(danger(`discord: invalid gateway proxy: ${String(err)}`));
     return createGatewayPlugin({
       options,
       fetchImpl: (input, init) => fetch(input, init as RequestInit),
+      runtime: params.runtime,
+      gatewayInfoTimeoutMs,
     });
   }
 }

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -7,6 +7,7 @@ const {
   globalFetchMock,
   HttpsProxyAgent,
   getLastAgent,
+  MockWebSocket,
   restProxyAgentSpy,
   undiciFetchMock,
   undiciProxyAgentSpy,
@@ -33,6 +34,12 @@ const {
     GuildMembers: 1 << 7,
   } as const;
 
+  class MockWebSocket {
+    constructor(url: string, options?: { agent?: unknown }) {
+      webSocketSpy(url, options);
+    }
+  }
+
   class GatewayPlugin {
     options: unknown;
     gatewayInfo: unknown;
@@ -42,6 +49,11 @@ const {
     }
     async registerClient(client: unknown) {
       baseRegisterClientSpy(client);
+    }
+    // Mirrors Carbon's own GatewayPlugin.createWebSocket, which already constructs from `ws` with no
+    // options — that is what makes "uses ws even without proxy" true for the un-proxied `super` path.
+    createWebSocket(url: string) {
+      return new MockWebSocket(url);
     }
   }
 
@@ -65,6 +77,7 @@ const {
     globalFetchMock,
     HttpsProxyAgent,
     getLastAgent: () => HttpsProxyAgent.lastCreated,
+    MockWebSocket,
     restProxyAgentSpy,
     undiciFetchMock,
     undiciProxyAgentSpy,
@@ -99,11 +112,7 @@ vi.mock("undici", () => ({
 }));
 
 vi.mock("ws", () => ({
-  default: class MockWebSocket {
-    constructor(url: string, options?: { agent?: unknown }) {
-      webSocketSpy(url, options);
-    }
-  },
+  default: MockWebSocket,
 }));
 
 describe("createDiscordGatewayPlugin", () => {
@@ -319,13 +328,15 @@ describe("createDiscordGatewayPlugin", () => {
     vi.useFakeTimers();
     const runtime = createRuntime();
     globalFetchMock.mockImplementation(() => new Promise(() => {}));
+    // A short configured timeout both crosses the fake-timer deadline below and asserts that
+    // discord.gatewayInfoTimeoutMs is threaded from config through to the metadata-fetch race.
     const plugin = createDiscordGatewayPlugin({
-      discordConfig: {},
+      discordConfig: { gatewayInfoTimeoutMs: 5_000 },
       runtime,
     });
 
     const registerPromise = registerGatewayClient(plugin);
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(5_000);
     await registerPromise;
 
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -4,6 +4,10 @@ export const DISCORD_DEFAULT_LISTENER_TIMEOUT_MS = 120_000;
 export const DISCORD_DEFAULT_INBOUND_WORKER_TIMEOUT_MS = 30 * 60_000;
 export const DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS = 60_000;
 export const DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS = 120_000;
+export const DISCORD_DEFAULT_GATEWAY_INFO_TIMEOUT_MS = 30_000;
+// Mirrors the `.max(120_000)` bound the config schema already enforces on
+// `discord.gatewayInfoTimeoutMs` (src/config/zod-schema.providers-core.ts).
+const MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 120_000;
 
 function clampDiscordTimeoutMs(timeoutMs: number, minimumMs: number): number {
   return Math.max(minimumMs, Math.min(Math.floor(timeoutMs), MAX_DISCORD_TIMEOUT_MS));
@@ -14,6 +18,13 @@ export function normalizeDiscordListenerTimeoutMs(raw: number | undefined): numb
     return DISCORD_DEFAULT_LISTENER_TIMEOUT_MS;
   }
   return clampDiscordTimeoutMs(raw!, 1_000);
+}
+
+export function normalizeDiscordGatewayInfoTimeoutMs(raw: number | undefined): number {
+  if (!Number.isFinite(raw) || (raw ?? 0) <= 0) {
+    return DISCORD_DEFAULT_GATEWAY_INFO_TIMEOUT_MS;
+  }
+  return Math.min(Math.floor(raw!), MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS);
 }
 
 export function normalizeDiscordInboundWorkerTimeoutMs(

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -73,7 +73,6 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/discord/src/monitor/message-handler.queue.test.ts",
   "extensions/discord/src/monitor/message-utils.test.ts",
   "extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts",
-  "extensions/discord/src/monitor/provider.proxy.test.ts",
   "extensions/discord/src/monitor/provider.rest-proxy.test.ts",
   "extensions/discord/src/monitor/threading.starter.test.ts",
   "extensions/discord/src/voice-message.test.ts",


### PR DESCRIPTION
Closes #2966.

## Problem

When the Discord bot starts, `createDiscordGatewayPlugin` fetches gateway metadata from `/gateway/bot` before opening the gateway WebSocket. `SafeGatewayPlugin.registerClient` awaited that fetch with no error handling, so **any** failure — including transient ones (HTTP 5xx, edge `upstream connect error` / `disconnect/reset before headers` interstitials) — aborted client registration and the bot never came online. There was also no timeout, so a hung `/gateway/bot` request stalled registration indefinitely.

## Fix

`SafeGatewayPlugin` now resolves gateway metadata through `resolveGatewayInfo`, which classifies failures:

- **Transient** (5xx, edge reset/interstitial bodies, body-read errors, or a timeout) → fall back to the well-known `DEFAULT_DISCORD_GATEWAY_URL` (`wss://gateway.discord.gg/`), log `discord: gateway metadata lookup failed transiently …`, and still call `super.registerClient(client)` so the socket opens. A `usedFallbackGatewayInfo` flag makes the next `registerClient` re-fetch real metadata instead of pinning the default URL for the process lifetime.
- **Fatal** (401/403, 429, proxy interstitial on a 2xx) → still throw, so `provider.ts`'s #2692 gateway-rejection guard keeps classifying them and the socket does not open.

The metadata fetch is now bounded by a configurable timeout, `discord.gatewayInfoTimeoutMs` (default 30 000 ms, max 120 000 ms), enforced via `AbortController` + `Promise.race` so a hung or signal-ignoring fetch also triggers the transient fallback.

The transient `DiscordGatewayMetadataError` deliberately keeps its inherited `name` of `"Error"`: `provider.ts` and `src/infra/unhandled-rejections.ts` classify these by message (the latter special-cases `AbortError`), so renaming would silently re-route both.

## Testing

`extensions/discord/src/monitor/provider.proxy.test.ts` is re-enabled (removed from `vitest.quarantine.ts`) and covers all three paths — transient-fallback, timeout-triggers-fallback, and non-transient-stays-fatal — plus fallback-metadata refresh on the next attempt.

- `pnpm check` (format + tsgo + lint): clean, 0 errors
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/discord/src/monitor/provider.proxy.test.ts`: 10/10 pass
- Sibling gateway-plugin suites (`provider.test.ts`, `provider.unhandled-rejection.test.ts`): 11/11 pass, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)