### PR TITLE
fix(slack): restore unfurl_links:false default and Web API error scope enrichment

### DIFF
--- a/extensions/slack/src/send.identity-fallback.test.ts
+++ b/extensions/slack/src/send.identity-fallback.test.ts
@@ -1,11 +1,12 @@
-import { logVerbose } from "remoteclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logVerbose } from "../../../src/globals.js";
 import { createSlackSendTestClient, installSlackBlockTestMocks } from "./blocks.test-helpers.js";
 
-vi.mock("remoteclaw/plugin-sdk/runtime-env", () => ({
+// send.ts imports logVerbose from src/globals.js directly, so mock that module rather
+// than the plugin-sdk/runtime-env barrel that merely re-exports it.
+vi.mock("../../../src/globals.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/globals.js")>()),
   logVerbose: vi.fn(),
-  danger: (message: string) => message,
-  shouldLogVerbose: () => false,
 }));
 
 installSlackBlockTestMocks();
@@ -191,6 +192,46 @@ describe("sendMessageSlack customize-scope fallback", () => {
     ).rejects.toThrow(
       "An API error occurred: missing_scope (needed: im:write; granted: chat:write, users:read; accepted: im:write, mpim:write)",
     );
+  });
+
+  // The assertions above use rejects.toThrow(string), which matches on substring and so
+  // would pass even if the detail were appended twice. The send path enriches at each
+  // throw site and again at the queued catch-all, so pin the exact message.
+  it("appends the scope detail exactly once across nested throw sites", async () => {
+    const client = createSlackSendTestClient();
+    vi.mocked(client.chat.postMessage).mockRejectedValueOnce(
+      buildMissingScopeError({ needed: "im:write", scopes: ["chat:write"] }),
+    );
+
+    const err = await sendMessageSlack("channel:C123", "hello", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+    }).then(
+      () => undefined,
+      (reason: unknown) => reason as Error,
+    );
+
+    expect(err?.message).toBe(
+      "An API error occurred: missing_scope (needed: im:write; granted: chat:write)",
+    );
+  });
+
+  it("opts back into link unfurling when unfurlLinks is true", async () => {
+    const client = createSlackSendTestClient();
+
+    await sendMessageSlack("channel:C123", "https://example.com", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      unfurlLinks: true,
+    });
+
+    expect(readPostMessagePayload(client, 0)).toEqual({
+      channel: "C123",
+      text: "https://example.com",
+      unfurl_links: true,
+    });
   });
 
   it("preserves Slack missing-scope details while opening DMs", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -64,34 +64,106 @@ type SlackSendOpts = {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  /** Opt back into Slack's inline link previews for this send. Defaults to false. */
+  unfurlLinks?: boolean;
+};
+
+type SlackWebApiErrorData = {
+  error?: unknown;
+  needed?: unknown;
+  response_metadata?: {
+    scopes?: unknown;
+    acceptedScopes?: unknown;
+  };
 };
 
 function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
   return Boolean(identity?.username || identity?.iconUrl || identity?.iconEmoji);
 }
 
-function isSlackCustomizeScopeError(err: unknown): boolean {
+function readSlackWebApiErrorData(err: unknown): SlackWebApiErrorData | undefined {
   if (!(err instanceof Error)) {
-    return false;
+    return undefined;
   }
-  const maybeData = err as Error & {
-    data?: {
-      error?: string;
-      needed?: string;
-      response_metadata?: { scopes?: string[]; acceptedScopes?: string[] };
-    };
-  };
-  const code = normalizeLowercaseStringOrEmpty(maybeData.data?.error);
+  const data = (err as Error & { data?: unknown }).data;
+  return data && typeof data === "object" ? (data as SlackWebApiErrorData) : undefined;
+}
+
+function normalizeSlackScopeList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.flatMap((scope) => {
+    const normalized = normalizeOptionalString(scope);
+    return normalized ? [normalized] : [];
+  });
+}
+
+/**
+ * Append the OAuth scope detail Slack attaches to a Web API error so operators see
+ * which scope to grant instead of a bare "An API error occurred: missing_scope".
+ */
+function formatSlackWebApiErrorMessage(err: unknown): string | undefined {
+  if (!(err instanceof Error)) {
+    return undefined;
+  }
+  const data = readSlackWebApiErrorData(err);
+  const code = normalizeOptionalString(data?.error);
+  if (!code) {
+    return undefined;
+  }
+  const details: string[] = [];
+  const needed = normalizeOptionalString(data?.needed);
+  if (needed) {
+    details.push(`needed: ${needed}`);
+  }
+  const scopes = normalizeSlackScopeList(data?.response_metadata?.scopes);
+  if (scopes.length) {
+    details.push(`granted: ${scopes.join(", ")}`);
+  }
+  const acceptedScopes = normalizeSlackScopeList(data?.response_metadata?.acceptedScopes);
+  if (acceptedScopes.length) {
+    details.push(`accepted: ${acceptedScopes.join(", ")}`);
+  }
+  const base = err.message || `An API error occurred: ${code}`;
+  return details.length ? `${base} (${details.join("; ")})` : base;
+}
+
+/**
+ * Returning a fresh Error (rather than mutating `err.message`) drops the `data`
+ * payload, which is load-bearing twice over: it keeps this idempotent, and it stops
+ * `describeDeliveryError` — which duck-types on `data` — from appending the same
+ * scope detail a second time.
+ */
+function enrichSlackWebApiError(err: unknown): unknown {
+  const message = formatSlackWebApiErrorMessage(err);
+  if (!message || !(err instanceof Error) || message === err.message) {
+    return err;
+  }
+  return new Error(message);
+}
+
+async function withEnrichedSlackWebApiError<T>(task: () => Promise<T>): Promise<T> {
+  try {
+    return await task();
+  } catch (err) {
+    throw enrichSlackWebApiError(err);
+  }
+}
+
+function isSlackCustomizeScopeError(err: unknown): boolean {
+  const data = readSlackWebApiErrorData(err);
+  const code = normalizeLowercaseStringOrEmpty(data?.error);
   if (code !== "missing_scope") {
     return false;
   }
-  const needed = normalizeLowercaseStringOrEmpty(maybeData.data?.needed);
-  if (needed?.includes("chat:write.customize")) {
+  const needed = normalizeLowercaseStringOrEmpty(data?.needed);
+  if (needed.includes("chat:write.customize")) {
     return true;
   }
   const scopes = [
-    ...(maybeData.data?.response_metadata?.scopes ?? []),
-    ...(maybeData.data?.response_metadata?.acceptedScopes ?? []),
+    ...normalizeSlackScopeList(data?.response_metadata?.scopes),
+    ...normalizeSlackScopeList(data?.response_metadata?.acceptedScopes),
   ].map((scope) => normalizeLowercaseStringOrEmpty(scope));
   return scopes.includes("chat:write.customize");
 }
@@ -103,12 +175,15 @@ async function postSlackMessageBestEffort(params: {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  unfurlLinks?: boolean;
 }) {
   const basePayload = {
     channel: params.channelId,
     text: params.text,
     thread_ts: params.threadTs,
     ...(params.blocks?.length ? { blocks: params.blocks } : {}),
+    // Bot replies should not expand inline link previews unless a caller opts in.
+    unfurl_links: params.unfurlLinks ?? false,
   };
   try {
     // Slack Web API types model icon_url and icon_emoji as mutually exclusive.
@@ -133,10 +208,10 @@ async function postSlackMessageBestEffort(params: {
     });
   } catch (err) {
     if (!hasCustomIdentity(params.identity) || !isSlackCustomizeScopeError(err)) {
-      throw err;
+      throw enrichSlackWebApiError(err);
     }
     logVerbose("slack send: missing chat:write.customize, retrying without custom identity");
-    return params.client.chat.postMessage(basePayload);
+    return withEnrichedSlackWebApiError(() => params.client.chat.postMessage(basePayload));
   }
 }
 
@@ -255,7 +330,9 @@ async function resolveChannelId(
   if (cachedChannelId) {
     return { channelId: cachedChannelId, isDm: true, cacheHit: true };
   }
-  const response = await client.conversations.open({ users: recipient.id });
+  const response = await withEnrichedSlackWebApiError(() =>
+    client.conversations.open({ users: recipient.id }),
+  );
   const channelId = response.channel?.id;
   if (!channelId) {
     throw new Error("Failed to open Slack DM channel");
@@ -365,15 +442,20 @@ export async function sendMessageSlack(
     threadTs: opts.threadTs,
   });
   const result = await runQueuedSlackSend(queueKey, () =>
-    sendMessageSlackQueued({
-      trimmedMessage,
-      opts,
-      cfg,
-      account,
-      token,
-      recipient,
-      blocks,
-    }),
+    // Catch-all for the queued path: covers the files.* upload calls, which have their
+    // own missing_scope failure mode (see uploadSlackFile). Already-enriched errors from
+    // the postMessage / conversations.open sites pass through untouched.
+    withEnrichedSlackWebApiError(() =>
+      sendMessageSlackQueued({
+        trimmedMessage,
+        opts,
+        cfg,
+        account,
+        token,
+        recipient,
+        blocks,
+      }),
+    ),
   );
   const threadTs = normalizeSlackThreadTsCandidate(opts.threadTs);
   if (threadTs && result.channelId && account.accountId) {
@@ -412,6 +494,7 @@ async function sendMessageSlackQueued(params: {
       threadTs: opts.threadTs,
       identity: opts.identity,
       blocks,
+      unfurlLinks: opts.unfurlLinks,
     });
     return {
       messageId: response.ts ?? "unknown",
@@ -460,6 +543,7 @@ async function sendMessageSlackQueued(params: {
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks: opts.unfurlLinks,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }
@@ -471,6 +555,7 @@ async function sendMessageSlackQueued(params: {
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks: opts.unfurlLinks,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -142,18 +142,18 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   // (including the GroupSpace regression guard). The remaining arg-menu divergence is skipped
   // in-file via `describe.skip` with rationale (slash.test.ts) rather than darkening the whole
   // file here — narrower debt, still tracked by #2782.
-  // The 3 below stay, each out of scope for a test-side un-quarantine (see PR for details):
+  // #2962 (slack): send.identity-fallback un-quarantined — both SOURCE regressions are fixed in
+  // send.ts (unfurl_links:false payload default + Slack Web API error enrichment at every throw
+  // site). The feared blast radius did not materialize: the other send tests asserting postMessage
+  // payloads (send.blocks, send.upload) use expect.objectContaining, which tolerates the added key.
+  // The 2 below stay, each out of scope for a test-side un-quarantine (see PR for details):
   // - client: proxy-agent support was gutted (no client-options.ts); restoring needs new
   //   plugin-sdk fetch-runtime helpers (resolveEnvHttpProxyUrl / resolveActiveManagedProxyTlsOptions)
   //   that don't exist in the fork — a network-egress SOURCE change for a separate security-gated PR.
-  // - send.identity-fallback: send.ts dropped upstream's Slack Web API error-enrichment
-  //   (needed/granted/accepted detail) + the unfurl_links:false payload default; restoring is a
-  //   SOURCE change with blast radius on non-quarantined send tests (unfurl_links on every payload).
   // - dispatch.preview-fallback: obsolete premise — dispatch.ts finalizes previews via inline
   //   chat.update now, not finalizeSlackPreviewEdit (which is dead code); the test needs a rewrite.
   "extensions/slack/src/client.test.ts",
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
-  "extensions/slack/src/send.identity-fallback.test.ts",
   "extensions/telegram/src/bot-message-context.dm-threads.test.ts",
   "extensions/telegram/src/bot-message-context.group-body.test.ts",
   "extensions/telegram/src/bot-message-context.named-account-dm.test.ts",


### PR DESCRIPTION
Closes #2962

## Problem

The Slack outbound send path (`extensions/slack/src/send.ts`) was missing two behaviors the test suite requires. Both reproduce against live source:

1. **Link previews auto-expand.** `postSlackMessageBestEffort` built the `chat.postMessage` payload with no `unfurl_links` key anywhere in the file, so Slack applied its default (`unfurl_links: true`) and bot replies expanded inline link previews.
2. **Scope detail dropped from Web API errors.** The non-customize path re-threw the raw error, so operators saw a bare `An API error occurred: missing_scope` with no indication which scope to grant. `isSlackCustomizeScopeError` already parsed `data.needed` and `data.response_metadata.{scopes,acceptedScopes}` — but only to decide whether to retry; the detail never reached the thrown message.

Both are on the actively-used Slack adapter, and `send.identity-fallback.test.ts` (quarantined) already encoded the intended contract for both.

## Fix

**`unfurl_links`** — added to the base `chat.postMessage` payload, defaulting to `false`, overridable per send via a new `SlackSendOpts.unfurlLinks`.

**Error enrichment** — factored the field-parsing already present in `isSlackCustomizeScopeError` into `readSlackWebApiErrorData` + `normalizeSlackScopeList` (no duplicated parse), and reused it to append `(needed: …; granted: …; accepted: …)` at every site that surfaces a Slack Web API error:

| Site | Covers |
|---|---|
| `postSlackMessageBestEffort` re-throw + its identity retry | `chat.postMessage` |
| `resolveChannelId` | `conversations.open` |
| Catch-all on the queued send path | the `files.*` upload calls, which have their own `missing_scope` mode (see `uploadSlackFile`) |

Enrichment returns a **fresh `Error`** rather than mutating `err.message`. Dropping `data` is load-bearing twice: it makes enrichment idempotent across the nested sites, and it stops `describeDeliveryError` (`src/infra/outbound/`, #2098) — which duck-types on `data` — from appending the same detail a second time.

The refactor also hardened the parse: the previous `...(scopes ?? [])` spread would splat a non-array string into individual characters; `normalizeSlackScopeList` returns `[]` for non-arrays.

## Blast radius

The error object identity changes (Slack `CodedError` with `data` → plain `Error`). Every consumer of errors escaping `sendMessageSlack` was enumerated:

| Consumer | Verdict |
|---|---|
| `describe-delivery-error.ts` (duck-types `data.needed` / `.response_metadata.scopes`) | `data` dropped → falls back to `err.message`, now enriched **and richer** (gains `accepted:`). No test asserts the old end-to-end string. |
| `deliver.ts:525,807` | via the above — green |
| `delivery-queue.ts` `isPermanentDeliveryError` | matches `/missing_scope/i` on the **string**; enriched message still contains it |
| `isSlackCustomizeScopeError` | runs on the raw error **before** enrichment |
| `gateway-status/helpers.ts` `MISSING_SCOPE_PATTERN` | **not a consumer** — gateway RPC probe operator scopes (`operator.read`), not Slack |
| `monitor/reconnect-policy.ts` | **not a consumer** — monitor/socket path, not send |

The quarantine note feared "blast radius on non-quarantined send tests (unfurl_links on every payload)". Empirically disproven: `send.blocks` and `send.upload` assert payloads via `expect.objectContaining`, which tolerates the added key. Both green.

## Tests

`send.identity-fallback.test.ts` un-quarantined. Two notes worth reviewer attention:

- **Restoring the source alone did not make it pass.** It fixed 5 of 8 assertions; the 3 `logVerbose` ones still failed with `Number of calls: 0` — an unrelated, pre-existing **mock-seam drift**. The test (synced from upstream, `openclaw`→`remoteclaw` rebranded) mocks `remoteclaw/plugin-sdk/runtime-env`, but this fork's `send.ts` imports `logVerbose` from `../../../src/globals.js`; the barrel only *re-exports* it, so mocking the barrel never intercepts the call. Upstream's `send.ts` imports from its own barrel, so the mock matches there. Retargeted the mock to `src/globals.js`, matching the precedent at `monitor/media.test.ts:21`. Fixing it source-side was rejected: `./plugin-sdk/runtime-env` is not among this fork's 56 exported `plugin-sdk` subpaths (`text-runtime` is), so `send.ts` importing it would ship an import that fails to resolve at runtime.
- **Added a guard pinning the exact message.** The four inherited enrichment assertions use `rejects.toThrow(string)`, which matches on *substring* — they would pass even if the detail were appended twice, which is precisely the hazard the multi-site design introduces. `appends the scope detail exactly once across nested throw sites` asserts the exact message with `toBe`.

One new case per the issue's instruction to add one only if an opt-back-into-unfurling option is introduced (`opts back into link unfurling when unfurlLinks is true`).

Verified the lane genuinely collects the un-quarantined file (`vitest list --filesOnly` → 465 files, file present; still-quarantined `client.test.ts` correctly absent, confirming the filter is active).

| Gate | Result |
|---|---|
| `send.identity-fallback.test.ts` | **9 passed** (was 3 failed / 5 passed) |
| Extensions lane | **465 files, 4436 passed, 25 skipped, 0 failed** |
| Auto-reply lane | **56 files, 630 passed, 0 failed** |
| Unit lane | **1014 files, 9794 passed, 42 skipped, 0 failed** |
| `pnpm check` (format + lint + tsgo) | **exit 0** |

## Notes for the reviewer

- **The issue's "regression" framing is slightly off, harmlessly.** `git log -S'unfurl_links' -- extensions/slack/src/send.ts` returns nothing — `unfurl_links` never existed in this file's fork history. It is not a fork-local rewrite that dropped it; the file arrived via port + syncs as an upstream subset that never carried the behavior. User-visible effect and fix direction are unchanged.
- **Follow-up filed, deliberately out of scope.** `docs/gateway/config-channels.md` documents `channels.slack.unfurlLinks` / `unfurlMedia` **config** keys, but they are absent from `src/config/types.slack.ts` and the zod schema — docs arrived via content-only doc syncs (#2829, #2840) that outran the code, so documented config is silently ignored. This PR adds the send-level option (the seam that fix needs) and makes the docs' *behavioral* claim ("defaults to `false`") true; wiring the config keys end-to-end — including `unfurlMedia`, which is unrelated to either regression here — is tracked in #2987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
