### PR TITLE
fix(mattermost): preserve accessGroup: allowlist entry case — restore access-group authorization (#2959)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-auth.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.test.ts
@@ -3,10 +3,18 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const isDangerousNameMatchingEnabled = vi.hoisted(() => vi.fn());
 const resolveAllowlistMatchSimple = vi.hoisted(() => vi.fn());
 
-vi.mock("./runtime-api.js", () => ({
-  isDangerousNameMatchingEnabled,
-  resolveAllowlistMatchSimple,
-}));
+// monitor-auth.ts resolves these two sender helpers from `remoteclaw/plugin-sdk/mattermost`
+// (the fork consolidated the former `./runtime-api.js` seam into the plugin-sdk barrel).
+// Override only those two; keep every other real export (parseAccessGroupAllowFromEntry,
+// resolveControlCommandGate, resolveEffectiveAllowFromLists, group-access helpers, …).
+vi.mock("remoteclaw/plugin-sdk/mattermost", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("remoteclaw/plugin-sdk/mattermost")>();
+  return {
+    ...actual,
+    isDangerousNameMatchingEnabled,
+    resolveAllowlistMatchSimple,
+  };
+});
 
 describe("mattermost monitor auth", () => {
   let authorizeMattermostCommandInvocation: typeof import("./monitor-auth.js").authorizeMattermostCommandInvocation;
@@ -31,6 +39,7 @@ describe("mattermost monitor auth", () => {
   it("normalizes allowlist entries", () => {
     expect(normalizeMattermostAllowEntry(" @Alice ")).toBe("alice");
     expect(normalizeMattermostAllowEntry("mattermost:Bob")).toBe("bob");
+    expect(normalizeMattermostAllowEntry("User:Alice")).toBe("alice");
     expect(normalizeMattermostAllowEntry("accessGroup:Ops")).toBe("accessGroup:Ops");
     expect(normalizeMattermostAllowEntry("*")).toBe("*");
     expect(normalizeMattermostAllowList([" Alice ", "user:alice", "ALICE", "*"])).toEqual([
@@ -57,11 +66,11 @@ describe("mattermost monitor auth", () => {
     });
   });
 
-  it("resolves direct command authorization from shared ingress", async () => {
+  it("resolves direct command authorization from shared ingress", () => {
     isDangerousNameMatchingEnabled.mockReturnValue(false);
     resolveAllowlistMatchSimple.mockReturnValue({ allowed: false });
 
-    await expect(
+    expect(
       authorizeMattermostCommandInvocation({
         account: {
           config: { dmPolicy: "open" },
@@ -74,7 +83,7 @@ describe("mattermost monitor auth", () => {
         allowTextCommands: true,
         hasControlCommand: true,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       ok: false,
       denyReason: "unauthorized",
       commandAuthorized: false,
@@ -88,7 +97,7 @@ describe("mattermost monitor auth", () => {
 
     resolveAllowlistMatchSimple.mockReturnValue({ allowed: true });
 
-    await expect(
+    expect(
       authorizeMattermostCommandInvocation({
         account: {
           config: { dmPolicy: "open", allowFrom: ["*"] },
@@ -101,7 +110,7 @@ describe("mattermost monitor auth", () => {
         allowTextCommands: false,
         hasControlCommand: false,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       ok: true,
       commandAuthorized: true,
       channelInfo: { type: "D", name: "alice", display_name: "Alice" },
@@ -112,7 +121,7 @@ describe("mattermost monitor auth", () => {
       roomLabel: "#alice",
     });
 
-    await expect(
+    expect(
       authorizeMattermostCommandInvocation({
         account: {
           config: { dmPolicy: "disabled" },
@@ -125,7 +134,7 @@ describe("mattermost monitor auth", () => {
         allowTextCommands: false,
         hasControlCommand: false,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       ok: false,
       denyReason: "dm-disabled",
       commandAuthorized: false,
@@ -137,7 +146,7 @@ describe("mattermost monitor auth", () => {
       roomLabel: "#alice",
     });
 
-    await expect(
+    expect(
       authorizeMattermostCommandInvocation({
         account: {
           config: { groupPolicy: "allowlist" },
@@ -150,7 +159,7 @@ describe("mattermost monitor auth", () => {
         allowTextCommands: true,
         hasControlCommand: false,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       ok: false,
       denyReason: "channel-no-allowlist",
       commandAuthorized: false,

--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -1,7 +1,9 @@
 import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/mattermost";
 import {
+  ACCESS_GROUP_ALLOW_FROM_PREFIX,
   evaluateSenderGroupAccessForPolicy,
   isDangerousNameMatchingEnabled,
+  parseAccessGroupAllowFromEntry,
   resolveAllowlistMatchSimple,
   resolveControlCommandGate,
   resolveEffectiveAllowFromLists,
@@ -17,6 +19,13 @@ export function normalizeMattermostAllowEntry(entry: string): string {
   }
   if (trimmed === "*") {
     return "*";
+  }
+  // Access-group references (`accessGroup:<name>`) must stay case-preserved: the
+  // downstream parser matches the prefix case-sensitively, so lowercasing the whole
+  // entry corrupts it into an inert literal that authorizes no one (fail-closed).
+  const accessGroupName = parseAccessGroupAllowFromEntry(trimmed);
+  if (accessGroupName) {
+    return `${ACCESS_GROUP_ALLOW_FROM_PREFIX}${accessGroupName}`;
   }
   const stripped = trimmed.replace(/^(mattermost|user):/i, "").replace(/^@/, "");
   return stripped.trim() ? normalizeLowercaseStringOrEmpty(stripped) : "";

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -11,6 +11,10 @@ export {
 } from "../auto-reply/reply/history.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
 export type { ChatType } from "../channels/chat-type.js";
+export {
+  ACCESS_GROUP_ALLOW_FROM_PREFIX,
+  parseAccessGroupAllowFromEntry,
+} from "../channels/allow-from.js";
 export { resolveControlCommandGate } from "../channels/command-gating.js";
 export { logInboundDrop, logTypingFailure } from "../channels/logging.js";
 export { resolveAllowlistMatchSimple } from "../channels/plugins/allowlist-match.js";

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -126,17 +126,17 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   // #2782 (mattermost): channel-plugin-api + reply-delivery un-quarantined (test-side — retarget
   // the bundled-seam smoke test to channel-plugin-runtime.ts since the fork consolidated away
   // channel-plugin-api.ts/mattermostSetupPlugin; rebrand OPENCLAW_STATE_DIR→REMOTECLAW_STATE_DIR).
-  // The 2 below stay, each needing out-of-scope work:
+  // #2959 (mattermost): monitor-auth un-quarantined — the `accessGroup:Ops` lowercasing regression
+  // is fixed at source (normalizeMattermostAllowEntry now carves access-group entries out of the
+  // lowercasing branch, case-preserved), and the file's other two tests were retargeted from the
+  // stale `./runtime-api.js` mock to the plugin-sdk barrel seam and de-drifted from `await`/async
+  // to the sync `authorizeMattermostCommandInvocation` signature.
+  // The 1 below stays, needing out-of-scope work:
   // - interactions: 2/47 assert an un-ported post-threading feature — forwarding the fetched `post`
   //   (with root_id) to resolveSessionKey (positional→object signature change), handleInteraction,
   //   and dispatchButtonClick for thread-scoped session keys; spans interactions.ts + monitor.ts
   //   session-key resolution — multi-file, separate PR.
-  // - monitor-auth: SECURITY (authz) — normalizeMattermostAllowEntry lowercases `accessGroup:Ops`
-  //   entries, but the test expects case-preserved (upstream parseAccessGroupAllowFromEntry). The
-  //   access-group allowlist-normalization semantics need a security-reviewed source change —
-  //   separate PR. (The file's other two tests also carry a stale mock target + sync/async drift.)
   "extensions/mattermost/src/mattermost/interactions.test.ts",
-  "extensions/mattermost/src/mattermost/monitor-auth.test.ts",
   // #2782 (slack): monitor.tool-result un-quarantined (test-side: the ack-reaction test
   // needs statusReactions disabled to exercise the direct one-shot react path — status
   // reactions now supersede it when enabled; pairing assertion updated to the shared


### PR DESCRIPTION
Closes #2959

## Problem
`normalizeMattermostAllowEntry` lowercased the entire allowlist entry, so an `accessGroup:Ops` reference became `accessgroup:ops`. The access-group parser (`parseAccessGroupAllowFromEntry`) matches the `accessGroup:` prefix **case-sensitively**, so the lowercased token was no longer recognized as an access-group reference — it degraded into an inert literal that matches nothing. Configured access-group members were silently **denied** (fail-closed), and the case-preservation contract on a security-relevant path was broken.

There is **no over-admit / privilege-escalation** path: a case-variant entry cannot mis-authorize an unintended sender (the corrupted token matches no real, lowercased sender id). The impact is a functional authorization regression plus a broken contract.

## Fix
- Carve access-group references out of the lowercasing branch in `normalizeMattermostAllowEntry`: parse the trimmed entry with `parseAccessGroupAllowFromEntry` and, when it names a group, return `accessGroup:${name}` **case-preserved**. Every other entry (`@user`, `mattermost:`/`user:` prefixes, `*`, plain ids) still lowercases exactly as before.
- Re-export `parseAccessGroupAllowFromEntry` and `ACCESS_GROUP_ALLOW_FROM_PREFIX` through the mattermost plugin-sdk barrel so the extension reuses the shared parser (no duplicated prefix constant).

## Tests
- Un-quarantined `extensions/mattermost/src/mattermost/monitor-auth.test.ts` (removed from `vitest.quarantine.ts`). Making it green required, beyond the source change:
  - retargeting the stale `./runtime-api.js` mock (a seam that does not exist in the fork) to the real `remoteclaw/plugin-sdk/mattermost` barrel via `importOriginal`, overriding only the two sender helpers and keeping every other export real;
  - de-drifting the `authorizeMattermostCommandInvocation` assertions from `await …/.resolves` to the function's actual **synchronous** signature.
- Added the requested assertions: `accessGroup:Ops` → `accessGroup:Ops` (case-preserved) and `User:Alice` → `alice` (non-access-group still lowercased).

## ⚠️ Downstream resolution is separately incomplete (intentionally not fixed here)
Per the issue's secondary note: the fork's mattermost ingress does **not** yet *resolve* access-group entries to member ids downstream. `resolveAllowlistMatchSimple` (the matcher the mattermost adapter uses) performs literal id comparison with no access-group handling, and the resolver under `src/channels/message-access/*` is not wired into the plugin-sdk allowlist path (there is no `plugin-sdk/access-groups` subpath in the fork). This PR restores the **case-preservation contract** — correct, forward-compatible, and matching upstream semantics — so the token survives intact for a future resolver, but end-to-end access-group expansion in mattermost remains unwired. Flagged for separate tracking; deliberately not expanded into scope here.

## Verification
- `monitor-auth.test.ts`: 3/3 pass. Full mattermost extension lane (`vitest.extensions.config.ts`): 23 files / 212 tests pass. `vitest list` confirms `monitor-auth.test.ts` is now included and `interactions.test.ts` stays quarantined.
- `pnpm check` (format + `tsgo` + lint + fork-integrity gates): green.
