### PR TITLE
fix(test): derive root vitest plugin-sdk aliases from shared source of truth

### DIFF
--- a/src/plugin-sdk/root-vitest-alias.test.ts
+++ b/src/plugin-sdk/root-vitest-alias.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { pluginSdkSubpaths } from "../../scripts/lib/plugin-sdk-entries.mjs";
+import rootVitestConfig from "../../vitest.config.ts";
+
+// The repo-root `vitest.config.ts` owns the plugin-sdk aliases for bare `vitest`,
+// `pnpm test:watch`, and — via the `baseConfig` spread in `vitest.unit.config.ts` —
+// the CI unit lane. It is the one alias list not derived from the shared source of
+// truth, so it silently drifted and dropped `request-url` (#2964); nothing caught it
+// because no unit-lane test imported that subpath. These assertions are that guard.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+type AliasEntry = { find: string | RegExp; replacement: string };
+
+const aliasEntries = rootVitestConfig.resolve?.alias as AliasEntry[];
+const stringFinds = aliasEntries
+  .map((entry) => entry.find)
+  .filter((find): find is string => typeof find === "string");
+
+function listLocalPluginSdkSubpaths(): string[] {
+  return fs
+    .readdirSync(path.join(repoRoot, "src", "plugin-sdk"), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => entry.name.slice(0, -".ts".length))
+    .filter((subpath) => subpath !== "index" && !/\.(?:test|spec|d)$/u.test(subpath));
+}
+
+describe("root vitest.config.ts plugin-sdk aliases", () => {
+  it("exposes the alias list as an ordered array", () => {
+    expect(Array.isArray(aliasEntries)).toBe(true);
+    expect(stringFinds.length).toBeGreaterThan(0);
+  });
+
+  it("aliases every subpath in the shared source of truth", () => {
+    const missing = pluginSdkSubpaths.filter(
+      (subpath) => !stringFinds.includes(`remoteclaw/plugin-sdk/${subpath}`),
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it("aliases every subpath backed by a src/plugin-sdk source file", () => {
+    const missing = listLocalPluginSdkSubpaths().filter(
+      (subpath) => !stringFinds.includes(`remoteclaw/plugin-sdk/${subpath}`),
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it("points request-url at its real source file (#2964)", () => {
+    const entry = aliasEntries.find((item) => item.find === "remoteclaw/plugin-sdk/request-url");
+
+    expect(entry).toBeDefined();
+    expect(entry?.replacement).toBe(path.join(repoRoot, "src", "plugin-sdk", "request-url.ts"));
+    expect(fs.existsSync(entry?.replacement ?? "")).toBe(true);
+  });
+
+  it("keeps the prefix-matching barrel alias last so subpaths win", () => {
+    const barrelIndex = stringFinds.indexOf("remoteclaw/plugin-sdk");
+
+    expect(barrelIndex).toBe(stringFinds.length - 1);
+  });
+
+  // Imported dynamically so a resolution failure fails this test with a readable
+  // error instead of aborting collection for the whole file.
+  it("resolves the bare request-url subpath at runtime (#2964)", async () => {
+    const { resolveRequestUrl } = await import("remoteclaw/plugin-sdk/request-url");
+
+    expect(resolveRequestUrl("https://example.invalid/y")).toBe("https://example.invalid/y");
+    expect(resolveRequestUrl(new URL("https://example.invalid/x"))).toBe(
+      "https://example.invalid/x",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,91 +1,44 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+import { pluginSdkSubpaths } from "./scripts/lib/plugin-sdk-entries.mjs";
+import privateLocalOnlyPluginSdkSubpaths from "./scripts/lib/plugin-sdk-private-local-only-subpaths.json" with { type: "json" };
 
 const repoRoot = path.dirname(fileURLToPath(import.meta.url));
 const isCI = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
 const isWindows = process.platform === "win32";
 const localWorkers = Math.max(4, Math.min(16, os.cpus().length));
 const ciWorkers = isWindows ? 2 : 3;
-const pluginSdkSubpaths = [
-  "account-id",
-  "account-resolution",
-  "allow-from",
-  "browser-security-runtime",
-  "channel-lifecycle",
-  "core",
-  "channel-config-helpers",
-  "channel-streaming",
-  "group-access",
-  "json-store",
-  "media-store",
-  "persistent-dedupe",
-  "reply-chunking",
-  "reply-payload",
-  "runtime",
-  "runtime-env",
-  "runtime-store",
-  "string-coerce-runtime",
-  "string-normalization-runtime",
-  "compat",
-  "telegram",
-  "discord",
-  "slack",
-  "signal",
-  "imessage",
-  "whatsapp",
-  "line",
-  "msteams",
-  "acpx",
-  "bluebubbles",
-  "copilot-proxy",
-  "device-pair",
-  "diagnostics-otel",
-  "diagnostics-prometheus",
-  "diffs",
-  "feishu",
-  "googlechat",
-  "irc",
-  "llm-task",
-  "lobster",
-  "matrix",
-  "mattermost",
-  "nextcloud-talk",
-  "nostr",
-  "open-prose",
-  "phone-control",
-  "synology-chat",
-  "talk-voice",
-  "test-utils",
-  "text-runtime",
-  "text-utility-runtime",
-  "thread-ownership",
-  "tlon",
-  "tool-send",
-  "twitch",
-  "voice-call",
-  "zalo",
-  "zalouser",
-  "keyed-async-queue",
-  "health",
-  "plugin-test-runtime",
-  "provider-model-shared",
-  "routing",
-  "runtime-config-snapshot",
-  "secret-ref-runtime",
-  "ssrf-policy",
-  "temp-path",
-  "dangerous-name-runtime",
-  "webhook-request-guards",
-  "webhook-targets",
-] as const;
+
+/** Subpaths backed by a real `src/plugin-sdk/<name>.ts`, including fork-side ones
+ * absent from the published entrypoint list (`telegram`, `discord`, `health`, ...). */
+function listLocalPluginSdkSubpaths(): string[] {
+  return fs
+    .readdirSync(path.join(repoRoot, "src", "plugin-sdk"), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => entry.name.slice(0, -".ts".length))
+    .filter((subpath) => subpath !== "index" && !/\.(?:test|spec|d)$/u.test(subpath));
+}
+
+// Derived, never hand-maintained: the same shared source of truth that
+// test/vitest/vitest.shared.config.ts uses, unioned with the subpaths actually on
+// disk. The previous hand-maintained copy silently omitted `request-url`, so bare
+// `vitest` failed to resolve imports the scoped/CI lanes resolved fine (#2964).
+const pluginSdkAliasSubpaths = [
+  ...new Set([
+    ...pluginSdkSubpaths,
+    ...privateLocalOnlyPluginSdkSubpaths,
+    ...listLocalPluginSdkSubpaths(),
+  ]),
+].toSorted((left, right) => left.localeCompare(right));
 
 export default defineConfig({
   resolve: {
     // Keep this ordered: the base `remoteclaw/plugin-sdk` alias is a prefix match.
     alias: [
-      ...pluginSdkSubpaths.map((subpath) => ({
+      ...pluginSdkAliasSubpaths.map((subpath) => ({
         find: `remoteclaw/plugin-sdk/${subpath}`,
         replacement: path.join(repoRoot, "src", "plugin-sdk", `${subpath}.ts`),
       })),


### PR DESCRIPTION
Closes #2964

## Problem

The repo-root `vitest.config.ts` hand-maintained its own `pluginSdkSubpaths` array (70 entries). It drifted from the shared source of truth `scripts/lib/plugin-sdk-entries.mjs` (328 entries) that `test/vitest/vitest.shared.config.ts` derives from, and omitted `request-url`.

`extensions/bluebubbles/src/request-url.ts` re-exports from the bare subpath, so any test reaching it under the root config failed:

```
$ pnpm exec vitest run extensions/bluebubbles/src/attachments.test.ts   # no --config
Error: Cannot find package 'remoteclaw/plugin-sdk/request-url'
  imported from extensions/bluebubbles/src/request-url.ts
 Test Files  1 failed (1) | Tests  no tests
```

Two corrections to the issue's premise, both verified against this branch:

- **The observed failure is a bare-specifier resolution error, not the predicted `src/plugin-sdk/index.ts/request-url` misresolution.** With no alias entry the specifier is left for Node, and `./plugin-sdk/request-url` is absent from the root `package.json` `exports` map — so self-reference resolution fails too. (Subpaths like `./plugin-sdk/telegram` *are* exported, which is why they behave differently.)
- **This is not local-only.** `vitest.unit.config.ts` spreads `baseConfig` from `vitest.config.ts`, so the CI unit lane (run 3×-sharded by `scripts/test-parallel.mjs`) inherits these aliases. CI stayed green only because no unit-lane test imported `request-url`, and `extensions/bluebubbles/src/attachments.test.ts` is quarantined out of the extensions lane (`vitest.quarantine.ts`). The drift was one import away from breaking CI.

## Fix

`vitest.config.ts` now derives the alias list instead of hand-maintaining it — the shared source of truth unioned with the subpaths actually backed by a `src/plugin-sdk/*.ts` file.

**The union is load-bearing, not belt-and-braces.** Deriving from the shared list alone regressed previously-green tests: 16 fork-side subpaths (`telegram`, `discord`, `health`, `synology-chat`, `lobster`, ...) have real source files and live importers but are absent from `plugin-sdk-entrypoints.json`, so dropping their aliases broke resolution (`Cannot find package 'remoteclaw/plugin-sdk/discord'`). Deriving from disk as well keeps them and stays self-maintaining.

Safety property — the new alias set is a **strict superset** of the old one, so no previously-working resolution can change:

| | old | new |
|---|---|---|
| `remoteclaw/plugin-sdk/*` aliases | 70 | 385 |
| aliases lost | — | **0** |
| `request-url` present | no | yes |
| prefix-matching barrel alias last | yes | yes |

## Guard

New `src/plugin-sdk/root-vitest-alias.test.ts` fails on this drift class. It runs in the unit lane (which inherits the root config's aliases), and asserts:

- every subpath in `scripts/lib/plugin-sdk-entries.mjs` is aliased;
- every subpath backed by a `src/plugin-sdk/*.ts` file is aliased;
- `request-url` points at its real source file;
- the prefix-matching barrel alias stays last;
- the bare `remoteclaw/plugin-sdk/request-url` subpath resolves at runtime.

Validated in both directions — a guard that only ever passes proves nothing:

- against the fixed config → **6/6 pass**
- against the pre-fix config → **4 fail** with actionable diagnostics (`expected [ Array(276) ] to deeply equal []`, 102 missing on-disk subpaths, `request-url` alias undefined, runtime `Cannot find package`), while the 2 shape/ordering tests still pass

## Verification

All run in this worktree; failures quoted, not summarized.

| Gate | Command | Result |
|---|---|---|
| Repro (was failing) | `vitest run extensions/bluebubbles/src/attachments.test.ts` (no `--config`) | **23 passed** (was 0 + resolution error) |
| No regression | `vitest run src/plugin-sdk/subpaths.test.ts` | 11 passed (baseline 11) |
| No regression | `vitest run extensions/telegram/src/channel.test.ts` | 11 passed (baseline 11) |
| Affected CI lane | `vitest run --config vitest.unit.config.ts src/plugin-sdk/` | **40 files / 362 tests passed** |
| Extension sample (root config) | 9 files incl. bluebubbles/telegram/discord/slack/feishu/matrix | 6 passed, 2 failed — **0 resolution errors** |
| Typecheck | `pnpm tsgo` | clean |
| Lint | `pnpm lint` | `Found 0 warnings and 0 errors.` |
| Format | `pnpm format` | clean (7283 files) |

The 2 failing files in the sample are `extensions/discord/src/voice-message.test.ts` and `extensions/slack/src/client.test.ts` — both already in `vitest.quarantine.ts`, failing on ffmpeg/proxy-agent assertions unrelated to aliasing. Confirmed pre-existing: **identical 10 failed / 2 files before and after** this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)