### PR TITLE
fix(telegram): route inbound through the policy-aware resolver — fail-closed (#2961)

### DIFF
--- a/extensions/telegram/src/bot-message-context.audio-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-context.audio-transcript.test.ts
@@ -48,7 +48,12 @@ async function buildGroupVoiceContext(params: {
     allMedia: [{ path: params.mediaPath, contentType: "audio/ogg" }],
     options: { forceWasMentioned: params.forceWasMentioned ?? true },
     cfg: {
-      agents: { defaults: { model: DEFAULT_MODEL, workspace: DEFAULT_WORKSPACE } },
+      agents: {
+        // Fail-closed routing (#2961): with no configured agent the message is dropped as
+        // unmatched before any transcript work happens.
+        list: [{ id: "main" }],
+        defaults: { model: DEFAULT_MODEL, workspace: DEFAULT_WORKSPACE },
+      },
       channels: { telegram: {} },
       messages: { groupChat: { mentionPatterns: [DEFAULT_MENTION_PATTERN] } },
     },

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -120,7 +120,12 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
 describe("buildTelegramMessageContext direct peer routing", () => {
   it("isolates dm sessions by sender id when chat id differs", async () => {
     const runtimeCfg = {
-      agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" } },
+      agents: {
+        // Fail-closed routing (#2961): with no configured agent nothing matches and the
+        // message is dropped as unmatched before a session key is ever built.
+        list: [{ id: "main" }],
+        defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" },
+      },
       channels: { telegram: {} },
       messages: { groupChat: { mentionPatterns: [] } },
       session: { dmScope: "per-channel-peer" as const },

--- a/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
+++ b/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
@@ -1,21 +1,51 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const recordInboundSessionMock = vi.fn().mockResolvedValue(undefined);
-vi.mock("../channels/session.js", () => ({
+// Mock path repaired (#2961): "../channels/session.js" predates the src/telegram/ ->
+// extensions/telegram/src/ move and resolved to a module that does not exist, so
+// recordInboundSession was never actually mocked here.
+vi.mock("../../../src/channels/session.js", () => ({
   recordInboundSession: (...args: unknown[]) => recordInboundSessionMock(...args),
 }));
 
 let buildTelegramMessageContextForTest: typeof import("./bot-message-context.test-harness.js").buildTelegramMessageContextForTest;
 let clearRuntimeConfigSnapshot: typeof import("../../../src/config/config.js").clearRuntimeConfigSnapshot;
-let setRuntimeConfigSnapshot: typeof import("../../../src/config/config.js").setRuntimeConfigSnapshot;
 
-describe("buildTelegramMessageContext named-account DM fallback", () => {
-  const baseCfg = {
-    agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" } },
-    channels: { telegram: {} },
-    messages: { groupChat: { mentionPatterns: [] } },
+/**
+ * No `agents.list`, no bindings: nothing matches, so `routing.unmatched` drops (its
+ * default action). This is the fixture the upstream "named-account DM fallback" cases
+ * were written against, back when an unmatched route silently landed on a phantom
+ * "default" agent.
+ */
+const unmatchedCfg = {
+  agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" } },
+  channels: { telegram: {} },
+  messages: { groupChat: { mentionPatterns: [] } },
+};
+
+/**
+ * Exactly one configured agent, so sole-agent promotion resolves the route
+ * (`matchedBy: "fallback.soleAgent"`) — what an ordinary single-agent deployment does.
+ */
+const soleAgentCfg = {
+  ...unmatchedCfg,
+  agents: {
+    list: [{ id: "main" }],
+    defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" },
+  },
+};
+
+function buildNamedAccountDmMessage(messageId = 1) {
+  return {
+    message_id: messageId,
+    chat: { id: 814912386, type: "private" as const },
+    date: 1700000000 + messageId - 1,
+    text: "hello",
+    from: { id: 814912386, first_name: "Alice" },
   };
+}
 
+describe("buildTelegramMessageContext named-account routing", () => {
   afterEach(() => {
     clearRuntimeConfigSnapshot();
     recordInboundSessionMock.mockClear();
@@ -23,111 +53,30 @@ describe("buildTelegramMessageContext named-account DM fallback", () => {
 
   beforeEach(async () => {
     vi.resetModules();
-    ({ clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
-      await import("../../../src/config/config.js"));
+    ({ clearRuntimeConfigSnapshot } = await import("../../../src/config/config.js"));
     ({ buildTelegramMessageContextForTest } =
       await import("./bot-message-context.test-harness.js"));
   });
 
-  function getLastUpdateLastRoute(): { sessionKey?: string } | undefined {
-    const callArgs = recordInboundSessionMock.mock.calls.at(-1)?.[0] as {
-      updateLastRoute?: { sessionKey?: string };
-    };
-    return callArgs?.updateLastRoute;
-  }
-
-  function buildNamedAccountDmMessage(messageId = 1) {
-    return {
-      message_id: messageId,
-      chat: { id: 814912386, type: "private" as const },
-      date: 1700000000 + messageId - 1,
-      text: "hello",
-      from: { id: 814912386, first_name: "Alice" },
-    };
-  }
-
-  async function buildNamedAccountDmContext(accountId = "atlas", messageId = 1) {
-    setRuntimeConfigSnapshot(baseCfg);
-    return await buildTelegramMessageContextForTest({
-      cfg: baseCfg,
-      accountId,
-      message: buildNamedAccountDmMessage(messageId),
-    });
-  }
-
-  it("allows DM through for a named account with no explicit binding", async () => {
-    setRuntimeConfigSnapshot(baseCfg);
-
+  // Fork inversion of the upstream "allows DM through for a named account with no
+  // explicit binding" case (see the skipped describe below). Upstream let this DM pass
+  // through on the phantom "default" tier; this fork has no such tier, so the route is
+  // unmatched and `routing.unmatched` drops it. Before #2961 the inbound path called the
+  // bare resolveAgentRoute(), which swallowed that drop and fail-open delivered the DM
+  // via `fallback.legacyRoute` — the vulnerability #2961 scenario D names.
+  it("drops an unbound named-account DM when nothing matches (fail-closed)", async () => {
     const ctx = await buildTelegramMessageContextForTest({
-      cfg: baseCfg,
+      cfg: unmatchedCfg,
       accountId: "atlas",
-      message: {
-        message_id: 1,
-        chat: { id: 814912386, type: "private" },
-        date: 1700000000,
-        text: "hello",
-        from: { id: 814912386, first_name: "Alice" },
-      },
+      message: buildNamedAccountDmMessage(),
     });
 
-    expect(ctx).not.toBeNull();
-    expect(ctx?.route.matchedBy).toBe("default");
-    expect(ctx?.route.accountId).toBe("atlas");
-  });
-
-  it("uses a per-account session key for named-account DMs", async () => {
-    const ctx = await buildNamedAccountDmContext();
-
-    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
-  });
-
-  it("keeps named-account fallback lastRoute on the isolated DM session", async () => {
-    const ctx = await buildNamedAccountDmContext();
-
-    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
-    expect(getLastUpdateLastRoute()?.sessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
-  });
-
-  it("isolates sessions between named accounts that share the default agent", async () => {
-    const atlas = await buildNamedAccountDmContext("atlas", 1);
-    const skynet = await buildNamedAccountDmContext("skynet", 2);
-
-    expect(atlas?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
-    expect(skynet?.ctxPayload?.SessionKey).toBe("agent:main:telegram:skynet:direct:814912386");
-    expect(atlas?.ctxPayload?.SessionKey).not.toBe(skynet?.ctxPayload?.SessionKey);
-  });
-
-  it("keeps identity-linked peer canonicalization in the named-account fallback path", async () => {
-    const cfg = {
-      ...baseCfg,
-      session: {
-        identityLinks: {
-          "alice-shared": ["telegram:814912386"],
-        },
-      },
-    };
-    setRuntimeConfigSnapshot(cfg);
-
-    const ctx = await buildTelegramMessageContextForTest({
-      cfg,
-      accountId: "atlas",
-      message: {
-        message_id: 1,
-        chat: { id: 999999999, type: "private" },
-        date: 1700000000,
-        text: "hello",
-        from: { id: 814912386, first_name: "Alice" },
-      },
-    });
-
-    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:alice-shared");
+    expect(ctx).toBeNull();
   });
 
   it("still drops named-account group messages without an explicit binding", async () => {
-    setRuntimeConfigSnapshot(baseCfg);
-
     const ctx = await buildTelegramMessageContextForTest({
-      cfg: baseCfg,
+      cfg: unmatchedCfg,
       accountId: "atlas",
       options: { forceWasMentioned: true },
       resolveGroupActivation: () => true,
@@ -143,11 +92,11 @@ describe("buildTelegramMessageContext named-account DM fallback", () => {
     expect(ctx).toBeNull();
   });
 
+  // Guards the ordinary single-agent path against the #2961 drop: a resolvable route must
+  // still be delivered, and DMs must still collapse onto the main session key.
   it("does not change the default-account DM session key", async () => {
-    setRuntimeConfigSnapshot(baseCfg);
-
     const ctx = await buildTelegramMessageContextForTest({
-      cfg: baseCfg,
+      cfg: soleAgentCfg,
       message: {
         message_id: 1,
         chat: { id: 42, type: "private" },
@@ -157,6 +106,125 @@ describe("buildTelegramMessageContext named-account DM fallback", () => {
       },
     });
 
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("fallback.soleAgent");
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main");
+  });
+
+  // The named-account gate is scoped to GROUP traffic (#2961 scenario C), so a
+  // named-account DM on a resolvable route is delivered, not dropped.
+  it("delivers a named-account DM when the route resolves", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: soleAgentCfg,
+      accountId: "atlas",
+      message: buildNamedAccountDmMessage(),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.accountId).toBe("atlas");
+  });
+});
+
+/**
+ * GUT-PINNED (#2961) — these cases encode UPSTREAM semantics this fork deliberately removed.
+ *
+ * They assert that an unbound named-account DM passes through on `matchedBy: "default"`
+ * and receives a per-account DM fallback session key
+ * (`agent:main:telegram:atlas:direct:<peer>`). Both halves are unreachable here:
+ *
+ *  1. The "default" tier does not exist. `MatchedByTier` (src/routing/resolve-route.ts)
+ *     enumerates only `binding.*`, `fallback.soleAgent`, `fallback.legacyRoute` and
+ *     `unmatched.catchAll`. The fork deleted the phantom default-agent fallback and
+ *     replaced it with sole-agent promotion — the comment on that promotion in
+ *     resolve-route.ts is explicit that it exists "without reintroducing the phantom
+ *     'default' agent fallback", and test/default-agent-elimination.test.ts pins that
+ *     contract. Pre-fix these cases observed `fallback.legacyRoute` (the fail-open
+ *     #2961 removes), never `default`.
+ *  2. The per-account DM key requires `session.dmScope: "per-account-channel-peer"`.
+ *     Under the default `dmScope: "main"`, buildAgentPeerSessionKey collapses every DM
+ *     to `agent:<id>:main` regardless of account, so no fork tier can produce
+ *     `agent:main:telegram:atlas:direct:...` from this fixture.
+ *
+ * The fork's posture is drop-by-default: an unbound named-account DM is DROPPED
+ * (fail-closed), which the live "drops an unbound named-account DM" case above pins.
+ * Do NOT un-skip these — re-adding the behavior they describe would reintroduce exactly
+ * the phantom-default fallback the fork removed. They are kept, rather than deleted, as a
+ * greppable record of the upstream/fork divergence.
+ */
+describe.skip("upstream named-account DM fallback (removed in this fork)", () => {
+  it("allows DM through for a named account with no explicit binding", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: unmatchedCfg,
+      accountId: "atlas",
+      message: buildNamedAccountDmMessage(),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("default");
+    expect(ctx?.route.accountId).toBe("atlas");
+  });
+
+  it("uses a per-account session key for named-account DMs", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: unmatchedCfg,
+      accountId: "atlas",
+      message: buildNamedAccountDmMessage(),
+    });
+
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
+  });
+
+  it("keeps named-account fallback lastRoute on the isolated DM session", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: unmatchedCfg,
+      accountId: "atlas",
+      message: buildNamedAccountDmMessage(),
+    });
+    const updateLastRoute = (
+      recordInboundSessionMock.mock.calls.at(-1)?.[0] as {
+        updateLastRoute?: { sessionKey?: string };
+      }
+    )?.updateLastRoute;
+
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
+    expect(updateLastRoute?.sessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
+  });
+
+  it("isolates sessions between named accounts that share the default agent", async () => {
+    const atlas = await buildTelegramMessageContextForTest({
+      cfg: unmatchedCfg,
+      accountId: "atlas",
+      message: buildNamedAccountDmMessage(1),
+    });
+    const skynet = await buildTelegramMessageContextForTest({
+      cfg: unmatchedCfg,
+      accountId: "skynet",
+      message: buildNamedAccountDmMessage(2),
+    });
+
+    expect(atlas?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:814912386");
+    expect(skynet?.ctxPayload?.SessionKey).toBe("agent:main:telegram:skynet:direct:814912386");
+    expect(atlas?.ctxPayload?.SessionKey).not.toBe(skynet?.ctxPayload?.SessionKey);
+  });
+
+  it("keeps identity-linked peer canonicalization in the named-account fallback path", async () => {
+    const cfg = {
+      ...unmatchedCfg,
+      session: { identityLinks: { "alice-shared": ["telegram:814912386"] } },
+    };
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg,
+      accountId: "atlas",
+      message: {
+        message_id: 1,
+        chat: { id: 999999999, type: "private" },
+        date: 1700000000,
+        text: "hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:atlas:direct:alice-shared");
   });
 });

--- a/extensions/telegram/src/bot-message-context.routing-policy.test.ts
+++ b/extensions/telegram/src/bot-message-context.routing-policy.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearRuntimeConfigSnapshot } from "../../../src/config/config.js";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+/**
+ * Regression coverage for #2961 scenarios C and D on the INBOUND message path.
+ *
+ * Before the fix, `bot-message-context.ts` resolved routes with the bare
+ * `resolveAgentRoute()`, which applies the `routing.unmatched` policy and then
+ * *swallows* a drop verdict, falling back to the first configured agent tagged
+ * `fallback.legacyRoute` (see the migration warning in src/routing/resolve-route.ts).
+ * Every case below therefore FAILS against the pre-fix path: it delivered a context where
+ * these assert `null`.
+ *
+ * The two drops are distinct and are pinned separately:
+ *   - D fires when the route resolves to NOTHING (unmatched + no catch-all + no sole agent).
+ *   - C fires when the route resolves FINE, but on a non-`binding.*` tier, for a
+ *     named-account GROUP message. The catch-all fixtures below are what make C
+ *     discriminating: the route is non-null there, so D cannot account for the drop.
+ */
+
+const GROUP_CHAT_ID = -1001234567890;
+const GROUP_PEER_ID = String(GROUP_CHAT_ID);
+
+const baseChannels = { telegram: { dmPolicy: "open", allowFrom: ["*"] } };
+const baseMessages = { groupChat: { mentionPatterns: [] } };
+
+/** Two agents (no sole-agent promotion), no bindings, no catch-all => unmatched => drop. */
+const dropPolicyCfg = {
+  agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+  channels: baseChannels,
+  messages: baseMessages,
+};
+
+/** Same, but the drop policy is stated explicitly rather than relying on the default. */
+const explicitRejectCfg = {
+  ...dropPolicyCfg,
+  routing: { unmatched: "reject" },
+};
+
+/** Nothing matches, but the operator designated a catch-all: the route RESOLVES. */
+const catchAllCfg = {
+  agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+  routing: { unmatched: { agent: "alpha" } },
+  channels: baseChannels,
+  messages: baseMessages,
+};
+
+/** A catch-all PLUS an explicit binding of the named account's group to an agent. */
+const boundNamedAccountCfg = {
+  ...catchAllCfg,
+  bindings: [
+    {
+      agentId: "beta",
+      match: { channel: "telegram", accountId: "work", peer: { kind: "group", id: GROUP_PEER_ID } },
+    },
+  ],
+};
+
+function groupMessage() {
+  return {
+    message_id: 1,
+    chat: { id: GROUP_CHAT_ID, type: "supergroup" as const, title: "Test Group" },
+    date: 1_700_000_000,
+    text: "@bot hello",
+    from: { id: 42, first_name: "Alice" },
+  };
+}
+
+function dmMessage() {
+  return {
+    message_id: 1,
+    chat: { id: 814912386, type: "private" as const },
+    date: 1_700_000_000,
+    text: "hello",
+    from: { id: 814912386, first_name: "Alice" },
+  };
+}
+
+async function buildGroupContext(params: { cfg: unknown; accountId?: string }) {
+  return await buildTelegramMessageContextForTest({
+    cfg: params.cfg as Record<string, unknown>,
+    accountId: params.accountId,
+    message: groupMessage(),
+    options: { forceWasMentioned: true },
+    resolveGroupActivation: () => true,
+  });
+}
+
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
+});
+
+describe("#2961 scenario D — routing.unmatched drop policy on the inbound path", () => {
+  it("drops an unmatched inbound group message when no catch-all is configured", async () => {
+    const ctx = await buildGroupContext({ cfg: dropPolicyCfg });
+
+    expect(ctx).toBeNull();
+  });
+
+  it("drops an unmatched inbound DM when no catch-all is configured", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: dropPolicyCfg,
+      message: dmMessage(),
+    });
+
+    expect(ctx).toBeNull();
+  });
+
+  it("drops an unmatched inbound message under an explicit reject policy", async () => {
+    const ctx = await buildGroupContext({ cfg: explicitRejectCfg });
+
+    expect(ctx).toBeNull();
+  });
+
+  it("delivers the message once an operator configures a catch-all", async () => {
+    // Control: proves the drops above come from the policy, not from the resolver being
+    // unable to route this message at all.
+    const ctx = await buildGroupContext({ cfg: catchAllCfg });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("unmatched.catchAll");
+    expect(ctx?.route.agentId).toBe("alpha");
+  });
+});
+
+describe("#2961 scenario C — named-account group isolation", () => {
+  it("drops a named-account group message that only matched via the catch-all", async () => {
+    // DISCRIMINATING: the route resolves here (the catch-all supplies `alpha`), so the
+    // scenario-D drop does NOT apply — the message is delivered under D and dropped only
+    // by the named-account gate. The identical default-account case below is delivered.
+    const ctx = await buildGroupContext({ cfg: catchAllCfg, accountId: "work" });
+
+    expect(ctx).toBeNull();
+  });
+
+  it("delivers the same catch-all group message for the default account", async () => {
+    // Control: pins the gate to NAMED accounts only.
+    const ctx = await buildGroupContext({ cfg: catchAllCfg, accountId: "default" });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("unmatched.catchAll");
+  });
+
+  it("delivers a named-account group message that matched an explicit binding", async () => {
+    // Control: pins that the gate drops only NON-binding tiers — an operator who binds
+    // the named account's group explicitly still gets their traffic.
+    const ctx = await buildGroupContext({ cfg: boundNamedAccountCfg, accountId: "work" });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("binding.peer");
+    expect(ctx?.route.agentId).toBe("beta");
+  });
+
+  it("delivers a named-account DM that only matched via the catch-all", async () => {
+    // Control: pins the gate to GROUP traffic — #2961 scopes the isolation boundary to
+    // groups, so a named-account DM on a resolvable route is not gated.
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg: catchAllCfg,
+      accountId: "work",
+      message: dmMessage(),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.matchedBy).toBe("unmatched.catchAll");
+    expect(ctx?.route.accountId).toBe("work");
+  });
+});

--- a/extensions/telegram/src/bot-message-context.silent-ingest.test.ts
+++ b/extensions/telegram/src/bot-message-context.silent-ingest.test.ts
@@ -15,14 +15,19 @@ const internalHookMocks = vi.hoisted(() => ({
   triggerInternalHook: vi.fn(async () => undefined),
 }));
 
-vi.mock("remoteclaw/plugin-sdk/hook-runtime", () => {
+// Mock target repaired (#2961): the upstream test mocked the
+// `remoteclaw/plugin-sdk/hook-runtime` barrel, which does not exist in this fork — it is
+// a DEPRECATED plugin-sdk subpath (scripts/lib/plugin-sdk-deprecated-barrel-subpaths.json)
+// with no backing `src/plugin-sdk/hook-runtime.ts`, so the mock resolved to nothing and
+// never applied. The fork imports the hook primitives from `src/hooks/*` directly — the
+// same seam `src/auto-reply/reply/dispatch-from-config.ts` uses — so mock that instead.
+// Only the two capture points are stubbed; `fireAndForgetHook` and the real
+// `toInternalMessageReceivedContext` mapper deliberately run for real here.
+vi.mock("../../../src/hooks/internal-hooks.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/hooks/internal-hooks.js")>();
   return {
+    ...actual,
     createInternalHookEvent: internalHookMocks.createInternalHookEvent,
-    fireAndForgetHook: (task: Promise<unknown>) => void task,
-    toInternalMessageReceivedContext: (context: Record<string, unknown>) => ({
-      ...context,
-      metadata: { to: context.to },
-    }),
     triggerInternalHook: internalHookMocks.triggerInternalHook,
   };
 });
@@ -46,6 +51,9 @@ describe("telegram mention-skip silent ingest", () => {
       message: makeGroupMessage("hello without mention"),
       cfg: {
         agents: {
+          // Fail-closed routing (#2961): without a configured agent the message is
+          // dropped as unmatched before it can reach the mention-skip branch at all.
+          list: [{ id: "main" }],
           defaults: {
             model: "anthropic/sonnet-4.6",
             workspace: "/tmp/remoteclaw",
@@ -98,6 +106,9 @@ describe("telegram mention-skip silent ingest", () => {
       message: makeGroupMessage("hello without mention"),
       cfg: {
         agents: {
+          // Fail-closed routing (#2961): without a configured agent the message is
+          // dropped as unmatched before it can reach the mention-skip branch at all.
+          list: [{ id: "main" }],
           defaults: {
             model: "anthropic/sonnet-4.6",
             workspace: "/tmp/remoteclaw",

--- a/extensions/telegram/src/bot-message-context.test-harness.ts
+++ b/extensions/telegram/src/bot-message-context.test-harness.ts
@@ -1,9 +1,19 @@
 import { vi } from "vitest";
+import { setRuntimeConfigSnapshot } from "../../../src/config/config.js";
 import type { BuildTelegramMessageContextParams, TelegramMediaRef } from "./bot-message-context.js";
 import { finalizeTelegramInboundContextForTest } from "./bot-message-context.session-runtime-test-support.js";
 
 export const baseTelegramMessageContextConfig = {
-  agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" } },
+  agents: {
+    // Routing in this fork is fail-closed: there is no phantom "default" agent, so a
+    // config with no `agents.list` matches NOTHING and every inbound message is dropped
+    // by the `routing.unmatched` policy (#2961). Production configs always carry a
+    // non-empty `agents.list` (schema-enforced), so one agent is the realistic minimum
+    // for these fixtures — it exercises sole-agent promotion (`fallback.soleAgent`),
+    // which is exactly what a single-agent deployment does.
+    list: [{ id: "main" }],
+    defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/remoteclaw" },
+  },
   channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
   messages: { groupChat: { mentionPatterns: [] } },
 } as never;
@@ -25,6 +35,13 @@ export async function buildTelegramMessageContextForTest(
   Awaited<ReturnType<typeof import("./bot-message-context.js").buildTelegramMessageContext>>
 > {
   const { buildTelegramMessageContext } = await import("./bot-message-context.js");
+  const cfg = (params.cfg ?? baseTelegramMessageContextConfig) as never;
+  // Inbound routing deliberately reads a FRESH config via `loadConfig()` (bindings can
+  // change at runtime) rather than the injected `cfg`, so publish the fixture as the
+  // runtime snapshot — otherwise `loadConfig()` returns the empty config of the isolated
+  // test HOME, nothing routes, and every context is dropped as unmatched (#2961).
+  // Tests that mock `loadConfig` directly (e.g. topic-agentid) are unaffected.
+  setRuntimeConfigSnapshot(cfg);
   return await buildTelegramMessageContext({
     primaryCtx: {
       message: {
@@ -45,7 +62,7 @@ export async function buildTelegramMessageContextForTest(
         setMessageReaction: vi.fn(),
       },
     } as never,
-    cfg: (params.cfg ?? baseTelegramMessageContextConfig) as never,
+    cfg,
     account: { accountId: params.accountId ?? "default" } as never,
     historyLimit: 0,
     groupHistories: new Map(),

--- a/extensions/telegram/src/bot-message-context.thread-binding.test.ts
+++ b/extensions/telegram/src/bot-message-context.thread-binding.test.ts
@@ -9,7 +9,10 @@ const hoisted = vi.hoisted(() => {
   };
 });
 
-vi.mock("../infra/outbound/session-binding-service.js", async (importOriginal) => {
+// Mock path repaired (#2961): "../infra/outbound/session-binding-service.js" predates the
+// src/telegram/ -> extensions/telegram/src/ move and resolved to nothing, so the binding
+// service was never mocked and these cases could not exercise bound-conversation routing.
+vi.mock("../../../src/infra/outbound/session-binding-service.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../src/infra/outbound/session-binding-service.js")>();
   return {

--- a/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
+++ b/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
@@ -7,12 +7,23 @@ const { defaultRouteConfig } = vi.hoisted(() => ({
     agents: {
       list: [{ id: "alpha", default: true }, { id: "zu" }, { id: "q" }, { id: "support" }],
     },
+    // This fork has no phantom "default" agent tier, so `default: true` above does NOT
+    // make `alpha` the route for an unbound peer — with 4 agents configured, sole-agent
+    // promotion does not apply either, and the base route would be dropped as unmatched
+    // before any topic override could run. An explicit catch-all is what actually lands
+    // an unbound peer on `alpha` here, which is the precondition these topic-override
+    // cases assume (#2961).
+    routing: { unmatched: { agent: "alpha" } },
     channels: { telegram: {} },
     messages: { groupChat: { mentionPatterns: [] } },
   },
 }));
 
-vi.mock("../config/config.js", async (importOriginal) => {
+// Mock path repaired (#2961): these specifiers predate the src/telegram/ ->
+// extensions/telegram/src/ move, so "../config/config.js" pointed at a module that does
+// not exist. The mock silently never applied and `vi.mocked(loadConfig).mockReturnValue`
+// threw "mockReturnValue is not a function", failing the whole file in beforeEach.
+vi.mock("../../../src/config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../src/config/config.js")>();
   return {
     ...actual,
@@ -126,11 +137,21 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
     expect(ctx?.ctxPayload?.SessionKey).toContain("agent:alpha:");
   });
 
-  it("falls back to default agent when topic agentId does not exist", async () => {
+  // GUT-PINNED (#2961): asserts the REMOVED upstream default-agent fallback — that an
+  // unknown topic `agentId` resolves back to the agent flagged `default: true`. This fork
+  // has no default-agent concept in routing (`default: true` is inert config; the contract
+  // is pinned by test/default-agent-elimination.test.ts), and pickFirstExistingAgentId
+  // (src/routing/resolve-route.ts) deliberately SANITIZED-PASSES-THROUGH an id that is not
+  // in `agents.list` instead of falling back — it observed
+  // `agent:ghost:telegram:group:-1001234567890:topic:3`. Whether an unconfigured topic
+  // agentId should hard-fail rather than pass through is a shared-routing decision
+  // affecting every caller of that helper, not an adapter fix — out of scope here.
+  it.skip("falls back to default agent when topic agentId does not exist", async () => {
     vi.mocked(loadConfig).mockReturnValue({
       agents: {
         list: [{ id: "alpha", default: true }, { id: "zu" }],
       },
+      routing: { unmatched: { agent: "alpha" } },
       channels: { telegram: {} },
       messages: { groupChat: { mentionPatterns: [] } },
     } as never);

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "grammy";
+import { ensureConfiguredAcpRouteReady } from "../../../src/acp/persistent-bindings.route.js";
 import { resolveAckReaction } from "../../../src/agents/identity.js";
 import { hasControlCommand } from "../../../src/auto-reply/command-detection.js";
 import { normalizeCommandBody } from "../../../src/auto-reply/commands-registry.js";
@@ -29,6 +30,7 @@ import {
 } from "../../../src/channels/status-reactions.js";
 import type { RemoteClawConfig } from "../../../src/config/config.js";
 import { loadConfig } from "../../../src/config/config.js";
+import { resolveChannelGroupPolicy } from "../../../src/config/group-policy.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../src/config/sessions.js";
 import type {
   DmPolicy,
@@ -36,8 +38,14 @@ import type {
   TelegramTopicConfig,
 } from "../../../src/config/types.js";
 import { logVerbose, shouldLogVerbose } from "../../../src/globals.js";
+import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
+import {
+  toInternalMessageReceivedContext,
+  type CanonicalInboundMessageHookContext,
+} from "../../../src/hooks/message-hook-mappers.js";
 import { recordChannelActivity } from "../../../src/infra/channel-activity.js";
-import { resolveAgentRoute } from "../../../src/routing/resolve-route.js";
+import { DEFAULT_ACCOUNT_ID, type ResolvedAgentRoute } from "../../../src/routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../src/routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../src/security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -52,10 +60,8 @@ import {
   buildGroupLabel,
   buildSenderLabel,
   buildSenderName,
-  resolveTelegramDirectPeerId,
   buildTelegramGroupFrom,
   buildTelegramGroupPeerId,
-  buildTelegramParentPeer,
   buildTypingThreadParams,
   resolveTelegramMediaPlaceholder,
   expandTextLinks,
@@ -66,6 +72,7 @@ import {
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { StickerMetadata, TelegramContext } from "./bot/types.js";
+import { resolveTelegramConversationRoute } from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { evaluateTelegramGroupBaseAccess } from "./group-access.js";
@@ -129,6 +136,116 @@ export type BuildTelegramMessageContextParams = {
   sendChatActionHandler: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
 };
 
+/**
+ * #2961 scenario C — named-account group isolation (cross-account authorization).
+ *
+ * A non-default ("named") account is an explicitly configured, distinct bot identity, so
+ * per #2961 it "must have an explicit binding to handle group traffic".
+ *
+ * Upstream keyed this gate on `matchedBy === "default"` — the phantom default-agent tier
+ * this fork DELETED (see `src/routing/resolve-route.ts`: sole-agent promotion exists
+ * "without reintroducing the phantom 'default' agent fallback"). A verbatim port would be
+ * dead code that can never fire, because no fork tier is ever named "default". The
+ * fork-native equivalent is the tier CLASS: a route that did not match an explicit
+ * `binding.*` tier only landed on this agent via an operator catch-all
+ * (`unmatched.catchAll`), sole-agent promotion (`fallback.soleAgent`), or the legacy
+ * fail-open (`fallback.legacyRoute`) — none of which is an operator declaring "this named
+ * account handles this group".
+ *
+ * This gate is DISTINCT from the scenario-D drop rather than a restatement of it: D fires
+ * when the route resolves to NOTHING (the resolver returned null); C fires when the route
+ * resolves perfectly well, but on a non-binding tier. A named-account group message under
+ * a configured catch-all is delivered past D and dropped only here.
+ *
+ * DMs are deliberately not gated — the isolation boundary #2961 names is group traffic.
+ */
+function shouldDropNamedAccountGroupMessage(route: ResolvedAgentRoute): boolean {
+  const isNamedAccount = route.accountId !== DEFAULT_ACCOUNT_ID;
+  const matchedExplicitBinding = route.matchedBy.startsWith("binding.");
+  return isNamedAccount && !matchedExplicitBinding;
+}
+
+/**
+ * Resolve `ingest` for a group, honoring the `groups["*"]` wildcard default so a specific
+ * group entry that omits `ingest` inherits it instead of silently disabling ingest.
+ */
+function resolveTelegramGroupIngest(params: {
+  cfg: RemoteClawConfig;
+  chatId: number | string;
+  accountId: string;
+}): boolean {
+  const { groupConfig, defaultConfig } = resolveChannelGroupPolicy({
+    cfg: params.cfg,
+    channel: "telegram",
+    groupId: String(params.chatId),
+    accountId: params.accountId,
+  });
+  return groupConfig?.ingest ?? defaultConfig?.ingest ?? false;
+}
+
+/**
+ * #2961 scenario E — silent ingest.
+ *
+ * A non-mention group message that `requireMention` skips is still conversation context:
+ * when the group opts into `ingest`, emit the internal `message:received` event for it
+ * without dispatching to the agent. Mirrors the internal-hook bridge in
+ * `src/auto-reply/reply/dispatch-from-config.ts` (and `bot/delivery.replies.ts` for the
+ * `message:sent` side). No-ops unless the group has `ingest` enabled.
+ */
+function emitTelegramSilentIngestEvent(params: {
+  cfg: RemoteClawConfig;
+  accountId: string;
+  chatId: number | string;
+  resolvedThreadId?: number;
+  threadId?: number;
+  sessionKey: string;
+  content: string;
+  messageId?: string;
+  timestamp?: number;
+  senderId?: string;
+  senderName?: string;
+  senderUsername?: string;
+}): void {
+  if (
+    !resolveTelegramGroupIngest({
+      cfg: params.cfg,
+      chatId: params.chatId,
+      accountId: params.accountId,
+    })
+  ) {
+    return;
+  }
+  const conversationId = buildTelegramGroupFrom(params.chatId, params.resolvedThreadId);
+  const canonical: CanonicalInboundMessageHookContext = {
+    from: conversationId,
+    to: `telegram:${params.chatId}`,
+    content: params.content,
+    body: params.content,
+    timestamp: params.timestamp,
+    channelId: "telegram",
+    accountId: params.accountId,
+    conversationId,
+    messageId: params.messageId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    provider: "telegram",
+    surface: "telegram",
+    threadId: params.threadId,
+    isGroup: true,
+    groupId: String(params.chatId),
+  };
+  fireAndForgetHook(
+    triggerInternalHook(
+      createInternalHookEvent("message", "received", params.sessionKey, {
+        ...toInternalMessageReceivedContext(canonical),
+        timestamp: params.timestamp,
+      }),
+    ),
+    "telegram: message:received internal hook failed",
+  );
+}
+
 export const buildTelegramMessageContext = async ({
   primaryCtx,
   allMedia,
@@ -154,7 +271,15 @@ export const buildTelegramMessageContext = async ({
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+  // Telegram omits `chat.is_forum` on some supergroup payloads even when the message is a
+  // topic message. Fall back to the message-level `is_topic_message` flag so topic scoping
+  // — and with it the per-topic agent override (#2961 scenario A) — survives; without this
+  // every topic in such a payload collapses onto one group session. Mirrors the same
+  // fallback already used by sequential-key.ts.
+  const isForum =
+    (msg.chat as { is_forum?: boolean }).is_forum === true ||
+    (msg.chat.type === "supergroup" &&
+      (msg as { is_topic_message?: boolean }).is_topic_message === true);
   const threadSpec = resolveTelegramThreadSpec({
     isGroup,
     isForum,
@@ -163,21 +288,39 @@ export const buildTelegramMessageContext = async ({
   const resolvedThreadId = threadSpec.scope === "forum" ? threadSpec.id : undefined;
   const replyThreadId = threadSpec.id;
   const { groupConfig, topicConfig } = resolveTelegramGroupConfig(chatId, resolvedThreadId);
-  const peerId = isGroup
-    ? buildTelegramGroupPeerId(chatId, resolvedThreadId)
-    : resolveTelegramDirectPeerId({ chatId, senderId });
-  const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
+  // Route inbound through the SAME full resolver the native-command path uses
+  // (bot-native-commands.ts) rather than the bare, policy-bypassing resolveAgentRoute.
+  // That is what re-applies the per-topic agent override, configured + session bindings,
+  // and the `routing.unmatched` drop policy to ordinary inbound messages (#2961).
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
-  const route = resolveAgentRoute({
-    cfg: loadConfig(),
-    channel: "telegram",
+  const freshCfg = loadConfig();
+  const conversationRoute = resolveTelegramConversationRoute({
+    cfg: freshCfg,
     accountId: account.accountId,
-    peer: {
-      kind: isGroup ? "group" : "direct",
-      id: peerId,
-    },
-    parentPeer,
+    chatId,
+    isGroup,
+    resolvedThreadId,
+    replyThreadId,
+    senderId,
+    topicAgentId: topicConfig?.agentId,
   });
+  if (!conversationRoute) {
+    // #2961 scenario D — `routing.unmatched` drop policy: nothing matched, no sole agent,
+    // and no operator catch-all. Drop-with-telemetry already fired inside handleUnmatched().
+    // The bare resolveAgentRoute() this replaced swallowed that drop and fail-open routed
+    // the message to `fallback.legacyRoute` instead.
+    return null;
+  }
+  const route = conversationRoute.route;
+  if (isGroup && shouldDropNamedAccountGroupMessage(route)) {
+    logInboundDrop({
+      log: logVerbose,
+      channel: "telegram",
+      reason: "named-account group without an explicit binding",
+      target: buildTelegramGroupPeerId(chatId, resolvedThreadId),
+    });
+    return null;
+  }
   const baseSessionKey = route.sessionKey;
   // DMs: use raw messageThreadId for thread sessions (not forum topic ids)
   const dmThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
@@ -454,6 +597,22 @@ export const buildTelegramMessageContext = async ({
             }
           : null,
       });
+      // #2961 scenario E — the message is not dispatched, but it is still context: when
+      // the group opts into `ingest`, emit `message:received` before dropping it.
+      emitTelegramSilentIngestEvent({
+        cfg,
+        accountId: account.accountId,
+        chatId,
+        resolvedThreadId,
+        threadId: threadSpec.id,
+        sessionKey,
+        content: rawBody,
+        messageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
+        timestamp: msg.date ? msg.date * 1000 : undefined,
+        senderId: senderId || undefined,
+        senderName: buildSenderName(msg),
+        senderUsername: senderUsername || undefined,
+      });
       return null;
     }
   }
@@ -728,6 +887,30 @@ export const buildTelegramMessageContext = async ({
     OriginatingChannel: "telegram" as const,
     OriginatingTo: `telegram:${chatId}`,
   });
+
+  // The route above may have been rewritten to a configured ACP binding's targetSessionKey
+  // (`binding.channel`). Routing there is only half the contract: the bound session also has to
+  // be running, or the message lands in a session that was never started. Mirrors the discord
+  // inbound path (monitor/message-handler.preflight.ts) — drop-with-log rather than the
+  // user-facing error the native-command path sends, since an ordinary inbound message has no
+  // command to answer. No-op (`{ok:true}`) when no ACP binding is configured, so the common
+  // path pays nothing. Deliberately last: every cheaper drop above short-circuits first, and
+  // this runs before recordInboundSession() so a failed ensure writes no session state.
+  if (conversationRoute.configuredBinding) {
+    const ensured = await ensureConfiguredAcpRouteReady({
+      cfg: freshCfg,
+      configuredBinding: conversationRoute.configuredBinding,
+    });
+    if (!ensured.ok) {
+      logInboundDrop({
+        log: logVerbose,
+        channel: "telegram",
+        reason: `configured ACP binding unavailable: ${ensured.error}`,
+        target: conversationRoute.configuredBinding.spec.conversationId,
+      });
+      return null;
+    }
+  }
 
   const pinnedMainDmOwner = !isGroup
     ? resolvePinnedMainDmOwnerFromAllowlist({

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -31,11 +31,32 @@ const { loadConfig } = vi.hoisted((): { loadConfig: AnyMock } => ({
 export function getLoadConfigMock(): AnyMock {
   return loadConfig;
 }
+
+/**
+ * Backfill the schema-mandatory `agents.list` onto fixtures that omit it.
+ *
+ * Inbound routing is fail-closed since #2961: it honors the `routing.unmatched` policy
+ * instead of fail-open routing through `fallback.legacyRoute`. A fixture with no
+ * configured agent therefore matches nothing and is dropped as unmatched BEFORE the
+ * behavior these suites actually assert (envelopes, dedupe, pairing, mention gating,
+ * media-group buffering) can run. Production configs always carry a non-empty
+ * `agents.list` (schema-enforced); these fixtures simply predate that and omit it.
+ *
+ * A fixture that DOES declare `agents.list` is passed through untouched, so any suite
+ * making a real routing assertion still controls its own agents.
+ */
+function withFallbackAgentsList(cfg: RemoteClawConfig): RemoteClawConfig {
+  if (cfg?.agents?.list?.length) {
+    return cfg;
+  }
+  return { ...cfg, agents: { ...cfg?.agents, list: [{ id: "main" }] } };
+}
+
 vi.mock("../../../src/config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../src/config/config.js")>();
   return {
     ...actual,
-    loadConfig,
+    loadConfig: () => withFallbackAgentsList(loadConfig() as RemoteClawConfig),
   };
 });
 
@@ -216,6 +237,11 @@ export const getOnHandler = (event: string) => {
 
 const DEFAULT_TELEGRAM_TEST_CONFIG: RemoteClawConfig = {
   agents: {
+    // Routing is fail-closed (#2961): the inbound path now honors the `routing.unmatched`
+    // policy, so a config with no `agents.list` matches nothing and every message is
+    // dropped before these suites can observe anything. Production configs always carry a
+    // non-empty `agents.list` (schema-enforced), so one agent is the realistic minimum.
+    list: [{ id: "main" }],
     defaults: {
       envelopeTimezone: "utc",
     },

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -816,8 +816,11 @@ describe("createTelegramBot", () => {
     expect(payload.SessionKey).toBe("agent:opie:main");
   });
 
-  it("accepts non-default account DMs when dmPolicy is open (upstream no longer requires explicit bindings)", async () => {
+  it("accepts non-default account DMs when dmPolicy is open (no explicit binding required)", async () => {
     loadConfig.mockReturnValue({
+      // Declared explicitly rather than relying on the harness backfill, because this case
+      // IS a routing assertion: the DM is delivered only because a resolvable route exists.
+      agents: { list: [{ id: "main" }] },
       channels: {
         telegram: {
           accounts: {
@@ -846,8 +849,13 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    // Upstream changed: non-default accounts with dmPolicy=open now accept DMs
-    // without explicit bindings (routes via default agent fallback)
+    // A named account's DM needs no explicit binding: the route resolves via sole-agent
+    // promotion, and #2961's named-account gate is scoped to GROUP traffic, so DMs are not
+    // gated. The MECHANISM changed in #2961 though — this used to be delivered by the
+    // fail-open `fallback.legacyRoute` (the "default agent fallback" this comment used to
+    // describe). With no agent configured at all, this DM is now DROPPED instead, which is
+    // the fail-closed posture scenario D asks for; see
+    // bot-message-context.routing-policy.test.ts.
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -272,6 +272,13 @@ export type TelegramTopicConfig = {
 
 export type TelegramGroupConfig = {
   requireMention?: boolean;
+  /**
+   * When `requireMention` skips a non-mention group message, still emit an internal
+   * `message:received` event for it so the message is ingested as conversation context
+   * without being dispatched to the agent. Resolved with `groups["*"]` wildcard
+   * fallback, so a specific group entry that omits `ingest` inherits the default (#2961).
+   */
+  ingest?: boolean;
   /** Per-group override for group message policy (open|disabled|allowlist). */
   groupPolicy?: GroupPolicy;
   /** Optional tool policy overrides for this group. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -113,6 +113,11 @@ export const TelegramTopicSchema = z
 export const TelegramGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    // Emit an internal `message:received` event for non-mention group messages that
+    // `requireMention` skips (context ingestion without dispatch). The shared
+    // ChannelGroupConfig (src/config/group-policy.ts) already carried this field, but
+    // this strict schema rejected it, so it was unreachable config surface (#2961).
+    ingest: z.boolean().optional(),
     disableAudioPreflight: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional(),
     tools: ToolPolicySchema,

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -154,12 +154,25 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   // - dispatch.preview-fallback: obsolete premise — dispatch.ts finalizes previews via inline
   //   chat.update now, not finalizeSlackPreviewEdit (which is dead code); the test needs a rewrite.
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
+  // #2961 (telegram): 5 bot-message-context files un-quarantined via a SOURCE fix —
+  // the inbound path now routes through resolveTelegramConversationRoute (the same full
+  // resolver the native-command path uses) instead of the bare, policy-bypassing
+  // resolveAgentRoute, so topic-agent override (A), session bindings (B), the
+  // routing.unmatched drop policy (D) and the named-account group gate (C) apply to
+  // ordinary inbound messages, and the mention-skip branch fires the ingest hook (E).
+  // Each file ALSO needed its upstream mock paths repaired: they predate the
+  // src/telegram/ -> extensions/telegram/src/ move, so `vi.mock("../config/config.js")`
+  // & co. silently targeted non-existent modules and the mocks never applied.
+  // The 5 below stay, each out of #2961's scope. dm-threads specifically: its 2 remaining
+  // fails are session-key/route-echo SHAPE divergences, not routing-resolution bugs, and
+  // each needs its own source change — (a) `uses thread session key for dm topics` wants the
+  // DM thread key to embed the chat id (`agent:main:main:thread:1234:42`) but the fork
+  // derives it from the thread id alone (`:thread:42`, resolveThreadSessionKeys); (b) `uses
+  // topic session for forum groups` wants OriginatingTo to carry the topic suffix
+  // (`telegram:<chat>:topic:99`) but bot-message-context.ts emits a bare `telegram:<chat>`.
+  // Both have live outbound consumers, so they are a separate, reply-routing-reviewed PR.
   "extensions/telegram/src/bot-message-context.dm-threads.test.ts",
   "extensions/telegram/src/bot-message-context.group-body.test.ts",
-  "extensions/telegram/src/bot-message-context.named-account-dm.test.ts",
-  "extensions/telegram/src/bot-message-context.silent-ingest.test.ts",
-  "extensions/telegram/src/bot-message-context.thread-binding.test.ts",
-  "extensions/telegram/src/bot-message-context.topic-agentid.test.ts",
   "extensions/telegram/src/bot-message-dispatch.test.ts",
   "extensions/telegram/src/format.wrap-md.test.ts",
   "extensions/telegram/src/sequential-key.test.ts",


### PR DESCRIPTION
## Summary

Closes #2961.

Inbound Telegram messages resolved their agent route with the bare
`resolveAgentRoute()`. That function applies the `routing.unmatched` drop policy
and then **swallows** a drop verdict, fail-open routing to the first configured
agent (`matchedBy: "fallback.legacyRoute"`, plus a migration warning). Two
consequences on the inbound path:

- **Unmatched inbound** (no binding, no sole agent, no operator catch-all) was
  delivered to `agents[0]` instead of being dropped — the `routing.unmatched`
  policy was effectively ignored for ordinary messages.
- **Named-account group traffic** that matched only on a non-binding tier was
  delivered under the same fail-open fallback, leaking across the account
  isolation boundary the issue is about.

The native-command path already routed through `resolveTelegramConversationRoute`
(policy-aware, `null` ⇒ drop). This PR routes ordinary inbound through the **same**
resolver and consumes its full result.

## What changed (`extensions/telegram/src/bot-message-context.ts`)

The bare `resolveAgentRoute()` call is replaced with:

```ts
const conversationRoute = resolveTelegramConversationRoute({
  cfg: freshCfg, accountId, chatId, isGroup,
  resolvedThreadId, replyThreadId, senderId,
  topicAgentId: topicConfig?.agentId,
});
if (!conversationRoute) return null;               // (D) unmatched → drop
const route = conversationRoute.route;
if (isGroup && shouldDropNamedAccountGroupMessage(route)) return null;  // (C) isolation gate
// … build context …
if (conversationRoute.configuredBinding) {         // ACP readiness, drop-with-log on failure
  const ensured = await ensureConfiguredAcpRouteReady({ cfg: freshCfg, configuredBinding });
  if (!ensured.ok) return null;
}
```

Restored behaviors:

- **A — per-topic agent override** and **B — configured + session bindings** are
  re-applied inside `resolveTelegramConversationRoute` (topic override, then
  `resolveConfiguredAcpRoute`, then the session-binding thread lookup).
- **C — named-account group isolation gate.** `shouldDropNamedAccountGroupMessage`
  drops a **named-account GROUP** message whose route matched on a
  **non-`binding.*` tier**. This is the fork-native translation of upstream's
  `matchedBy === "default"` check (dead in this fork — see DROP posture below).
- **D — `routing.unmatched` drop policy honored.** `null` route ⇒ `return null`
  instead of the swallowed fail-open fallback.
- **ACP readiness.** When the route was rewritten to a configured ACP binding's
  `targetSessionKey` (`binding.channel`), the bound session is ensured live
  before delivery — routing there is only half the contract. Mirrors the Discord
  inbound path (`monitor/message-handler.preflight.ts`): drop-with-log, not the
  user-facing error the command path sends (an inbound message has no command to
  answer). No-op when no ACP binding is configured, so the common path pays
  nothing, and it runs last so no cheaper-droppable message ever ensures a session.
- **E — silent ingest.** The `message:received` internal hook now fires on the
  mention-skip branch when require-mention + group ingest are enabled (mirrors
  `bot/delivery.replies.ts`). This required adding the `ingest` group-config
  surface — `TelegramGroupConfig.ingest` (`src/config/types.telegram.ts`) plus
  `TelegramGroupSchema.ingest` (`src/config/zod-schema.providers-core.ts`, which is
  `.strict()`); without the schema key an operator literally could not enable it,
  so the hook wiring alone would be dead code.

## C is discriminating, not a C↔D collapse

The two drops are distinct and pinned separately:

- **D** fires when the resolver returns `null` (unmatched + no catch-all + no
  sole agent).
- **C** fires when the route resolves **fine**, on a non-`binding.*` tier, for a
  named-account **group**.

The scenario-C regression fixtures configure a **catch-all**
(`routing.unmatched.agent`), so the route is **non-null** (`unmatched.catchAll`)
— D cannot account for the drop; only the C gate can. Controls pin the gate to
named accounts only, to groups only, and to non-binding tiers only (an explicit
`binding.peer` for the named account still delivers).

## DROP posture (fork-consistent, fail-closed) — please read

This fork **deleted** the upstream phantom "default" agent tier
(`src/routing/resolve-route.ts:861-875`: *"preserves single-agent behavior
without reintroducing the phantom 'default' agent fallback"*). `MatchedByTier`
has no `"default"` member. Two consequences:

1. Upstream keys behavior-C's drop on `matchedBy === "default"`. That tier does
   not exist here, so a verbatim port is dead code — hence the fork-native
   non-`binding.*` translation above.
2. Upstream's `named-account-dm` DM cases assert that an **unbound named-account
   DM passes through** (`matchedBy: "default"`, per-account key). With the
   phantom tier gone and inbound now honoring the drop policy, **an unbound
   named-account DM is dropped fail-closed.** This is the deliberate,
   security-preferred posture for a cross-account isolation fix.

Accordingly, the upstream per-account DM pass-through cases in
`bot-message-context.named-account-dm.test.ts` are **gut-pinned**
(`describe.skip`, with a rationale citing the removed tier, `MatchedByTier`,
`test/default-agent-elimination.test.ts`, and the `dmScope:"main"` session-key
collapse). The **fork-valid** case *"still drops named-account group messages
without an explicit binding"* is **kept and un-quarantined** (it drops via the
same fail-closed path).

## Tests

- **Mock-path repairs.** Several suites still mocked the pre-move `src/telegram/`
  paths (`vi.mock("../config/config.js")` etc.), so `loadConfig` was never
  actually mocked. Repaired to `extensions/telegram/src/` relative paths.
- **Un-quarantined** from `vitest.quarantine.ts`: `topic-agentid` (A),
  `thread-binding` (B), `named-account-dm` (C/DROP), `silent-ingest` (E).
  `dm-threads` stays quarantined (2 pre-existing, out-of-scope failures — noted
  inline).
- **New** `bot-message-context.routing-policy.test.ts` — scenario-D drop cases
  (group / DM / explicit reject) + the discriminating scenario-C cases with
  catch-all controls.
- **Test-harness backfill.** Fail-closed routing means fixtures without an
  `agents.list` now drop. Rather than bury the security change under ~30
  mechanical fixture edits, a single documented harness wrapper backfills a
  sole `{ id: "main" }` agent for fixtures that don't declare one; fixtures that
  do are untouched.

## Verification

```
pnpm tsgo                                  → exit 0
pnpm check (format + lint + fork gates)    → exit 0  (0 warnings, 0 errors)
telegram lane (vitest.extensions.config)   → 58 files, 645 passed | 6 skipped
```

**Necropsy** — reverting **only** `bot-message-context.ts` to pristine HEAD (all
test + config changes kept) makes the regression tests **RED**:

```
Tests  6 failed | 6 passed | 5 skipped
  × scenario D — drops an unmatched inbound group message when no catch-all
  × scenario D — drops an unmatched inbound DM when no catch-all
  × scenario D — drops an unmatched inbound message under an explicit reject policy
  × scenario C — drops a named-account group message that only matched via the catch-all
  × named-account — drops an unbound named-account DM when nothing matches (fail-closed)
  × named-account — still drops named-account group messages without an explicit binding
  (all: AssertionError: expected { ctxPayload: {…} } to be null)
```

The 6 that stay green are the `delivers…` controls (correctly non-discriminating).
Restoring the fix returns the file byte-identical and the suites to green.

> `test-ui-smoke` is an unrelated browser-mode flake and is not affected by this
> change.
