### PR TITLE
fix(net): restore managed-proxy CA trust in shared undici helpers (#2984)

### DIFF
--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -189,11 +189,9 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  // Skipped pending #2984: `createHttp1ProxyAgent` dropped its
-  // `addActiveManagedProxyTlsOptions` wrapper, so `proxyTls.ca` is never populated.
-  // That fix is shared infra (it also reaches the guarded SSRF path), so it is tracked
-  // separately from the Discord proxy hardening in #2960. Un-skip with #2984.
-  it.skip("uses managed proxy CA trust when a configured REST proxy matches the managed proxy", async () => {
+  // #2984: `createHttp1ProxyAgent` applies `addActiveManagedProxyTlsOptions`, so a
+  // configured REST proxy that matches the active managed proxy inherits its CA trust.
+  it("uses managed proxy CA trust when a configured REST proxy matches the managed proxy", async () => {
     const caFile = writeTempCa("discord-rest-configured-proxy-ca");
     vi.stubEnv("HTTPS_PROXY", "https://127.0.0.1:8443");
     vi.stubEnv("https_proxy", "https://127.0.0.1:8443");
@@ -313,9 +311,9 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  // Skipped pending #2984 — see the note above; same missing
-  // `addActiveManagedProxyTlsOptions` wrapper, here in `createHttp1EnvHttpProxyAgent`.
-  it.skip("uses managed env proxy CA trust when no discord proxy URL is configured", async () => {
+  // #2984: same wrapper in `createHttp1EnvHttpProxyAgent` — the managed env proxy
+  // inherits CA trust when no explicit discord proxy URL is configured.
+  it("uses managed env proxy CA trust when no discord proxy URL is configured", async () => {
     const caFile = writeTempCa("discord-rest-managed-proxy-ca");
     vi.stubEnv("HTTPS_PROXY", "https://proxy.example:8443");
     vi.stubEnv("https_proxy", "https://proxy.example:8443");

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetActiveManagedProxyStateForTests,
+  registerActiveManagedProxyUrl,
+} from "./proxy/active-proxy-state.js";
+import { createHttp1EnvHttpProxyAgent, createHttp1ProxyAgent } from "./undici-runtime.js";
+
+// The real `undici-runtime.ts` runs against injected fake dispatcher constructors so we
+// can assert the exact options each helper hands to undici (mirrors the injection pattern
+// used by extensions/discord/src/monitor/provider.rest-proxy.test.ts).
+const TEST_UNDICI_RUNTIME_DEPS_KEY = "__REMOTECLAW_TEST_UNDICI_RUNTIME_DEPS__";
+const MANAGED_PROXY_URL = "https://managed.example:8443";
+
+const proxyAgentOptions: Array<Record<string, unknown>> = [];
+const envHttpProxyAgentOptions: Array<Record<string, unknown>> = [];
+
+function installUndiciRuntimeDeps(): void {
+  class Agent {
+    constructor(readonly options?: unknown) {}
+  }
+  class EnvHttpProxyAgent {
+    constructor(readonly options?: unknown) {
+      envHttpProxyAgentOptions.push((options ?? {}) as Record<string, unknown>);
+    }
+  }
+  class ProxyAgent {
+    constructor(readonly options: unknown) {
+      proxyAgentOptions.push((options ?? {}) as Record<string, unknown>);
+    }
+  }
+  (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+    Agent,
+    EnvHttpProxyAgent,
+    ProxyAgent,
+    fetch: vi.fn(),
+  };
+}
+
+function asRecord(value: unknown, field: string): Record<string, unknown> {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`expected ${field} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+// `withHttp1OnlyDispatcherOptions` may seed `proxyTls` with autoSelectFamily keys even when
+// no managed CA applies, so read `ca` defensively instead of asserting on the whole object.
+function caOf(options: Record<string, unknown> | undefined): unknown {
+  const proxyTls = options?.proxyTls;
+  return proxyTls && typeof proxyTls === "object"
+    ? (proxyTls as Record<string, unknown>).ca
+    : undefined;
+}
+
+describe("undici-runtime managed proxy CA trust (#2984)", () => {
+  const envKeys = [
+    "http_proxy",
+    "https_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "REMOTECLAW_PROXY_ACTIVE",
+    "REMOTECLAW_PROXY_CA_FILE",
+  ] as const;
+
+  beforeEach(() => {
+    _resetActiveManagedProxyStateForTests();
+    for (const key of envKeys) {
+      vi.stubEnv(key, "");
+    }
+    proxyAgentOptions.length = 0;
+    envHttpProxyAgentOptions.length = 0;
+    installUndiciRuntimeDeps();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
+    _resetActiveManagedProxyStateForTests();
+    vi.unstubAllEnvs();
+  });
+
+  function registerManagedProxy(ca: string): void {
+    vi.stubEnv("REMOTECLAW_PROXY_ACTIVE", "1");
+    registerActiveManagedProxyUrl(new URL(MANAGED_PROXY_URL), {
+      loopbackMode: "gateway-only",
+      proxyTls: { ca },
+    });
+  }
+
+  it("populates proxyTls.ca for an explicit proxy URI matching the active managed proxy", () => {
+    registerManagedProxy("managed-proxy-ca");
+
+    createHttp1ProxyAgent({ uri: MANAGED_PROXY_URL });
+
+    const options = proxyAgentOptions.at(0);
+    expect(caOf(options)).toBe("managed-proxy-ca");
+    expect(options?.allowH2).toBe(false);
+  });
+
+  it("populates proxyTls.ca for the managed env proxy", () => {
+    registerManagedProxy("managed-env-proxy-ca");
+
+    createHttp1EnvHttpProxyAgent({ httpsProxy: MANAGED_PROXY_URL });
+
+    const options = envHttpProxyAgentOptions.at(0);
+    expect(caOf(options)).toBe("managed-env-proxy-ca");
+    expect(options?.allowH2).toBe(false);
+  });
+
+  // Discriminating: strict no-op on the guarded path when the managed proxy is inactive —
+  // no CA is injected, matching pre-fix behaviour for that path.
+  it("does not add managed CA trust when the managed proxy is inactive", () => {
+    createHttp1ProxyAgent({ uri: MANAGED_PROXY_URL });
+
+    expect(caOf(proxyAgentOptions.at(0))).toBeUndefined();
+  });
+
+  // Discriminating: managed CA is scoped to the matching proxy URL only.
+  it("does not add managed CA trust to a proxy URI that does not match the managed proxy", () => {
+    registerManagedProxy("managed-proxy-ca");
+
+    createHttp1ProxyAgent({ uri: "https://other-proxy.example:8443" });
+
+    expect(caOf(proxyAgentOptions.at(0))).toBeUndefined();
+  });
+
+  // Discriminating (#2960 dispatcher-preservation): wiring CA trust must not disturb the
+  // DNS-pinned `connect.lookup` a guarded caller supplies.
+  it("preserves a caller-supplied connect.lookup while adding managed CA trust", () => {
+    registerManagedProxy("managed-env-proxy-ca");
+    const lookup = (): void => {};
+
+    createHttp1EnvHttpProxyAgent({ httpsProxy: MANAGED_PROXY_URL, connect: { lookup } });
+
+    const options = envHttpProxyAgentOptions.at(0);
+    expect(asRecord(options?.connect, "connect").lookup).toBe(lookup);
+    expect(caOf(options)).toBe("managed-env-proxy-ca");
+  });
+
+  // Discriminating: a caller-supplied proxyTls.ca wins over the managed CA (no override).
+  it("does not override a caller-supplied proxyTls.ca", () => {
+    registerManagedProxy("managed-proxy-ca");
+
+    createHttp1ProxyAgent({ uri: MANAGED_PROXY_URL, proxyTls: { ca: "caller-ca" } });
+
+    expect(caOf(proxyAgentOptions.at(0))).toBe("caller-ca");
+  });
+});

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { addActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
 import { resolveUndiciAutoSelectFamilyConnectOptions } from "./undici-family-policy.js";
 
 export const TEST_UNDICI_RUNTIME_DEPS_KEY = "__REMOTECLAW_TEST_UNDICI_RUNTIME_DEPS__";
@@ -156,8 +157,10 @@ export function createHttp1EnvHttpProxyAgent(
   timeoutMs?: number,
 ): import("undici").EnvHttpProxyAgent {
   const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
+  // `options` is optional, so the managed-proxy wrap can return undefined here;
+  // normalize to `{}` (the ProxyAgent path below always passes a built object).
   return new EnvHttpProxyAgent(
-    withHttp1OnlyDispatcherOptions(options, timeoutMs, {
+    withHttp1OnlyDispatcherOptions(addActiveManagedProxyTlsOptions(options) ?? {}, timeoutMs, {
       connect: true,
       proxyTls: true,
     }),
@@ -174,8 +177,12 @@ export function createHttp1ProxyAgent(
       ? { uri: options.toString() }
       : { ...options };
   return new ProxyAgent(
-    withHttp1OnlyDispatcherOptions(normalized as object, timeoutMs, {
-      proxyTls: true,
-    }) as UndiciProxyAgentOptions,
+    withHttp1OnlyDispatcherOptions(
+      addActiveManagedProxyTlsOptions(normalized as object),
+      timeoutMs,
+      {
+        proxyTls: true,
+      },
+    ) as UndiciProxyAgentOptions,
   );
 }


### PR DESCRIPTION
## Summary

`src/infra/net/undici-runtime.ts` diverged from the fork's upstream sync baseline: both `createHttp1ProxyAgent` and `createHttp1EnvHttpProxyAgent` dropped their `addActiveManagedProxyTlsOptions(...)` wrapper. As a result the managed proxy's CA was never trusted by any dispatcher these helpers build, and `addActiveManagedProxyTlsOptions` was **orphaned** — defined and unit-tested in `src/infra/net/proxy/managed-proxy-undici.ts`, but with **zero production callers**.

**Impact:** when the managed proxy is active (`REMOTECLAW_PROXY_ACTIVE=1` + `REMOTECLAW_PROXY_CA_FILE`), dispatchers built by these helpers do not trust the managed proxy CA, so TLS interception through it fails. These helpers are shared infra — also reached by the guarded media/SSRF path (`src/infra/net/ssrf.ts`, `src/infra/net/fetch-guard.ts`, `src/infra/net/proxy/proxy-validation.ts`) and Discord REST (`extensions/discord/src/monitor/rest-fetch.ts`).

Closes #2984.

## What changed

- **`src/infra/net/undici-runtime.ts`** — reinstated `addActiveManagedProxyTlsOptions(...)` in both helpers (import + wrap). Added a short comment explaining why the `EnvHttpProxyAgent` path needs `?? {}` (its `options` is optional, so the wrap can return `undefined`) while the `ProxyAgent` path always passes a built object.
- **`extensions/discord/src/monitor/provider.rest-proxy.test.ts`** — un-skipped the two tests deferred to this issue (`uses managed proxy CA trust when a configured REST proxy matches the managed proxy`, `uses managed env proxy CA trust when no discord proxy URL is configured`); both now pass.
- **`src/infra/net/undici-runtime.test.ts`** (new) — 6 discriminating unit tests.

## Security preservation (the #2960 dispatcher lesson)

The wrapper is safe on the guarded SSRF path because `addActiveManagedProxyTlsOptions`:

1. **Is a strict no-op when the managed proxy is inactive** — it returns the *same* `options` reference when `REMOTECLAW_PROXY_ACTIVE != 1` or the proxy URL does not match, so dispatcher construction on the guarded path is byte-for-byte unchanged. Verified against the full `src/infra/net` suite (241 tests, all inactive-by-default) and a dedicated unit test.
2. **Only ever adds/merges `proxyTls`** — it never touches `connect`, where the DNS-pinned `lookup` lives, so IPv4-pinning is preserved (a dedicated test asserts a caller-supplied `connect.lookup` survives while the CA is added).
3. **Preserves a caller-supplied `proxyTls`** — the merge is `{ ...managedCA, ...callerProxyTls }`, so the caller wins (a dedicated test asserts `caller-ca` beats the managed CA). The explicit-proxy pinned lookup rides in `requestTls`, a different key, and is untouched.

## Scope decision — `addIpSafeProxyClientFactory` deliberately NOT restored

The upstream baseline also had a sibling helper, `addIpSafeProxyClientFactory`, that strips an IP `servername` from proxy `connect` options via a `Pool` `clientFactory`. It is **intentionally left out of this change**: it injects a `clientFactory` **unconditionally** (a behavior change even when the managed proxy is inactive), no current test asserts it, and it wraps the `Pool`/`connect` machinery closer to the DNS-pinning path. Restoring it warrants its own change + review. This PR keeps the diff tight and the guarded path a strict no-op when inactive.

> Follow-up (not in this PR): decide whether `addIpSafeProxyClientFactory` should be restored, with its own test coverage.

## Tests

- New unit tests (`undici-runtime.test.ts`, 6): CA populated on a matching explicit proxy URI; CA populated for the managed env proxy; **no CA when inactive**; **no CA for a non-matching URL**; **DNS-pinned `connect.lookup` preserved** while CA is added; **caller `proxyTls.ca` not overridden**. Proven discriminating (they fail if the wiring is reverted).
- Discord `provider.rest-proxy.test.ts`: 10/10 (2 previously `it.skip`, now active).
- Regression: `src/infra/net` 241/241, Slack client 21/21, `pnpm tsgo` clean, `pnpm check` clean (format + lint + css-drift + lobster-leak), throwing-stub / zombie-import / stub-debt gates clean.
