### PR TITLE
fix(slack): route Web API and Socket Mode through HTTP(S)_PROXY

### DIFF
--- a/extensions/slack/src/client.socket-mode-proxy.test.ts
+++ b/extensions/slack/src/client.socket-mode-proxy.test.ts
@@ -1,0 +1,97 @@
+import * as SlackBolt from "@slack/bolt";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveSlackWebClientOptions } from "./client.js";
+
+// Same CJS/ESM interop fallback as monitor/provider.ts, but off the namespace
+// import: under vitest the default export of this CJS module carries no `App`.
+const slackBoltModule = SlackBolt as typeof import("@slack/bolt") & {
+  default?: typeof import("@slack/bolt");
+};
+const slackBolt =
+  (slackBoltModule.App ? slackBoltModule : slackBoltModule.default) ?? slackBoltModule;
+const { App } = slackBolt;
+
+/**
+ * Socket Mode proxy support is implicit: monitor/provider.ts only passes
+ * `clientOptions` to bolt's `App`, and bolt itself carries the agent the rest of
+ * the way — `App` merges `clientOptions` into `installerOptions`
+ * (App.js: `installerOptions = { clientOptions: this.clientOptions, ...installerOptions }`),
+ * SocketModeReceiver forwards `installerOptions.clientOptions` to SocketModeClient,
+ * which hands `webClientOptions.agent` to SlackWebSocket as `httpAgent`, which `ws`
+ * uses to tunnel the upgrade request.
+ *
+ * Nothing in this repo restates that chain, so a bolt upgrade that drops the merge
+ * would silently return Slack Socket Mode to direct egress — the #2954 regression,
+ * with Web API calls still correctly proxied and no other test failing. This pins
+ * the bolt-side half of the contract at the last seam observable without a network
+ * connection: the agent arriving on the SocketModeClient.
+ */
+const PROXY_ENV_KEYS = ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"] as const;
+const originalEnv = { ...process.env };
+
+function readSocketModeAgent(app: unknown): unknown {
+  // `receiver` (App) and `webClientOptions` (SocketModeClient) are both private;
+  // reach through structurally rather than suppress the type error.
+  const receiver = (app as { receiver?: { client?: unknown } }).receiver;
+  const socketClient = receiver?.client as { webClientOptions?: { agent?: unknown } } | undefined;
+  return socketClient?.webClientOptions?.agent;
+}
+
+function createSocketModeApp(clientOptions: ReturnType<typeof resolveSlackWebClientOptions>) {
+  return new App({
+    token: "xoxb-test",
+    appToken: "xapp-test",
+    socketMode: true,
+    clientOptions,
+    // Otherwise the constructor fires a live auth.test against slack.com.
+    tokenVerificationEnabled: false,
+  });
+}
+
+describe("slack socket mode proxy wiring", () => {
+  beforeEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      if (originalEnv[key] !== undefined) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("hands the env proxy agent to the Socket Mode client", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    const clientOptions = resolveSlackWebClientOptions();
+    expect(clientOptions.agent).toBeDefined();
+
+    const agent = readSocketModeAgent(createSocketModeApp(clientOptions));
+
+    expect(agent).toBe(clientOptions.agent);
+    expect((agent as { constructor: { name: string } }).constructor.name).toBe("HttpsProxyAgent");
+  });
+
+  it("leaves the Socket Mode client unproxied when no proxy is configured", () => {
+    const clientOptions = resolveSlackWebClientOptions();
+    expect(clientOptions.agent).toBeUndefined();
+
+    expect(readSocketModeAgent(createSocketModeApp(clientOptions))).toBeUndefined();
+  });
+
+  it("leaves the Socket Mode client unproxied when NO_PROXY excludes Slack", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    process.env.NO_PROXY = "slack.com";
+    try {
+      const clientOptions = resolveSlackWebClientOptions();
+
+      expect(readSocketModeAgent(createSocketModeApp(clientOptions))).toBeUndefined();
+    } finally {
+      delete process.env.NO_PROXY;
+    }
+  });
+});

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -136,13 +136,13 @@ describe("slack web client config", () => {
   it("passes no-retry config into the write client by default", () => {
     const customAgent = {} as never;
 
-    expect(WebClient).toHaveBeenCalledWith(
-      "xoxb-test",
-      expect.objectContaining({
-        timeout: 4321,
-        retryConfig: SLACK_WRITE_RETRY_OPTIONS,
-      }),
-    );
+    createSlackWriteClient("xoxb-test", { timeout: 4321, agent: customAgent });
+
+    expect(WebClient).toHaveBeenCalledWith("xoxb-test", {
+      agent: customAgent,
+      retryConfig: SLACK_WRITE_RETRY_OPTIONS,
+      timeout: 4321,
+    });
   });
 
   it("builds stable non-secret token cache keys", () => {

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
 import { type RetryOptions, type WebClientOptions, WebClient } from "@slack/web-api";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { matchesNoProxy, resolveEnvHttpProxyUrl } from "../../../src/infra/net/proxy-env.js";
+import { resolveActiveManagedProxyTlsOptions } from "../../../src/infra/net/proxy/managed-proxy-undici.js";
 
 export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   retries: 2,
@@ -13,9 +16,41 @@ export const SLACK_WRITE_RETRY_OPTIONS: RetryOptions = {
   retries: 0,
 };
 
+/**
+ * Slack egress host, used to evaluate NO_PROXY. Both the Web API and the Socket
+ * Mode WebSocket are reached under `slack.com`, so one entry covers both paths.
+ */
+const SLACK_PROXY_TARGET_URL = "https://slack.com/";
+
+/**
+ * Build an HTTPS proxy agent from the standard proxy env vars for use as the
+ * `agent` option on Slack WebClients. Bolt carries the same agent through to the
+ * Socket Mode WebSocket upgrade on its own, so setting it here covers both the
+ * Web API and Socket Mode; client.socket-mode-proxy.test.ts pins that chain.
+ *
+ * Returns `undefined` when no proxy is configured, when NO_PROXY excludes Slack,
+ * or when the proxy URL is unusable — each of which leaves Slack on a direct
+ * connection, matching the behavior before a proxy was configured.
+ */
+export function resolveSlackProxyAgent(): HttpsProxyAgent<string> | undefined {
+  try {
+    const proxyUrl = resolveEnvHttpProxyUrl("https");
+    if (!proxyUrl || matchesNoProxy(SLACK_PROXY_TARGET_URL)) {
+      return undefined;
+    }
+    // An intercepting managed proxy terminates TLS with its own CA; without it
+    // every Slack request fails certificate validation.
+    const ca = resolveActiveManagedProxyTlsOptions({ proxyUrl })?.ca;
+    return new HttpsProxyAgent(proxyUrl, ca ? { ca } : undefined);
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveSlackWebClientOptions(options: WebClientOptions = {}): WebClientOptions {
   return {
     ...options,
+    agent: options.agent ?? resolveSlackProxyAgent(),
     retryConfig: options.retryConfig ?? SLACK_DEFAULT_RETRY_OPTIONS,
   };
 }
@@ -23,6 +58,7 @@ export function resolveSlackWebClientOptions(options: WebClientOptions = {}): We
 export function resolveSlackWriteClientOptions(options: WebClientOptions = {}): WebClientOptions {
   return {
     ...options,
+    agent: options.agent ?? resolveSlackProxyAgent(),
     retryConfig: options.retryConfig ?? SLACK_WRITE_RETRY_OPTIONS,
   };
 }

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -144,13 +144,15 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   // send.ts (unfurl_links:false payload default + Slack Web API error enrichment at every throw
   // site). The feared blast radius did not materialize: the other send tests asserting postMessage
   // payloads (send.blocks, send.upload) use expect.objectContaining, which tolerates the added key.
-  // The 2 below stay, each out of scope for a test-side un-quarantine (see PR for details):
-  // - client: proxy-agent support was gutted (no client-options.ts); restoring needs new
-  //   plugin-sdk fetch-runtime helpers (resolveEnvHttpProxyUrl / resolveActiveManagedProxyTlsOptions)
-  //   that don't exist in the fork — a network-egress SOURCE change for a separate security-gated PR.
+  // #2954 (slack): client un-quarantined — the proxy-agent SOURCE regression is fixed in client.ts
+  // (resolveSlackProxyAgent). The earlier note here claimed the required helpers "don't exist in
+  // the fork"; that was wrong — resolveEnvHttpProxyUrl (src/infra/net/proxy-env.ts) and
+  // resolveActiveManagedProxyTlsOptions (src/infra/net/proxy/managed-proxy-undici.ts) both exist,
+  // and extensions already import that first module directly (discord rest-fetch, telegram fetch).
+  // No plugin-sdk fetch-runtime subpath was needed. The file's whole proxy suite now runs in CI.
+  // The 1 below stays, out of scope for a test-side un-quarantine (see PR for details):
   // - dispatch.preview-fallback: obsolete premise — dispatch.ts finalizes previews via inline
   //   chat.update now, not finalizeSlackPreviewEdit (which is dead code); the test needs a rewrite.
-  "extensions/slack/src/client.test.ts",
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
   "extensions/telegram/src/bot-message-context.dm-threads.test.ts",
   "extensions/telegram/src/bot-message-context.group-body.test.ts",


### PR DESCRIPTION
## Problem

`resolveSlackWebClientOptions` (`extensions/slack/src/client.ts`) set only `retryConfig` and passed no `agent`. Every Slack Web API client inherited that (`directory-live.ts`, `probe.ts`, `actions.ts`, `monitor/provider.ts`), and so did the Socket Mode WebSocket. `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` were ignored and a managed proxy's TLS CA was never trusted. `send.ts`'s `withTrustedEnvProxyGuardedFetchMode` proxies only the raw file-upload `fetch`, not WebClient calls.

Impact:
- **Mandatory proxy** — Slack Web API + Socket Mode cannot connect at all.
- **Intercepting/managed proxy** — TLS fails, because the proxy CA isn't trusted.
- **Advisory proxy alongside a direct route** — Slack traffic (bot tokens in `Authorization`, full message content) egresses **outside** the operator's DLP/egress-inspection path. Not remotely exploitable, but it silently bypasses a configured security control, on the highest-value channel.

## Fix

`resolveSlackProxyAgent()` in `client.ts`: resolve via `resolveEnvHttpProxyUrl("https")` → return `undefined` if `NO_PROXY` excludes `slack.com` → apply an active managed proxy's CA via `resolveActiveManagedProxyTlsOptions({ proxyUrl })?.ca` → return an `HttpsProxyAgent`. Wired into **both** `resolveSlackWebClientOptions` and `resolveSlackWriteClientOptions` as `agent: options.agent ?? resolveSlackProxyAgent()`, so an explicitly supplied agent still wins and the no-proxy path stays direct exactly as today. Any failure (no proxy, NO_PROXY match, malformed URL) degrades to a direct connection rather than breaking Slack.

## Socket Mode needs no separate wiring — verified, not assumed

The issue expected this to be the complex part. It isn't, and the reason matters for review. **bolt already carries the agent through:**

1. `App` merges client options into installer options — `installerOptions = { clientOptions: this.clientOptions, ...installerOptions }` (bolt `dist/App.js:148`, which runs *before* `initReceiver` at `:172`).
2. `SocketModeReceiver` forwards `clientOptions: installerOptions.clientOptions` to `SocketModeClient` (`dist/receivers/SocketModeReceiver.js:35`).
3. `SocketModeClient` passes `httpAgent: this.webClientOptions.agent` to `SlackWebSocket` (`socket-mode dist/src/SocketModeClient.js:135`).
4. `SlackWebSocket` hands `agent: this.options.httpAgent` to `ws` for the upgrade (`dist/src/SlackWebSocket.js:74`).

Grounded against the installed **bolt 4.7.3 / socket-mode 2.0.7**, not the upstream commit message — which claims the agent flows via bolt's *top-level* `clientOptions`; that specific path is false here, since `initReceiver` does **not** pass `clientOptions` to `SocketModeReceiver`. It arrives through the `installerOptions` merge instead.

I first added an explicit `installerOptions: { clientOptions }` to `provider.ts` and **reverted it**: a control probe showed the agent already reaches `SocketModeClient` without it, so the edit was redundant and its explanatory comment was wrong. **`provider.ts` is unchanged in this PR.**

Because that leaves the Socket Mode behavior *implicit* — nothing in this repo restates the chain — `client.socket-mode-proxy.test.ts` pins it against real bolt (no mocks). If a bolt upgrade drops the merge, Slack Socket Mode would silently return to direct egress with Web API still correctly proxied and no other test failing. This makes that fail CI instead.

## Tests

`client.test.ts` **already contained the complete proxy spec** (13 tests) left orphaned when the implementation was gutted — the file was quarantined, so it never ran. Un-quarantined rather than rewritten; it now passes against the restored implementation.

- **`client.test.ts` — 21 passed.** Agent from `HTTPS_PROXY`; `HTTP_PROXY` fallback; lowercase `https_proxy` precedence; empty-lowercase authoritative; `NO_PROXY` (`slack.com`, `.slack.com`, space-separated, `*`, non-matching host); explicit agent not overridden; write client; malformed URL degrades; **managed-proxy CA applied** (`agent.connectOpts.ca`).
- **`client.socket-mode-proxy.test.ts` — 3 passed (new).** Agent reaches `SocketModeClient`; unproxied with no proxy; unproxied when `NO_PROXY` excludes Slack.

**Discrimination check (mutation test):** removing the `agent:` wiring turns **7 of the 24 red** — including `adds managed proxy CA trust` and `hands the env proxy agent to the Socket Mode client`; restoring returns 24/24. The tests catch the actual #2954 regression rather than merely passing.

Also fixed a latent defect in the file being un-quarantined: `passes no-retry config into the write client by default` asserted `toHaveBeenCalledWith` but **never called `createSlackWriteClient`** (`Number of calls: 0`) — it could never fail. Its invocation was restored from upstream.

## Notes for review

- **The quarantine note was wrong and is corrected.** It claimed restoring proxy support "needs new plugin-sdk fetch-runtime helpers (`resolveEnvHttpProxyUrl` / `resolveActiveManagedProxyTlsOptions`) that don't exist in the fork". Both exist — `src/infra/net/proxy-env.ts` and `src/infra/net/proxy/managed-proxy-undici.ts` — and extensions already import the former directly (`discord/src/monitor/rest-fetch.ts`, `telegram/src/fetch.ts`). No plugin-sdk subpath was needed.
- **Sibling issue #2984** reports `addActiveManagedProxyTlsOptions` is orphaned in the shared undici runtime. It does **not** affect this fix: `resolveActiveManagedProxyTlsOptions` is self-contained — it reads active-proxy state or loads the CA file itself, and never routes through the orphaned wrapper. Confirmed empirically, not just by reading: the managed-CA test fails when the wiring is removed and passes with it.
- **No `package.json` change.** `extensions/slack` is `"private": true`, declares no `dependencies`, and resolves `@slack/web-api` / `@slack/bolt` from the root — where `https-proxy-agent@^8.0.0` already sits. Adding a deps block would diverge from how this extension resolves its other Slack deps. (Upstream used `^9.0.0`; the fork standardizes on `^8.0.0`, as feishu does.)
- `NO_PROXY` is matched against `https://slack.com/`, which covers both the Web API and the Socket Mode host. `slackApiUrl` is unused in the fork, so it is deliberately not plumbed through.

## Gates (run locally, this worktree)

| Gate | Command | Result |
|---|---|---|
| Full CI `lint` job | `pnpm check` (format:check + tsgo + lint + fork-integrity gates) | exit 0 |
| Typecheck | `pnpm tsgo` | exit 0 |
| CI `test-extensions` lane | `vitest run --config vitest.extensions.config.ts` | exit 0 — **472 files, 4502 passed, 27 skipped** |
| Slack proxy suites | same config, both files | **24 passed** |

The extensions lane was run via its **config** (no file arguments) so the quarantine include-filter is honored, and a verbose run confirms the un-quarantined file actually executes (17 proxy assertions) rather than being silently excluded.

Closes #2954