### PR TITLE
fix(feishu): fail thread replies to withdrawn targets instead of top-level fallback (#2957)

### DIFF
--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "remoteclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { createFeishuApiError, requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
 import { parsePostContent } from "./post.js";
@@ -90,16 +91,53 @@ async function sendFallbackDirect(
   },
   errorPrefix: string,
 ): Promise<FeishuSendResult> {
-  const response = await client.im.message.create({
-    params: { receive_id_type: params.receiveIdType },
-    data: {
-      receive_id: params.receiveId,
-      content: params.content,
-      msg_type: params.msgType,
-    },
-  });
+  const response = await requestFeishuApi(
+    () =>
+      client.im.message.create({
+        params: { receive_id_type: params.receiveIdType },
+        data: {
+          receive_id: params.receiveId,
+          content: params.content,
+          msg_type: params.msgType,
+        },
+      }),
+    errorPrefix,
+    { includeNestedErrorLogId: true },
+  );
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
+}
+
+const THREAD_REPLY_FALLBACK_BLOCKED_ERROR =
+  "Feishu thread reply failed: reply target is unavailable and cannot safely fall back to a top-level send.";
+
+/**
+ * Decide how to handle a withdrawn/unavailable reply target.
+ *
+ * A thread reply (`replyInThread`) must never silently escalate to a top-level
+ * message: falling back would broadcast thread-scoped content to the whole chat
+ * (over-disclosure). Unless the caller explicitly opts in via
+ * `allowTopLevelReplyFallback`, a thread reply to an unavailable target FAILS.
+ * Non-thread replies retain the existing top-level fallback.
+ */
+function sendReplyFallbackOrThrow(
+  client: FeishuCreateMessageClient,
+  params: {
+    replyInThread?: boolean;
+    allowTopLevelReplyFallback?: boolean;
+    directParams: {
+      receiveId: string;
+      receiveIdType: "chat_id" | "email" | "open_id" | "union_id" | "user_id";
+      content: string;
+      msgType: string;
+    };
+    directErrorPrefix: string;
+  },
+): Promise<FeishuSendResult> {
+  if (params.replyInThread && params.allowTopLevelReplyFallback !== true) {
+    throw new Error(THREAD_REPLY_FALLBACK_BLOCKED_ERROR);
+  }
+  return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
 }
 
 async function sendReplyOrFallbackDirect(
@@ -107,6 +145,7 @@ async function sendReplyOrFallbackDirect(
   params: {
     replyToMessageId?: string;
     replyInThread?: boolean;
+    allowTopLevelReplyFallback?: boolean;
     content: string;
     msgType: string;
     directParams: {
@@ -135,12 +174,12 @@ async function sendReplyOrFallbackDirect(
     });
   } catch (err) {
     if (!isWithdrawnReplyError(err)) {
-      throw err;
+      throw createFeishuApiError(err, params.replyErrorPrefix, { includeNestedErrorLogId: true });
     }
-    return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
+    return sendReplyFallbackOrThrow(client, params);
   }
   if (shouldFallbackFromReplyTarget(response)) {
-    return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
+    return sendReplyFallbackOrThrow(client, params);
   }
   assertFeishuMessageApiSuccess(response, params.replyErrorPrefix);
   return toFeishuSendResult(response, params.directParams.receiveId);
@@ -288,6 +327,12 @@ export type SendFeishuMessageParams = {
   replyToMessageId?: string;
   /** When true, reply creates a Feishu topic thread instead of an inline reply */
   replyInThread?: boolean;
+  /**
+   * When true, a reply to an unavailable (withdrawn/deleted) target may fall back
+   * to a top-level send even for thread replies. Defaults to false: thread replies
+   * FAIL rather than escalate thread-scoped content to the whole chat.
+   */
+  allowTopLevelReplyFallback?: boolean;
   /** Mention target users */
   mentions?: MentionTarget[];
   /** Account ID (optional, uses default if not specified) */
@@ -319,7 +364,16 @@ function buildFeishuPostMessagePayload(params: { messageText: string }): {
 export async function sendMessageFeishu(
   params: SendFeishuMessageParams,
 ): Promise<FeishuSendResult> {
-  const { cfg, to, text, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const {
+    cfg,
+    to,
+    text,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    mentions,
+    accountId,
+  } = params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const tableMode = getFeishuRuntime().channel.text.resolveMarkdownTableMode({
     cfg,
@@ -339,6 +393,7 @@ export async function sendMessageFeishu(
   return sendReplyOrFallbackDirect(client, {
     replyToMessageId,
     replyInThread,
+    allowTopLevelReplyFallback,
     content,
     msgType,
     directParams,
@@ -354,11 +409,18 @@ export type SendFeishuCardParams = {
   replyToMessageId?: string;
   /** When true, reply creates a Feishu topic thread instead of an inline reply */
   replyInThread?: boolean;
+  /**
+   * When true, a reply to an unavailable (withdrawn/deleted) target may fall back
+   * to a top-level send even for thread replies. Defaults to false: thread replies
+   * FAIL rather than escalate thread-scoped content to the whole chat.
+   */
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 };
 
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
-  const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, card, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } =
+    params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
@@ -366,6 +428,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   return sendReplyOrFallbackDirect(client, {
     replyToMessageId,
     replyInThread,
+    allowTopLevelReplyFallback,
     content,
     msgType: "interactive",
     directParams,
@@ -432,17 +495,40 @@ export async function sendMarkdownCardFeishu(params: {
   replyToMessageId?: string;
   /** When true, reply creates a Feishu topic thread instead of an inline reply */
   replyInThread?: boolean;
+  /**
+   * When true, a reply to an unavailable (withdrawn/deleted) target may fall back
+   * to a top-level send even for thread replies. Defaults to false: thread replies
+   * FAIL rather than escalate thread-scoped content to the whole chat.
+   */
+  allowTopLevelReplyFallback?: boolean;
   /** Mention target users */
   mentions?: MentionTarget[];
   accountId?: string;
 }): Promise<FeishuSendResult> {
-  const { cfg, to, text, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const {
+    cfg,
+    to,
+    text,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    mentions,
+    accountId,
+  } = params;
   let cardText = text;
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
   const card = buildMarkdownCard(cardText);
-  return sendCardFeishu({ cfg, to, card, replyToMessageId, replyInThread, accountId });
+  return sendCardFeishu({
+    cfg,
+    to,
+    card,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+  });
 }
 
 /**

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -76,14 +76,12 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/discord/src/monitor/provider.rest-proxy.test.ts",
   "extensions/discord/src/monitor/threading.starter.test.ts",
   "extensions/discord/src/voice-message.test.ts",
-  // #2782 (feishu): monitor.reaction/send.reply-fallback remain — each needs a
-  // separate SOURCE change (see PR for un-quarantine of the other 6, which were stale
-  // tests fixed test-side). monitor.account.ts lacks receive-layer early-event dedup;
-  // send.ts lost the thread-reply-fallback safety guard + Feishu error-diagnostics wrap.
-  // media.test.ts un-quarantined in #2969 (content-type→file_type routing + download
-  // header metadata restored in media.ts).
+  // #2782 (feishu): monitor.reaction remains — needs a separate SOURCE change
+  // (monitor.account.ts lacks receive-layer early-event dedup). send.reply-fallback.test.ts
+  // un-quarantined in #2957 (thread-reply-fallback safety guard + Feishu error-diagnostics
+  // wrap restored in send.ts). media.test.ts un-quarantined in #2969 (content-type→file_type
+  // routing + download header metadata restored in media.ts).
   "extensions/feishu/src/monitor.reaction.test.ts",
-  "extensions/feishu/src/send.reply-fallback.test.ts",
   // #2782 (imessage): accounts + parse-notification un-quarantined via SOURCE fixes — accounts.ts
   // restores the createAccountListHelpers `implicitDefaultAccount` options + `defaultAccount`
   // resolution; parse-notification.ts restores stripImessageLengthPrefixedUtf8Text. The 2 below


### PR DESCRIPTION
## Summary

A Feishu reply configured to stay in a thread (`replyInThread: true`) whose target had been withdrawn/deleted silently fell back to a top-level `im.message.create`, broadcasting thread-scoped content to the **entire chat** — an over-disclosure of content intended for a narrower audience (which may include agent output meant for a smaller group). The reply should fail rather than escalate its audience.

## Fix

- Add `allowTopLevelReplyFallback?: boolean` to the Feishu send params (public types + internal path). When `replyInThread === true` and the caller has **not** opted in, both withdrawn-target fallback branches now **throw** (`Feishu thread reply failed: reply target is unavailable and cannot safely fall back to a top-level send.`) instead of escalating the audience. Non-thread replies (`replyInThread` false/unset) retain the existing top-level fallback.
- Route the fallback `create` and the non-withdrawn reply catch through the existing `requestFeishuApi` / `createFeishuApiError` diagnostics wrap (`includeNestedErrorLogId`), so Feishu error detail (`http_status`, `feishu_code`, `feishu_log_id`, `feishu_troubleshooter`) is preserved instead of surfacing a bare Axios/SDK message.

## Tests

Un-quarantines `extensions/feishu/src/send.reply-fallback.test.ts` — the pre-written coverage for exactly this guard + diagnostics wrap (its quarantine ledger entry named the owed source change: *"send.ts lost the thread-reply-fallback safety guard + Feishu error-diagnostics wrap"*). Reproduction: against the pre-fix source the file is **3 failed | 8 passed**; with the fix it is **11 passed**.

- thread + withdrawn target → send **throws**, `im.message.create` **not** called (both response-code and thrown-error variants).
- non-thread + withdrawn target → still falls back to a top-level send (allowed).
- direct-send rejection preserves Feishu diagnostics in the thrown message.

Verified locally: full feishu extension lane (`vitest.extensions.config.ts`, 33 files / 360 tests) green; `pnpm check` (format + tsgo + lint + fork-integrity gates) green.

Closes #2957
