### PR TITLE
test(telegram): correct un-quarantine ledger count and relabel a scenario-D drop test (#3002)

### DIFF
--- a/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
+++ b/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
@@ -74,7 +74,15 @@ describe("buildTelegramMessageContext named-account routing", () => {
     expect(ctx).toBeNull();
   });
 
-  it("still drops named-account group messages without an explicit binding", async () => {
+  // Scenario D (unmatched), NOT the scenario-C named-account gate — the group analog of the
+  // DM case above. `unmatchedCfg` has no `agents.list`, so the route resolves to NOTHING and
+  // bot-message-context.ts drops it as unmatched (returns null on `!conversationRoute`) BEFORE
+  // shouldDropNamedAccountGroupMessage (the C gate) is ever reached. This case would still pass
+  // if the C gate were deleted, so it is NOT discriminating C coverage. The genuine C control —
+  // a NON-null catch-all route dropped ONLY by the gate — lives in
+  // bot-message-context.routing-policy.test.ts ("drops a named-account group message that only
+  // matched via the catch-all").
+  it("drops an unbound named-account group message when nothing matches (fail-closed)", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       cfg: unmatchedCfg,
       accountId: "atlas",

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -156,13 +156,16 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   // - dispatch.preview-fallback: obsolete premise — dispatch.ts finalizes previews via inline
   //   chat.update now, not finalizeSlackPreviewEdit (which is dead code); the test needs a rewrite.
   "extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts",
-  // #2961 (telegram): 5 bot-message-context files un-quarantined via a SOURCE fix —
+  // #2961 (telegram): 4 bot-message-context files un-quarantined via a SOURCE fix
+  // (named-account-dm, silent-ingest, thread-binding, topic-agentid), plus 1 net-new
+  // routing-policy test (bot-message-context.routing-policy.test.ts) added in the same PR —
+  // never quarantined, so not one of the 4 "un-quarantined". The fix:
   // the inbound path now routes through resolveTelegramConversationRoute (the same full
   // resolver the native-command path uses) instead of the bare, policy-bypassing
   // resolveAgentRoute, so topic-agent override (A), session bindings (B), the
   // routing.unmatched drop policy (D) and the named-account group gate (C) apply to
   // ordinary inbound messages, and the mention-skip branch fires the ingest hook (E).
-  // Each file ALSO needed its upstream mock paths repaired: they predate the
+  // Each of those 4 ALSO needed its upstream mock paths repaired: they predate the
   // src/telegram/ -> extensions/telegram/src/ move, so `vi.mock("../config/config.js")`
   // & co. silently targeted non-existent modules and the mocks never applied.
   // The 5 below stay, each out of #2961's scope. dm-threads specifically: its 2 remaining


### PR DESCRIPTION
## Summary

Two cosmetic doc/test-label inaccuracies landed with the #2961 fix (merged as #3000, the
current HEAD `01074adc84`). Both are pure documentation / test-label hygiene — **no
product-source behavior change, no test assertion or fixture change.** Each premise was
re-verified against the current default branch before editing.

### 1 — Quarantine-ledger over-counted the un-quarantined files

`vitest.quarantine.ts` said *"5 bot-message-context files un-quarantined via a SOURCE fix."*
The #3000 diff actually removed **4** files from the quarantine list (`named-account-dm`,
`silent-ingest`, `thread-binding`, `topic-agentid`); the 5th now-running file,
`bot-message-context.routing-policy.test.ts`, is **net-new** in the same PR and was never
quarantined — so it was not "un-quarantined."

- Corrected the count to *"4 … un-quarantined, plus 1 net-new routing-policy test."*
- Scoped the downstream *"Each file … needed its upstream mock paths repaired"* note to
  *"Each of those 4"* — the net-new test never had stale mock paths, so it is excluded.

### 2 — A kept test was labeled like the isolation control but exercises a different drop path

The case `"still drops named-account group messages without an explicit binding"` (in
`bot-message-context.named-account-dm.test.ts`) read as exercising the scenario-**C**
named-account gate (`shouldDropNamedAccountGroupMessage`). But its `unmatchedCfg` has no
`agents.list`, so the route resolves to **null** and the message is dropped as scenario-**D**
(unmatched) at the earlier `if (!conversationRoute) return null` guard in
`bot-message-context.ts` — *before* the C gate at the following `isGroup && …` line is ever
reached. The case would still pass even if the C gate were deleted.

- Relabeled the test as the scenario-D (unmatched) drop, parallel to its DM sibling
  (`"drops an unbound named-account DM when nothing matches (fail-closed)"`).
- Added an explanatory comment and cross-referenced the genuine discriminating C control —
  `"drops a named-account group message that only matched via the catch-all"` in
  `bot-message-context.routing-policy.test.ts`, which resolves a **non-null** catch-all route
  so only the C gate can account for the drop.

**Latent risk addressed:** if `routing-policy.test.ts` were ever removed, real C-gate coverage
would be lost and the `named-account-dm` case would not catch it (it passes on the D path
regardless). The new comment makes that dependency explicit.

## Verification

- Relabeled test still passes: **4 passed | 5 skipped** (only the title string + comments
  changed; config, message fixture, and `expect(ctx).toBeNull()` are byte-identical).
- `oxfmt` produces no changes; diff is **2 files, +14 / −3** — comment lines plus one
  `it(...)` title only. No production `src/`/`extensions/*/src/*.ts` source touched.

**Severity: LOW** (test / doc hygiene). Surfaced by the independent security review of #3000
as a non-blocking advisory.

Closes #3002.
