### PR TITLE
fix(imessage): stop leaking the [[rc:reply:<id>]] tag into outbound text (#2990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@
   OpenClaw #78864, dropped by a content-only sync when this fork's resolver had
   structurally diverged.
 
+### Fixed
+
+- **iMessage — stop leaking the `[[rc:reply:<id>]]` reply tag into delivered text
+  ([remoteclaw#2990](https://github.com/remoteclaw/remoteclaw/issues/2990)):**
+  The legacy `imsg` outbound path re-encoded reply threading as an inline
+  `[[rc:reply:<id>]]` tag prepended to the message body. Because `imsg`
+  (`steipete/tap/imsg`) delivers text verbatim and has no knowledge of this
+  RemoteClaw-internal directive, reply-to sends shipped the literal tag to the
+  human recipient (for example `[[rc:reply:123]] Sure, that works`). Reply
+  threading now travels via a structured `reply_to` RPC field, and any inline
+  directive tags (`[[rc:reply:...]]`, `[[audio_as_voice]]`) are stripped from the
+  user-visible body before delivery. Ports upstream OpenClaw #39512 (thanks
+  @mvanhorn), which had not reached this fork. BlueBubbles was unaffected — it
+  already threads via a structured `selectedMessageGuid`.
+
 ## 0.1.0
 
 First RemoteClaw release. Forked from [OpenClaw v2026.2.25](https://github.com/openclaw/openclaw/releases/tag/v2026.2.25)

--- a/extensions/imessage/src/send.reply-tag.test.ts
+++ b/extensions/imessage/src/send.reply-tag.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import type { loadConfig } from "../../../src/config/config.js";
+import type { ResolvedIMessageAccount } from "./accounts.js";
+import type { IMessageRpcClient } from "./client.js";
+import { sendMessageIMessage } from "./send.js";
+
+const cfg = {
+  channels: { imessage: { enabled: true } },
+} as unknown as ReturnType<typeof loadConfig>;
+
+const account: ResolvedIMessageAccount = {
+  accountId: "default",
+  enabled: true,
+  config: {},
+  configured: true,
+};
+
+function createFakeClient() {
+  const request = vi.fn(
+    async (_method: string, _params?: Record<string, unknown>, _opts?: unknown) => ({
+      message_id: "imsg-1",
+    }),
+  );
+  const client = { request, stop: vi.fn(async () => {}) } as unknown as IMessageRpcClient;
+  return { client, request };
+}
+
+function lastSendParams(request: ReturnType<typeof createFakeClient>["request"]) {
+  const call = request.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("send was not called");
+  }
+  expect(call[0]).toBe("send");
+  return (call[1] ?? {}) as Record<string, unknown>;
+}
+
+// Regression coverage for #2990 (ports openclaw#39512): the legacy `imsg` bridge
+// delivers text verbatim and does not interpret RemoteClaw's inline directive
+// tags, so reply threading must ride the structured `reply_to` RPC field and the
+// user-visible body must never contain a `[[rc:reply:...]]` (or other directive)
+// tag.
+describe("sendMessageIMessage reply threading", () => {
+  it("passes replyToId as a structured reply_to param instead of embedding it in text", async () => {
+    const { client, request } = createFakeClient();
+
+    await sendMessageIMessage("+15551234567", "hello world", {
+      client,
+      config: cfg,
+      account,
+      replyToId: "abc-123",
+    });
+
+    const params = lastSendParams(request);
+    expect(params.text).toBe("hello world");
+    expect(params.reply_to).toBe("abc-123");
+  });
+
+  it("strips an inline [[rc:reply:...]] tag from text and still threads via reply_to", async () => {
+    const { client, request } = createFakeClient();
+
+    await sendMessageIMessage("+15551234567", "[[rc:reply:old]] hello", {
+      client,
+      config: cfg,
+      account,
+      replyToId: "new-id",
+    });
+
+    const params = lastSendParams(request);
+    expect(params.text).toBe("hello");
+    expect(params.reply_to).toBe("new-id");
+  });
+
+  it("sanitizes replyToId before passing it as the reply_to param", async () => {
+    const { client, request } = createFakeClient();
+
+    await sendMessageIMessage("+15551234567", "hello", {
+      client,
+      config: cfg,
+      account,
+      replyToId: " [ab]\n\u0000c\td ] ",
+    });
+
+    const params = lastSendParams(request);
+    expect(params.text).toBe("hello");
+    expect(params.reply_to).toBe("abcd");
+  });
+
+  it("omits reply_to when the sanitized replyToId is empty", async () => {
+    const { client, request } = createFakeClient();
+
+    await sendMessageIMessage("+15551234567", "hello", {
+      client,
+      config: cfg,
+      account,
+      replyToId: "[]\n\t",
+    });
+
+    const params = lastSendParams(request);
+    expect(params.text).toBe("hello");
+    expect(params.reply_to).toBeUndefined();
+  });
+
+  it("strips a stray [[rc:reply:...]] tag even when no replyToId option is given", async () => {
+    const { client, request } = createFakeClient();
+
+    await sendMessageIMessage("+15551234567", "[[rc:reply:65]] Great question", {
+      client,
+      config: cfg,
+      account,
+    });
+
+    const params = lastSendParams(request);
+    expect(params.text).toBe("Great question");
+    expect(params.reply_to).toBeUndefined();
+  });
+
+  it("strips a [[audio_as_voice]] tag from outbound text", async () => {
+    const { client, request } = createFakeClient();
+
+    await sendMessageIMessage("+15551234567", "hello [[audio_as_voice]] world", {
+      client,
+      config: cfg,
+      account,
+    });
+
+    const params = lastSendParams(request);
+    expect(params.text).toBe("hello world");
+  });
+
+  it("throws when the text is only directive tags and there is no media", async () => {
+    const { client } = createFakeClient();
+
+    await expect(
+      sendMessageIMessage("+15551234567", "[[rc:reply:65]]", {
+        client,
+        config: cfg,
+        account,
+      }),
+    ).rejects.toThrow("iMessage send requires text or media");
+  });
+});

--- a/extensions/imessage/src/send.sent-text.test.ts
+++ b/extensions/imessage/src/send.sent-text.test.ts
@@ -23,17 +23,19 @@ function createFakeClient() {
 }
 
 describe("sendMessageIMessage sent text", () => {
-  it("returns the text handed to the bridge, not the caller's input", async () => {
+  it("returns the stripped body handed to the bridge, not the caller's input", async () => {
     const { client, request } = createFakeClient();
 
-    const sent = await sendMessageIMessage("+15551234567", "hello", {
+    // A stray inline reply tag never reaches the human: the bridge receives the
+    // stripped body, and sentText reports that same delivered body so the echo
+    // cache can match the platform's self-echo.
+    const sent = await sendMessageIMessage("+15551234567", "[[rc:reply:abc]] hello", {
       client,
       config: cfg,
       account,
-      replyToId: "abc",
     });
 
-    expect(sent.sentText).toBe("[[rc:reply:abc]] hello");
+    expect(sent.sentText).toBe("hello");
     // The invariant that makes body matching possible: sentText is exactly the
     // body the bridge was asked to send, so it is what the platform echoes back.
     expect(request).toHaveBeenCalledWith(
@@ -62,24 +64,27 @@ describe("sendMessageIMessage sent text", () => {
     );
   });
 
-  it("lets the echo cache match a self-echo by body", async () => {
+  it("lets the echo cache match a self-echo by the delivered body", async () => {
     const { client } = createFakeClient();
     const scope = "default:+15551234567";
 
+    // Reply threading now travels out-of-band via the structured reply_to param,
+    // so the delivered body is the plain text — that is what the platform echoes.
     const sent = await sendMessageIMessage("+15551234567", "hello", {
       client,
       config: cfg,
       account,
       replyToId: "abc",
     });
+    expect(sent.sentText).toBe("hello");
 
     const cache = createSentMessageCache();
     cache.remember(scope, { text: sent.sentText, messageId: sent.messageId });
 
-    // An echo carrying only the body (no matching outbound id) is still suppressed.
-    expect(cache.has(scope, { text: "[[rc:reply:abc]] hello" })).toBe(true);
-    // Regression guard for #2971: remembering the caller's pre-transform text
-    // would never match the echoed body.
-    expect(cache.has(scope, { text: "hello" })).toBe(false);
+    // An echo carrying only the delivered body is suppressed.
+    expect(cache.has(scope, { text: "hello" })).toBe(true);
+    // Regression guard for #2990: the inline tag is never delivered, so the
+    // platform never echoes the tagged form — remembering it would never match.
+    expect(cache.has(scope, { text: "[[rc:reply:abc]] hello" })).toBe(false);
   });
 });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -3,6 +3,7 @@ import { resolveMarkdownTableMode } from "../../../src/config/markdown-tables.js
 import { convertMarkdownTables } from "../../../src/markdown/tables.js";
 import { kindFromMime } from "../../../src/media/mime.js";
 import { resolveOutboundAttachmentFromUrl } from "../../../src/media/outbound-attachment.js";
+import { stripInlineDirectiveTagsForDelivery } from "../../../src/utils/directive-tags.js";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { formatIMessageChatTarget, type IMessageService, parseIMessageTarget } from "./targets.js";
@@ -41,7 +42,6 @@ type IMessageSendResult = {
   sentText: string;
 };
 
-const LEADING_REPLY_TAG_RE = /^\s*\[\[\s*rc:reply\s*:\s*([^\]\n]+)\s*\]\]\s*/i;
 const MAX_REPLY_TO_ID_LENGTH = 256;
 
 function stripUnsafeReplyTagChars(value: string): string {
@@ -69,21 +69,6 @@ function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
     return sanitized.slice(0, MAX_REPLY_TO_ID_LENGTH);
   }
   return sanitized;
-}
-
-function prependReplyTagIfNeeded(message: string, replyToId?: string): string {
-  const resolvedReplyToId = sanitizeReplyToId(replyToId);
-  if (!resolvedReplyToId) {
-    return message;
-  }
-  const replyTag = `[[rc:reply:${resolvedReplyToId}]]`;
-  const existingLeadingTag = message.match(LEADING_REPLY_TAG_RE);
-  if (existingLeadingTag) {
-    const remainder = message.slice(existingLeadingTag[0].length).trimStart();
-    return remainder ? `${replyTag} ${remainder}` : replyTag;
-  }
-  const trimmedMessage = message.trimStart();
-  return trimmedMessage ? `${replyTag} ${trimmedMessage}` : replyTag;
 }
 
 function resolveMessageId(result: Record<string, unknown> | null | undefined): string | null {
@@ -154,13 +139,26 @@ export async function sendMessageIMessage(
     });
     message = convertMarkdownTables(message, tableMode);
   }
-  message = prependReplyTagIfNeeded(message, opts.replyToId);
+  // Strip inline directive tags ([[rc:reply:...]], [[audio_as_voice]]) from the
+  // user-visible body before handing it to the bridge. The legacy `imsg` CLI
+  // delivers text verbatim and has no knowledge of these RemoteClaw-internal
+  // tags, so any that reach here would ship literally to the human recipient.
+  // Reply threading is conveyed via the structured `reply_to` RPC field, not an
+  // inline tag. (#2990; ports openclaw#39512)
+  message = stripInlineDirectiveTagsForDelivery(message).text;
+  if (!message.trim() && !filePath) {
+    throw new Error("iMessage send requires text or media");
+  }
+  const resolvedReplyToId = sanitizeReplyToId(opts.replyToId);
 
   const params: Record<string, unknown> = {
     text: message,
     service: service || "auto",
     region,
   };
+  if (resolvedReplyToId) {
+    params.reply_to = resolvedReplyToId;
+  }
   if (filePath) {
     params.file = filePath;
   }


### PR DESCRIPTION
## Verification finding: the tag **leaks** (fix included)

Issue #2990 asked whether the legacy iMessage (`imsg`) bridge strips the inline
`[[rc:reply:<id>]]` reply-encoding tag before a human recipient sees it. Grounded
against live fork source, the answer is **no — it leaks**, confirmed three ways:

1. **Authoritative upstream fix.** OpenClaw `e0972db` (PR #39512, "stop leaking
   reply tags in iMessage outbound text", thanks @mvanhorn) is the canonical fix.
   It is **not** in this fork's history (the fork branched at ~v2026.3.7, applied
   the `rc:reply` namespace rename, and never picked up the v2026.3.28 fix). This
   PR ports it.
2. **`imsg` is a third-party CLI** (`brew install steipete/tap/imsg`, documented as
   legacy). It delivers text verbatim and has no knowledge of RemoteClaw's internal
   `[[rc:reply:...]]` vocabulary (defined in this repo's own `src/utils/directive-tags.ts`
   + `src/middleware/system-prompt.ts`). Its `send` RPC carried no reply field.
3. **The fork's own echo-cache** (`send.sent-text.test.ts`, #2971) remembered the
   *literal* `[[rc:reply:abc]] hello` body because "it is what the platform echoes
   back" — an empirical fork-side observation that the delivered message contained
   the literal tag.

### Mechanism (before)

`extensions/imessage/src/send.ts` re-encoded the structured `replyToId` back into
the user-visible body via `prependReplyTagIfNeeded`, then handed
`[[rc:reply:<id>]] <text>` to `imsg send` as the outbound `text`. A reply-to send
therefore delivered e.g. `[[rc:reply:123]] Sure, that works` literally to the human.
Reachable on the live path: auto-reply parses the agent's `[[rc:reply]]` → strips it
+ extracts `replyToId` → the outbound adapter / monitor `deliverReplies` pass
`replyToId` → `sendMessageIMessage` re-adds the tag.

## Fix

- Remove `prependReplyTagIfNeeded`. Strip inline directive tags
  (`[[rc:reply:...]]`, `[[audio_as_voice]]`) from the user-visible body via the
  fork's existing `stripInlineDirectiveTagsForDelivery`.
- Pass the reply target through a **structured `reply_to` RPC field** instead of an
  inline tag (mirrors how BlueBubbles already threads via `selectedMessageGuid`, and
  what upstream #39512 does — `imsg`'s `send` honors `reply_to`).
- Re-check for empty text after stripping so a tag-only body with no media throws
  `iMessage send requires text or media`.

The fork already carried `stripInlineDirectiveTagsForDelivery` + its unit tests +
the plugin-sdk export — only the `send.ts` change and its send-level tests were
missing (a half-ported state).

BlueBubbles was unaffected (structured `selectedMessageGuid`).

## Tests

- **New** `extensions/imessage/src/send.reply-tag.test.ts` (7 discriminating tests):
  `reply_to` is a structured param not embedded in text; inline tags are stripped;
  `replyToId` sanitization; `reply_to` omitted when empty; stray-tag stripping without
  a `replyToId`; `[[audio_as_voice]]` stripping; throws on tag-only text.
- **Updated** `send.sent-text.test.ts` — the echo-cache `sentText` invariant now
  asserts the post-strip delivered body (which is what the platform echoes).
- Runs in the required `test-extensions` CI lane.

Verified locally: full iMessage extension suite (19 files / 133 tests) ✓,
`directive-tags` unit (27) ✓, `pnpm check` (format + tsgo + lint + fork gates) ✓,
rebrand / zombie-import gates ✓.

Closes #2990.
