### PR TITLE
fix(imessage): surface sent text on send result — restore echo body matching

### DIFF
--- a/extensions/imessage/src/monitor/deliver.runtime.ts
+++ b/extensions/imessage/src/monitor/deliver.runtime.ts
@@ -1,0 +1,4 @@
+export { chunkTextWithMode, resolveChunkMode } from "../../../../src/auto-reply/chunk.js";
+export { loadConfig } from "../../../../src/config/config.js";
+export { resolveMarkdownTableMode } from "../../../../src/config/markdown-tables.js";
+export { convertMarkdownTables } from "../../../../src/markdown/tables.js";

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -1,11 +1,14 @@
-import { chunkTextWithMode, resolveChunkMode } from "../../../../src/auto-reply/chunk.js";
 import type { ReplyPayload } from "../../../../src/auto-reply/types.js";
-import { loadConfig } from "../../../../src/config/config.js";
-import { resolveMarkdownTableMode } from "../../../../src/config/markdown-tables.js";
-import { convertMarkdownTables } from "../../../../src/markdown/tables.js";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
 import type { createIMessageRpcClient } from "../client.js";
 import { sendMessageIMessage } from "../send.js";
+import {
+  chunkTextWithMode,
+  convertMarkdownTables,
+  loadConfig,
+  resolveChunkMode,
+  resolveMarkdownTableMode,
+} from "./deliver.runtime.js";
 import type { SentMessageCache } from "./echo-cache.js";
 import { sanitizeOutboundText } from "./sanitize-outbound.js";
 
@@ -37,7 +40,6 @@ export async function deliverReplies(params: {
       continue;
     }
     if (mediaList.length === 0) {
-      sentMessageCache?.remember(scope, { text });
       for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
         const sent = await sendMessageIMessage(target, chunk, {
           maxBytes,
@@ -45,7 +47,10 @@ export async function deliverReplies(params: {
           accountId,
           replyToId: payload.replyToId,
         });
-        sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+        sentMessageCache?.remember(scope, {
+          text: sent.sentText,
+          messageId: sent.messageId,
+        });
       }
     } else {
       let first = true;
@@ -60,7 +65,7 @@ export async function deliverReplies(params: {
           replyToId: payload.replyToId,
         });
         sentMessageCache?.remember(scope, {
-          text: caption || undefined,
+          text: sent.sentText || undefined,
           messageId: sent.messageId,
         });
       }

--- a/extensions/imessage/src/send.sent-text.test.ts
+++ b/extensions/imessage/src/send.sent-text.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { loadConfig } from "../../../src/config/config.js";
+import type { ResolvedIMessageAccount } from "./accounts.js";
+import type { IMessageRpcClient } from "./client.js";
+import { createSentMessageCache } from "./monitor/echo-cache.js";
+import { sendMessageIMessage } from "./send.js";
+
+const cfg = {
+  channels: { imessage: { enabled: true } },
+} as unknown as ReturnType<typeof loadConfig>;
+
+const account: ResolvedIMessageAccount = {
+  accountId: "default",
+  enabled: true,
+  config: {},
+  configured: true,
+};
+
+function createFakeClient() {
+  const request = vi.fn(async () => ({ message_id: "imsg-1" }));
+  const client = { request, stop: vi.fn(async () => {}) } as unknown as IMessageRpcClient;
+  return { client, request };
+}
+
+describe("sendMessageIMessage sent text", () => {
+  it("returns the text handed to the bridge, not the caller's input", async () => {
+    const { client, request } = createFakeClient();
+
+    const sent = await sendMessageIMessage("+15551234567", "hello", {
+      client,
+      config: cfg,
+      account,
+      replyToId: "abc",
+    });
+
+    expect(sent.sentText).toBe("[[rc:reply:abc]] hello");
+    // The invariant that makes body matching possible: sentText is exactly the
+    // body the bridge was asked to send, so it is what the platform echoes back.
+    expect(request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ text: sent.sentText }),
+      expect.anything(),
+    );
+  });
+
+  it("returns the media placeholder as sent text for media-only sends", async () => {
+    const { client, request } = createFakeClient();
+
+    const sent = await sendMessageIMessage("+15551234567", "", {
+      client,
+      config: cfg,
+      account,
+      mediaUrl: "https://example.com/a.jpg",
+      resolveAttachmentImpl: async () => ({ path: "/fake/a.jpg", contentType: "image/jpeg" }),
+    });
+
+    expect(sent.sentText).toBe("<media:image>");
+    expect(request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ text: "<media:image>" }),
+      expect.anything(),
+    );
+  });
+
+  it("lets the echo cache match a self-echo by body", async () => {
+    const { client } = createFakeClient();
+    const scope = "default:+15551234567";
+
+    const sent = await sendMessageIMessage("+15551234567", "hello", {
+      client,
+      config: cfg,
+      account,
+      replyToId: "abc",
+    });
+
+    const cache = createSentMessageCache();
+    cache.remember(scope, { text: sent.sentText, messageId: sent.messageId });
+
+    // An echo carrying only the body (no matching outbound id) is still suppressed.
+    expect(cache.has(scope, { text: "[[rc:reply:abc]] hello" })).toBe(true);
+    // Regression guard for #2971: remembering the caller's pre-transform text
+    // would never match the echoed body.
+    expect(cache.has(scope, { text: "hello" })).toBe(false);
+  });
+});

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -32,6 +32,13 @@ type IMessageSendOpts = {
 
 type IMessageSendResult = {
   messageId: string;
+  /**
+   * The text as handed to the bridge — after markdown-table conversion, media
+   * placeholder substitution, and reply-tag prefixing. The echo cache matches
+   * inbound self-echoes against the body the platform actually echoes, so this
+   * must be the post-transform text rather than the caller's input.
+   */
+  sentText: string;
 };
 
 const LEADING_REPLY_TAG_RE = /^\s*\[\[\s*rc:reply\s*:\s*([^\]\n]+)\s*\]\]\s*/i;
@@ -181,6 +188,7 @@ export async function sendMessageIMessage(
     const resolvedId = resolveMessageId(result);
     return {
       messageId: resolvedId ?? (result?.ok ? "ok" : "unknown"),
+      sentText: message,
     };
   } finally {
     if (shouldClose) {

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -144,7 +144,7 @@ describe("sendMessage channel normalization", () => {
         to: "someone@example.com",
         channel: "imsg",
         deps: {
-          sendIMessage: vi.fn(async () => ({ messageId: "i1" })),
+          sendIMessage: vi.fn(async () => ({ messageId: "i1", sentText: "hi" })),
         },
       },
       assertDeps: (deps: { sendIMessage?: ReturnType<typeof vi.fn> }) => {

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -82,18 +82,17 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/feishu/src/monitor.reaction.test.ts",
   // #2782 (imessage): accounts + parse-notification un-quarantined via SOURCE fixes — accounts.ts
   // restores the createAccountListHelpers `implicitDefaultAccount` options + `defaultAccount`
-  // resolution; parse-notification.ts restores stripImessageLengthPrefixedUtf8Text. The 2 below
-  // stay, each needing out-of-scope work:
-  // - deliver: the fork gutted the sentText/echoText send-result contract (send.ts returns only
-  //   {messageId}); test asserts the actual media-echo placeholder + post-send-only remember
-  //   (#47830, no pre-send full-text remember). Restoring is a multi-module outbound/self-chat-echo
-  //   subsystem change — separate PR.
+  // resolution; parse-notification.ts restores stripImessageLengthPrefixedUtf8Text.
+  // #2971 (imessage): deliver un-quarantined via SOURCE fix — send.ts now returns the post-
+  // transform `sentText` alongside `messageId`, and deliver.ts remembers THAT (not the caller's
+  // pre-transform text) post-send only, restoring the media-echo placeholder + the #47830
+  // no-pre-send-full-text-remember contract.
+  // The 1 below stays, needing out-of-scope work:
   // - inbound-processing: SECURITY-sensitive — the dmPolicy access-control + echo/self-chat
   //   detection ORDER diverged from upstream (fork does access-before-echo; tests expect
   //   echo/self-chat-before-access) AND `dmPolicy:"open"` with an empty allowlist blocks where the
   //   tests expect allow; reconciling touches shared src/security/dm-policy-shared authz — separate
   //   security-reviewed PR.
-  "extensions/imessage/src/monitor/deliver.test.ts",
   "extensions/imessage/src/monitor/inbound-processing.test.ts",
   // #2782 (line): channel.sendPayload.test.ts — 8/12 pass; the 4 failures are a
   // SOURCE gap (not a test fix). channel.ts `sendPayload` has no LINE video-media


### PR DESCRIPTION
Closes #2971

## Problem

`IMessageSendResult` carried only `messageId`, so `deliverReplies` had no access to the body the bridge was actually asked to send. It fell back to remembering the caller's **pre-transform** input in the echo cache.

The sharpest consequence is the media path. For a media-only reply the caller's input is the empty caption, so the cache remembered `text: undefined`:

```ts
sentMessageCache?.remember(scope, {
  text: caption || undefined, // media-only reply → caption is "" → undefined
  messageId: sent.messageId,
});
```

`send.ts` substitutes a `<media:image>` placeholder *internally*, so the body the platform echoes was never visible to the caller and could never be matched.

## Fix

`sendMessageIMessage` now returns the post-transform `message` as `sentText` — the text handed to the bridge, after markdown-table conversion, media-placeholder substitution, and reply-tag prefixing — and `deliverReplies` remembers that.

`messageId` keying is untouched. This is purely additive to the ID-based suppression: it restores the **body-matching fallback** that self-chat depends on, where the inbound numeric SQLite row id never matches an outbound GUID (see the `skipIdShortCircuit` contract in `echo-cache.ts`).

This also fixes reply-tagged sends. The fork encodes replies as a literal `[[rc:reply:<id>]]` text prefix (upstream instead passes a structured `--reply-to` flag, and the fork's JSON-RPC `send` params carry no reply field), so the tag is part of the sent body — and the old code remembered the un-tagged chunk.

### Dropped the pre-send `remember()`

The pre-send `remember(scope, { text })` of the full un-chunked text is removed. The platform echoes each chunk as its own message, so that entry never matched a real echo — it only widened the self-chat false-positive window (the #47830 fix, which the fork had lost). It also left a text entry with **no backing id**, which bypassed the id short-circuit in `SentMessageCache.has` via `textBackedByIdCache`.

For a single-chunk reply the pre-send and post-send entries were identical, so nothing is lost.

## Tests

`extensions/imessage/src/monitor/deliver.test.ts` is **un-quarantined** — it already asserted exactly this contract, and 3 of its 4 tests were failing:

- `records the actual sent placeholder for media-only replies` → got `text: undefined`, wanted `text: "<media:image>"`
- `records outbound text and message ids (post-send only)` → got the pre-send full-text `remember`
- `propagates payload replyToId through all text chunks`

`deliver.runtime.ts` is the seam that test mocks, matching the established `*.runtime.ts` pattern used across adapters (22 precedents; upstream has this exact file too).

New focused regression spec `send.sent-text.test.ts` covers the send boundary the un-quarantined test mocks out:

- the send result carries the text actually handed to the bridge (asserted equal to the RPC `text` param)
- the media placeholder is surfaced as `sentText`
- round-trip: `sentText` → `createSentMessageCache().remember()` → an echo carrying only the body matches, while the pre-transform text does not

It is discriminating, not confirmatory: reverting the fix to `sentText: text` fails all 3.

`inbound-processing.test.ts` stays quarantined — its dmPolicy access-control ordering divergence is security-sensitive and out of scope here.

## Verification

| Gate | Result |
|---|---|
| `pnpm check` (format + tsgo + lint + fork gates) | pass |
| `test-extensions` lane (full config) | 466 files / 4434 pass |
| `test-auto-reply` lane (full config) | 56 files / 630 pass |
| unit lane (`src/infra/outbound`) | 39 files / 417 pass |
| imessage suite | 18 files / 126 pass |

The required `sentText` surfaced one contextually-typed mock in `src/infra/outbound/message.channels.test.ts`, updated to honor the real contract.

## Note for reviewers

Grounding the issue against live source corrected three of its premises, which is worth flagging:

- The paths omit the `monitor/` segment (`monitor/monitor-provider.ts`, `monitor/inbound-processing.ts`); the line numbers are accurate.
- The symbol-control evidence (`sentText` 0 refs, `sendMessageIMessage` 5) does not reproduce — actual counts are 65 and 43. The issue's grep looks to have been degraded.
- `createSentMessageCache` does **not** "key only on `messageId`" — `echo-cache.ts` already implements full text matching with a 4s TTL. The gap was upstream of it: the sent body never reached the cache.

Separately, `send.ts` demonstrably sends the literal `[[rc:reply:<id>]]` prefix as message text (`send.sent-text.test.ts` pins this), and nothing on the inbound path parses it back. Whether the bridge consumes it or it reaches users is out of scope for this fix but may deserve its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)