### PR TITLE
fix(discord): wire the inbound message-ID replay guard into the live path (#2968)

### DIFF
--- a/extensions/discord/src/monitor/inbound-worker.ts
+++ b/extensions/discord/src/monitor/inbound-worker.ts
@@ -1,8 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { ClaimableDedupe } from "remoteclaw/plugin-sdk/persistent-dedupe";
 import { createRunStateMachine } from "../../../../src/channels/run-state-machine.js";
 import { danger } from "../../../../src/globals.js";
 import { formatDurationSeconds } from "../../../../src/infra/format-time/format-duration.ts";
 import { KeyedAsyncQueue } from "../../../../src/plugin-sdk/keyed-async-queue.js";
+import {
+  commitDiscordInboundReplay,
+  DiscordRetryableInboundError,
+  releaseDiscordInboundReplay,
+} from "./inbound-dedupe.js";
 import { materializeDiscordInboundJob, type DiscordInboundJob } from "./inbound-job.js";
 import type { RuntimeEnv } from "./message-handler.preflight.types.js";
 import { processDiscordMessage } from "./message-handler.process.js";
@@ -14,6 +20,7 @@ type DiscordInboundWorkerParams = {
   setStatus?: any;
   abortSignal?: AbortSignal;
   runTimeoutMs?: number;
+  replayGuard: ClaimableDedupe;
 };
 
 export type DiscordInboundWorker = {
@@ -66,6 +73,37 @@ async function processDiscordInboundJob(params: {
   });
 }
 
+// The replay key is claimed before preflight (see message-handler.ts) and its claim is
+// resolved here, once the run's outcome is known: committed so a gateway RESUME
+// redelivery is dropped, or released so it is reprocessed.
+async function runDiscordInboundJobWithReplayGuard(params: {
+  job: DiscordInboundJob;
+  runtime: RuntimeEnv;
+  replayGuard: ClaimableDedupe;
+  lifecycleSignal?: AbortSignal;
+  runTimeoutMs?: number;
+}) {
+  const { job, replayGuard } = params;
+  try {
+    await processDiscordInboundJob({
+      job,
+      runtime: params.runtime,
+      lifecycleSignal: params.lifecycleSignal,
+      runTimeoutMs: params.runTimeoutMs,
+    });
+  } catch (error) {
+    if (error instanceof DiscordRetryableInboundError) {
+      releaseDiscordInboundReplay({ replayKeys: job.replayKeys, replayGuard, error });
+    } else {
+      // A non-retryable failure can still have emitted user-visible side effects, so
+      // keep the claim committed rather than replaying them on redelivery.
+      await commitDiscordInboundReplay({ replayKeys: job.replayKeys, replayGuard });
+    }
+    throw error;
+  }
+  await commitDiscordInboundReplay({ replayKeys: job.replayKeys, replayGuard });
+}
+
 export function createDiscordInboundWorker(
   params: DiscordInboundWorkerParams,
 ): DiscordInboundWorker {
@@ -80,16 +118,25 @@ export function createDiscordInboundWorker(
       void runQueue
         .enqueue(job.queueKey, async () => {
           if (!runState.isActive()) {
+            releaseDiscordInboundReplay({
+              replayKeys: job.replayKeys,
+              replayGuard: params.replayGuard,
+            });
             return;
           }
           runState.onRunStart();
           try {
             if (!runState.isActive()) {
+              releaseDiscordInboundReplay({
+                replayKeys: job.replayKeys,
+                replayGuard: params.replayGuard,
+              });
               return;
             }
-            await processDiscordInboundJob({
+            await runDiscordInboundJobWithReplayGuard({
               job,
               runtime: params.runtime,
+              replayGuard: params.replayGuard,
               lifecycleSignal: params.abortSignal,
               runTimeoutMs: params.runTimeoutMs,
             });

--- a/extensions/discord/src/monitor/message-handler.dedupe.test.ts
+++ b/extensions/discord/src/monitor/message-handler.dedupe.test.ts
@@ -1,0 +1,142 @@
+// Focused regression coverage for the inbound message-ID replay guard wired into
+// createDiscordMessageHandler (#2968). These three cases were re-homed out of the
+// still-quarantined message-handler.queue.test.ts (which stays quarantined only on its
+// timeout-fallback-reply cases, an open maintainer-intent decision) so the dedup behavior
+// gates CI on its own. Mirrors the #2953/#2970 focused-spec re-homing precedent.
+import { describe, expect, it, vi } from "vitest";
+import { DiscordRetryableInboundError } from "./inbound-dedupe.js";
+import {
+  createDiscordMessageHandler,
+  preflightDiscordMessageMock,
+  processDiscordMessageMock,
+} from "./message-handler.module-test-helpers.js";
+import {
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
+
+type SetStatusFn = (patch: Record<string, unknown>) => void;
+
+function createMessageData(messageId: string, channelId = "ch-1") {
+  return {
+    channel_id: channelId,
+    author: { id: "user-1" },
+    message: {
+      id: messageId,
+      author: { id: "user-1", bot: false },
+      content: "hello",
+      channel_id: channelId,
+      attachments: [{ id: `att-${messageId}` }],
+    },
+  };
+}
+
+function createPreflightContext(channelId = "ch-1") {
+  return {
+    ...createDiscordPreflightContext(channelId),
+    accountId: "default",
+    token: "test-token",
+    textLimit: 2_000,
+    replyToMode: "off" as const,
+    discordConfig: {
+      enabled: true,
+      token: "test-token",
+      groupPolicy: "allowlist" as const,
+    },
+  };
+}
+
+function installDefaultDiscordPreflight() {
+  preflightDiscordMessageMock.mockImplementation(async (params: { data: { channel_id: string } }) =>
+    createPreflightContext(params.data.channel_id),
+  );
+}
+
+function createHandlerWithDefaultPreflight(overrides?: {
+  setStatus?: SetStatusFn;
+  workerRunTimeoutMs?: number;
+}) {
+  installDefaultDiscordPreflight();
+  return createDiscordMessageHandler(createDiscordHandlerParams(overrides));
+}
+
+describe("createDiscordMessageHandler inbound replay guard", () => {
+  it("drops duplicate inbound message deliveries before they reach preflight", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const handler = createHandlerWithDefaultPreflight();
+    const duplicate = createMessageData("m-dup");
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries duplicate deliveries after an explicit retryable worker failure", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    processDiscordMessageMock
+      .mockRejectedValueOnce(new DiscordRetryableInboundError("retry me"))
+      .mockResolvedValueOnce(undefined);
+    const params = createDiscordHandlerParams();
+    const handler = createDiscordMessageHandler(params);
+    installDefaultDiscordPreflight();
+    const duplicate = createMessageData("m-retry");
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(params.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "discord inbound worker failed: DiscordRetryableInboundError: retry me",
+        ),
+      );
+    });
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+    });
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps replay committed after a non-retryable worker failure", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const visibleSideEffect = vi.fn();
+    processDiscordMessageMock.mockImplementationOnce(async () => {
+      visibleSideEffect();
+      throw new Error("post-send failure");
+    });
+    const params = createDiscordHandlerParams();
+    const handler = createDiscordMessageHandler(params);
+    installDefaultDiscordPreflight();
+    const duplicate = createMessageData("m-fail");
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(params.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord inbound worker failed: Error: post-send failure"),
+      );
+    });
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await Promise.resolve();
+
+    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+    expect(visibleSideEffect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { DiscordRetryableInboundError } from "./inbound-dedupe.js";
 import {
   createDiscordMessageHandler,
   preflightDiscordMessageMock,
@@ -258,84 +257,12 @@ describe("createDiscordMessageHandler queue behavior", () => {
     });
   });
 
-  it("drops duplicate inbound message deliveries before they reach preflight", async () => {
-    preflightDiscordMessageMock.mockReset();
-    processDiscordMessageMock.mockReset();
-
-    const handler = createHandlerWithDefaultPreflight();
-    const duplicate = createMessageData("m-dup");
-
-    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
-    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
-
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-    });
-    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries duplicate deliveries after an explicit retryable worker failure", async () => {
-    preflightDiscordMessageMock.mockReset();
-    processDiscordMessageMock.mockReset();
-
-    processDiscordMessageMock
-      .mockRejectedValueOnce(new DiscordRetryableInboundError("retry me"))
-      .mockResolvedValueOnce(undefined);
-    const params = createDiscordHandlerParams();
-    const handler = createDiscordMessageHandler(params);
-    installDefaultDiscordPreflight();
-    const duplicate = createMessageData("m-retry");
-
-    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-    });
-    await vi.waitFor(() => {
-      expect(params.runtime.error).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "discord inbound worker failed: DiscordRetryableInboundError: retry me",
-        ),
-      );
-    });
-
-    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
-    });
-    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps replay committed after a non-retryable worker failure", async () => {
-    preflightDiscordMessageMock.mockReset();
-    processDiscordMessageMock.mockReset();
-
-    const visibleSideEffect = vi.fn();
-    processDiscordMessageMock.mockImplementationOnce(async () => {
-      visibleSideEffect();
-      throw new Error("post-send failure");
-    });
-    const params = createDiscordHandlerParams();
-    const handler = createDiscordMessageHandler(params);
-    installDefaultDiscordPreflight();
-    const duplicate = createMessageData("m-fail");
-
-    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
-    await vi.waitFor(() => {
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-    });
-    await vi.waitFor(() => {
-      expect(params.runtime.error).toHaveBeenCalledWith(
-        expect.stringContaining("discord inbound worker failed: Error: post-send failure"),
-      );
-    });
-
-    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
-    await Promise.resolve();
-
-    expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
-    expect(visibleSideEffect).toHaveBeenCalledTimes(1);
-  });
+  // The inbound replay-guard dedup cases that used to live here were re-homed to
+  // message-handler.dedupe.test.ts (un-quarantined, gates CI) once the guard was wired in
+  // (#2968). This file stays quarantined ONLY on its timeout-fallback-reply cases below,
+  // which assert a user-facing "timed out" channel reply that is a separate,
+  // ratification-pending maintainer decision (onTimeout is still log-only). See
+  // vitest.quarantine.ts.
 
   it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {
     vi.useFakeTimers();

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -5,6 +5,12 @@ import {
 } from "../../../../src/channels/inbound-debounce-policy.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../../../src/config/runtime-group-policy.js";
 import { danger } from "../../../../src/globals.js";
+import {
+  buildDiscordInboundReplayKey,
+  claimDiscordInboundReplay,
+  createDiscordInboundReplayGuard,
+  releaseDiscordInboundReplay,
+} from "./inbound-dedupe.js";
 import { buildDiscordInboundJob } from "./inbound-job.js";
 import { createDiscordInboundWorker } from "./inbound-worker.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
@@ -42,12 +48,36 @@ export function createDiscordMessageHandler(
     params.discordConfig?.ackReactionScope ??
     params.cfg.messages?.ackReactionScope ??
     "group-mentions";
+  const replayGuard = createDiscordInboundReplayGuard();
   const inboundWorker = createDiscordInboundWorker({
     runtime: params.runtime,
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
     runTimeoutMs: params.workerRunTimeoutMs,
+    replayGuard,
   });
+
+  async function claimDiscordInboundReplayKeys(
+    entries: ReadonlyArray<{ data: DiscordMessageEvent }>,
+  ): Promise<{ claimedKeys: string[]; anyClaimAttempted: boolean }> {
+    const claimedKeys: string[] = [];
+    let anyClaimAttempted = false;
+    for (const entry of entries) {
+      const replayKey = buildDiscordInboundReplayKey({
+        accountId: params.accountId,
+        data: entry.data,
+      });
+      if (!replayKey) {
+        continue;
+      }
+      anyClaimAttempted = true;
+      const claimed = await claimDiscordInboundReplay({ replayKey, replayGuard });
+      if (claimed) {
+        claimedKeys.push(replayKey);
+      }
+    }
+    return { claimedKeys, anyClaimAttempted };
+  }
 
   const { debouncer } = createChannelInboundDebouncer<{
     data: DiscordMessageEvent;
@@ -95,6 +125,16 @@ export function createDiscordMessageHandler(
       if (abortSignal?.aborted) {
         return;
       }
+      // Claim each message's replay key BEFORE preflight so a gateway RESUME
+      // redelivery of an already-seen message is dropped here instead of being
+      // preflighted and dispatched a second time. Messages without an id can't be
+      // deduped and pass through; when every claimable id is a duplicate the whole
+      // flush is dropped. Claimed keys travel with the job so the worker can commit
+      // them on success or release them on a retryable failure.
+      const { claimedKeys, anyClaimAttempted } = await claimDiscordInboundReplayKeys(entries);
+      if (anyClaimAttempted && claimedKeys.length === 0) {
+        return;
+      }
       if (entries.length === 1) {
         const ctx = await preflightDiscordMessage({
           ...params,
@@ -105,9 +145,10 @@ export function createDiscordMessageHandler(
           client: last.client,
         });
         if (!ctx) {
+          releaseDiscordInboundReplay({ replayKeys: claimedKeys, replayGuard });
           return;
         }
-        inboundWorker.enqueue(buildDiscordInboundJob(ctx));
+        inboundWorker.enqueue(buildDiscordInboundJob(ctx, { replayKeys: claimedKeys }));
         return;
       }
       const combinedBaseText = entries
@@ -137,6 +178,7 @@ export function createDiscordMessageHandler(
         client: last.client,
       });
       if (!ctx) {
+        releaseDiscordInboundReplay({ replayKeys: claimedKeys, replayGuard });
         return;
       }
       if (entries.length > 1) {
@@ -152,7 +194,7 @@ export function createDiscordMessageHandler(
           ctxBatch.MessageSidLast = ids[ids.length - 1];
         }
       }
-      inboundWorker.enqueue(buildDiscordInboundJob(ctx));
+      inboundWorker.enqueue(buildDiscordInboundJob(ctx, { replayKeys: claimedKeys }));
     },
     onError: (err) => {
       params.runtime.error?.(danger(`discord debounce flush failed: ${String(err)}`));

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -70,6 +70,18 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/discord/src/monitor.tool-result.sends-status-replies-responseprefix.test.ts",
   "extensions/discord/src/monitor/auto-presence.test.ts",
   "extensions/discord/src/monitor/message-handler.preflight.test.ts",
+  // #2968 (discord): the inbound message-ID replay guard is now wired into
+  // inbound-worker.ts / message-handler.ts, and this file's 3 dedup cases were re-homed to
+  // message-handler.dedupe.test.ts (un-quarantined, so the dedup behavior gates CI) — the
+  // #2953/#2970 focused-spec re-homing precedent. message-handler.queue.test.ts STAYS
+  // quarantined ONLY on its 3 timeout-fallback-reply cases ("applies explicit inbound worker
+  // timeout ...", "waits for the timeout fallback reply before starting the next queued run",
+  // "routes the timeout fallback to the created auto-thread target"): they assert a
+  // user-facing "Discord inbound worker timed out." channel reply, but onTimeout is
+  // deliberately still log-only pending a separate, ratification-pending maintainer decision
+  // on whether that fallback reply should exist. (The file's remaining queue-behavior cases
+  // pass, but file-level quarantine is all-or-nothing.) Un-quarantine when the timeout-reply
+  // decision lands.
   "extensions/discord/src/monitor/message-handler.queue.test.ts",
   "extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts",
   "extensions/discord/src/voice-message.test.ts",


### PR DESCRIPTION
## Problem

The Discord adapter ships a message-ID replay guard in
`extensions/discord/src/monitor/inbound-dedupe.ts`
(`createDiscordInboundReplayGuard`, `buildDiscordInboundReplayKey`,
`claimDiscordInboundReplay`, `commitDiscordInboundReplay`,
`releaseDiscordInboundReplay`, `DiscordRetryableInboundError`), but **nothing on
the live inbound path used it** — a repo-wide search for those symbols returned
only the module itself plus its test.

The live path is `createDiscordMessageHandler` (`message-handler.ts`) →
`createDiscordInboundWorker` (`inbound-worker.ts`) → `enqueue` →
`processDiscordInboundJob` → `processDiscordMessage`. The worker serializes per
channel by `queueKey` (`KeyedAsyncQueue`) but never claimed/committed a
per-message replay key.

**Impact:** the Discord gateway redelivers `MESSAGE_CREATE` after a RESUME
(reconnect). Without the guard, the same message is enqueued and processed twice
→ duplicate agent dispatch and duplicate replies. Debounce coalescing does not
cover this: for messages with media, debounce is disabled, and RESUME
redelivery lands outside any debounce window regardless.

## Fix (dedup replay-guard core only)

Wire the existing guard into the live path:

- `message-handler.ts` creates one `createDiscordInboundReplayGuard()` store per
  handler instance and, in `onFlush`, **claims each message's replay key before
  preflight** (`buildDiscordInboundReplayKey` + `claimDiscordInboundReplay`).
  When every claimable id is already seen, the flush is dropped before preflight
  — the duplicate never reaches dispatch. Claimed keys travel with the job
  (`buildDiscordInboundJob(ctx, { replayKeys })`).
- `inbound-worker.ts` resolves the claim once the run outcome is known:
  **commit** on success, **release** on a `DiscordRetryableInboundError` (so a
  later redelivery retries), and **keep committed** on a non-retryable failure
  (so user-visible side effects are not replayed on redelivery). Jobs dropped
  because the worker was deactivated release their claim to avoid an inflight
  leak.

### Wiring
- `extensions/discord/src/monitor/message-handler.ts` — per-instance
  `replayGuard`; `claimDiscordInboundReplayKeys()` claims before preflight; drops
  the flush when all ids are duplicates; releases on null preflight.
- `extensions/discord/src/monitor/inbound-worker.ts` —
  `runDiscordInboundJobWithReplayGuard()` commit/release/keep-committed lifecycle.

## Explicitly out of scope (separate pending decision)

The worker's `onTimeout` handler (`inbound-worker.ts`) is **deliberately left
log-only and untouched**. Whether a user-facing "timed out" channel reply should
be delivered is a separate, maintainer-intent decision that is not settled here.
Because of that, this PR addresses **only the dedup core**, so the issue may be
only partially addressed — the timeout-fallback-reply sub-piece is intentionally
not implemented.

## Tests

The 3 dedup cases were **re-homed** out of the still-quarantined
`message-handler.queue.test.ts` into a focused, un-quarantined
`message-handler.dedupe.test.ts` so the dedup behavior gates CI (mirrors the
focused-spec re-homing precedent used for prior adapter un-quarantines).
`message-handler.queue.test.ts` **stays quarantined only on its three
timeout-fallback-reply cases**, which assert the un-built user-facing timeout
reply pending the decision above; the quarantine ledger note is updated to say
exactly that.

Focused spec (`message-handler.dedupe.test.ts`), all green:
- drops duplicate inbound message deliveries before they reach preflight
- retries duplicate deliveries after an explicit retryable worker failure
- keeps replay committed after a non-retryable worker failure

### Verification (run locally, synchronous)
- **Typecheck** — `tsgo -p extensions/discord/tsconfig.json`: zero errors in the
  discord extension. (The only error in the graph is a pre-existing
  `qrcode-terminal` DefinitelyTyped issue in `extensions/whatsapp/src/qr-image.ts`,
  confirmed identical on the base commit with these changes stashed.)
- **Discord extension suite** — `vitest.extensions.config.ts` scoped to
  `extensions/discord/` (quarantine applied, as CI runs it):
  **65 files passed, 442 passed, 5 skipped, exit 0**; the quarantined
  `queue.test.ts` correctly did not run; the 3 dedupe cases are collected in the
  lane.
- **Necropsy** — with the wiring stashed (pre-wire code), the focused spec goes
  red exactly where it should: *"drops duplicate inbound message deliveries
  before they reach preflight"* fails with **"expected to be called 1 times, but
  got 2 times"** (both deliveries reach preflight/process), and *"keeps replay
  committed after a non-retryable worker failure"* fails 2-vs-1. Restoring the
  wiring turns them green again — the guard is load-bearing.

Closes #2968
