### PR TITLE
fix(zalouser): gate group-policy name matching on dangerouslyAllowNameMatching (#2976)

### DIFF
--- a/extensions/zalouser/src/channel.test.ts
+++ b/extensions/zalouser/src/channel.test.ts
@@ -42,6 +42,59 @@ function resolveGroupToolPolicy(
   });
 }
 
+// Resolves the tool policy with a group id and a DISTINCT, attacker-mutable display name
+// (groupChannel), optionally opting into the spoofable name-matching behavior. Used by the
+// #2976 spoofable-name necropsy specs below.
+function resolveGroupToolPolicyWithName(params: {
+  groups: Record<string, { tools?: { allow?: string[]; deny?: string[] } }>;
+  groupId: string;
+  groupChannel: string;
+  dangerouslyAllowNameMatching?: boolean;
+}) {
+  return getResolveToolPolicy()({
+    cfg: {
+      channels: {
+        zalouser: {
+          ...(params.dangerouslyAllowNameMatching ? { dangerouslyAllowNameMatching: true } : {}),
+          groups: params.groups,
+        },
+      },
+    },
+    accountId: "default",
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+  });
+}
+
+// Same spoofable-name setup as resolveGroupToolPolicyWithName, but for the requireMention consumer
+// of the shared resolveZalouserGroupPolicyEntry — mention-gating is the second privilege surface a
+// spoofed name could inherit (a trusted entry's requireMention:false). Used by the #2976 specs.
+function resolveRequireMentionWithName(params: {
+  groups: Record<string, { requireMention?: boolean }>;
+  groupId: string;
+  groupChannel: string;
+  dangerouslyAllowNameMatching?: boolean;
+}) {
+  const resolveRequireMention = zalouserPlugin.groups?.resolveRequireMention;
+  expect(resolveRequireMention).toBeTypeOf("function");
+  if (!resolveRequireMention) {
+    throw new Error("resolveRequireMention unavailable");
+  }
+  return resolveRequireMention({
+    cfg: {
+      channels: {
+        zalouser: {
+          ...(params.dangerouslyAllowNameMatching ? { dangerouslyAllowNameMatching: true } : {}),
+          groups: params.groups,
+        },
+      },
+    },
+    accountId: "default",
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+  });
+}
+
 describe("zalouser outbound", () => {
   beforeEach(() => {
     mockSendMessage.mockClear();
@@ -162,5 +215,80 @@ describe("zalouser channel policies", () => {
       remove: false,
     });
     expect(result).toBeDefined();
+  });
+});
+
+// Necropsy regression specs for #2976 (post-admission tool-policy inheritance via a spoofable
+// group name). resolveZalouserGroupPolicyEntry resolved the policy entry with the group's mutable
+// display name (groupChannel) as an unconditional match candidate — unlike the inbound-admission
+// path (monitor.ts), which was hardened by #2953 to gate name matching on
+// dangerouslyAllowNameMatching. The helper buildZalouserGroupCandidates already honored
+// allowNameMatching:false (green in group-policy.test.ts throughout the vulnerable window); the
+// defect was the caller wiring in channel.ts, so these specs exercise the plugin's
+// resolveToolPolicy consumer rather than the helper.
+describe("zalouser group tool policy — spoofable-name gating (#2976)", () => {
+  it("does NOT inherit a trusted entry's tools when a spoofable group name impersonates it", () => {
+    // Attacker's real (non-allowlisted) group id, whose mutable display name has been set to
+    // impersonate the allowlisted "Trusted Team" entry. Pre-fix, "Trusted Team" was a match
+    // candidate and the attacker inherited system.run; post-fix (name matching off by default),
+    // only the stable id / wildcard resolve, so nothing matches.
+    const policy = resolveGroupToolPolicyWithName({
+      groups: { "Trusted Team": { tools: { allow: ["system.run"] } } },
+      groupId: "g-attacker-001",
+      groupChannel: "Trusted Team",
+    });
+    expect(policy).toBeUndefined();
+  });
+
+  it("still resolves by group name when dangerouslyAllowNameMatching is explicitly enabled", () => {
+    // The break-glass opt-in is unchanged: an operator who accepts mutable-name matching still
+    // gets it. Guards against over-correcting the fix into "names never match".
+    const policy = resolveGroupToolPolicyWithName({
+      groups: { "Trusted Team": { tools: { allow: ["system.run"] } } },
+      groupId: "g-attacker-001",
+      groupChannel: "Trusted Team",
+      dangerouslyAllowNameMatching: true,
+    });
+    expect(policy).toEqual({ allow: ["system.run"] });
+  });
+
+  it("still resolves by stable group id with name matching disabled (no regression)", () => {
+    const policy = resolveGroupToolPolicyWithName({
+      groups: { "g-real-001": { tools: { allow: ["search"] } } },
+      groupId: "g-real-001",
+      groupChannel: "Some Display Name",
+    });
+    expect(policy).toEqual({ allow: ["search"] });
+  });
+
+  it("still resolves the wildcard group policy with name matching disabled (no regression)", () => {
+    const policy = resolveGroupToolPolicyWithName({
+      groups: { "*": { tools: { deny: ["system.run"] } } },
+      groupId: "g-attacker-001",
+      groupChannel: "Trusted Team",
+    });
+    expect(policy).toEqual({ deny: ["system.run"] });
+  });
+
+  it("does NOT inherit a trusted entry's requireMention via a spoofable group name (fail-closed)", () => {
+    // requireMention is the second surface reached through the same resolver: pre-fix the spoofed
+    // name matched "Trusted Team" and inherited requireMention:false (bot replies without a
+    // mention); post-fix the name is not a candidate, so it falls back to the fail-closed default.
+    const requireMention = resolveRequireMentionWithName({
+      groups: { "Trusted Team": { requireMention: false } },
+      groupId: "g-attacker-001",
+      groupChannel: "Trusted Team",
+    });
+    expect(requireMention).toBe(true);
+  });
+
+  it("still honors requireMention by group name when dangerouslyAllowNameMatching is enabled", () => {
+    const requireMention = resolveRequireMentionWithName({
+      groups: { "Trusted Team": { requireMention: false } },
+      groupId: "g-attacker-001",
+      groupChannel: "Trusted Team",
+      dangerouslyAllowNameMatching: true,
+    });
+    expect(requireMention).toBe(false);
   });
 });

--- a/extensions/zalouser/src/channel.ts
+++ b/extensions/zalouser/src/channel.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   deleteAccountFromConfigSection,
   formatAllowFromLowercase,
+  isDangerousNameMatchingEnabled,
   isNumericTargetId,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
@@ -200,12 +201,18 @@ function resolveZalouserGroupPolicyEntry(params: ChannelGroupContext) {
     accountId: params.accountId ?? undefined,
   });
   const groups = account.config.groups ?? {};
+  // Group display names/channels are mutable and attacker-controlled: anyone can create or rename
+  // a group to impersonate a trusted allowlist entry. Gate name matching on the same opt-in the
+  // inbound-admission path uses (monitor.ts, hardened in #2953) so a spoofable name cannot inherit
+  // a trusted entry's tool policy / requireMention on an already-admitted route.
+  const allowNameMatching = isDangerousNameMatchingEnabled(account.config);
   return findZalouserGroupEntry(
     groups,
     buildZalouserGroupCandidates({
       groupId: params.groupId,
       groupChannel: params.groupChannel,
       includeWildcard: true,
+      allowNameMatching,
     }),
   );
 }


### PR DESCRIPTION
## Summary

`resolveZalouserGroupPolicyEntry` (`extensions/zalouser/src/channel.ts`) resolved a group's policy
entry using the group's **attacker-mutable display name/channel** (`groupChannel`) as an
**unconditional** allowlist match candidate — it did not honor the `dangerouslyAllowNameMatching`
opt-in that gates group-name matching on the inbound-admission path.

This is the tool-policy / requireMention counterpart to the inbound-admission hardening in #2953
(commit `1ef15b0`), which fixed `monitor.ts` but did **not** touch `channel.ts`.

## Root cause

`buildZalouserGroupCandidates` treats name matching as **on unless explicitly disabled**
(`group-policy.ts`: `if (params.allowNameMatching !== false) { push(groupChannel) … }`). The
inbound path threads `allowNameMatching = isDangerousNameMatchingEnabled(account.config)`;
`resolveZalouserGroupPolicyEntry` omitted the argument, so it defaulted to name-matching **on**.

`groupChannel` originates from the attacker-mutable group subject
(`src/auto-reply/reply/groups.ts`: `ctx.GroupChannel ?? ctx.GroupSubject`). Under
`groupPolicy: "open"` (routes admitted without allowlist gating), a group whose spoofable name
matched a trusted allowlist entry could **inherit that trusted entry's tool policy and
`requireMention`** on an already-admitted route — a post-admission privilege surface (tool-policy
inheritance + mention-gating bypass) narrower than the inbound bypass but the same root cause.

## Fix

Thread `allowNameMatching = isDangerousNameMatchingEnabled(account.config)` into the
`buildZalouserGroupCandidates` call inside `resolveZalouserGroupPolicyEntry` — exactly as the
inbound-admission path does. When the opt-in is off (the default), the mutable
name/channel is no longer a policy-match candidate; only the stable group id and `*` wildcard
resolve. The single change protects **both** consumers of the shared resolver —
`resolveZalouserGroupToolPolicy` and `resolveZalouserRequireMention`.

`channel.ts` diff: one import + compute-and-thread `allowNameMatching` + a rationale comment. The
production change is byte-for-byte idiomatic with `monitor.ts:324`.

Scope note: `includeGroupIdAlias` is intentionally **not** added here. It is a separate,
non-security parity axis (the `group:<id>` candidate is derived from the stable id, not the mutable
name), and adding it would expand resolution behavior on a security patch. Kept out to keep the diff
tight.

## Testing — discriminating necropsy

The helper `buildZalouserGroupCandidates` already honored `allowNameMatching:false` and stayed green
in `group-policy.test.ts` throughout the vulnerable window; the defect was the **caller wiring**, so
the new specs exercise the plugin's `resolveToolPolicy` / `resolveRequireMention` consumers, not the
helper. Added to `channel.test.ts` (6 specs):

- **tool policy** — spoofed name does NOT inherit `tools` (flag off); resolves by name only with
  `dangerouslyAllowNameMatching: true`; stable id + wildcard still resolve (no regression).
- **requireMention** — spoofed name does NOT inherit `requireMention:false` (falls back to the
  fail-closed `true` default); still honored by name with the opt-in.

Both discriminators are **empirically discriminating** — reproduced the pre-fix corpse (removed the
threaded `allowNameMatching` arg):

- **corpse**: `2 failed | 9 passed` — both discriminators fail
  (`expected { allow: [ 'system.run' ] } to be undefined`, `expected false to be true`).
- **fix**: `11 passed`.

## Verification

- `node node_modules/vitest/vitest.mjs run --config vitest.extensions.config.ts extensions/zalouser/`
  → **16 files, 110 tests passed** (quarantined `monitor.group-gating.test.ts` excluded by config).
- `pnpm check` (oxfmt + tsgo + oxlint + fork-integrity gates) → **pass**.
- Adversarial sweep: all three `buildZalouserGroupCandidates` production call sites now thread the
  flag (`channel.ts` here; `monitor.ts:219` + `:328` from #2953). No unhardened policy-by-name
  resolution remains.

Closes #2976
