### PR TITLE
fix(slack): Socket-Mode proxy agent-forwarding tripwire + remove dead createSlackBoltApp (#2996)

### DIFF
--- a/extensions/slack/src/client.socket-mode-proxy.test.ts
+++ b/extensions/slack/src/client.socket-mode-proxy.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import * as SlackBolt from "@slack/bolt";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveSlackWebClientOptions } from "./client.js";
@@ -93,5 +94,51 @@ describe("slack socket mode proxy wiring", () => {
     } finally {
       delete process.env.NO_PROXY;
     }
+  });
+});
+
+/**
+ * Dependency tripwire for the un-asserted tail of the Socket-Mode agent-forwarding chain.
+ *
+ * The proxy tests above pin the contract only up to `SocketModeClient.webClientOptions.agent`
+ * — the last seam observable without opening a live WebSocket. The final hops
+ * (`SocketModeClient` → `SlackWebSocket`, which hands the agent to `ws` as `httpAgent`) live
+ * inside `@slack/socket-mode` and run only against the live network. A `@slack/bolt` or
+ * `@slack/socket-mode` MAJOR that renamed or dropped that private
+ * `installerOptions.clientOptions` → `webClientOptions.agent` → `httpAgent` forwarding would
+ * leave the tests above GREEN while the WebSocket silently egressed direct (the #2954
+ * regression: Web API still proxied, bot token unproxied, nothing else failing).
+ *
+ * Semver-major is the review signal: these guards fail when either package leaves its verified
+ * major, forcing a human re-review of the forwarding path — App → SocketModeReceiver →
+ * SocketModeClient → SlackWebSocket → ws `httpAgent` — before the bump lands. Within-major
+ * bumps are trusted (a break there would surface as a live regression, not a semver signal).
+ */
+const tripwireRequire = createRequire(import.meta.url);
+const VERIFIED_BOLT_MAJOR = 4; // @slack/bolt@4.7.3
+const VERIFIED_SOCKET_MODE_MAJOR = 2; // @slack/socket-mode@2.0.7 (transitive via @slack/bolt)
+
+function majorOf(version: string): number {
+  return Number.parseInt(version.split(".")[0] ?? "", 10);
+}
+
+describe("slack socket mode proxy dependency tripwire", () => {
+  it("keeps @slack/bolt within the verified major (installerOptions merge re-review gate)", () => {
+    const { version } = tripwireRequire("@slack/bolt/package.json") as { version: string };
+    expect(
+      majorOf(version),
+      `@slack/bolt left verified major ${VERIFIED_BOLT_MAJOR} (installed ${version}). Re-verify App → SocketModeReceiver → SocketModeClient still forwards installerOptions.clientOptions.agent, then bump VERIFIED_BOLT_MAJOR.`,
+    ).toBe(VERIFIED_BOLT_MAJOR);
+  });
+
+  it("keeps @slack/socket-mode within the verified major (webClientOptions.agent → ws httpAgent re-review gate)", () => {
+    // socket-mode is transitive; pnpm's strict layout hides it from the workspace root, so
+    // resolve its package.json from @slack/bolt's own location.
+    const requireFromBolt = createRequire(tripwireRequire.resolve("@slack/bolt"));
+    const { version } = requireFromBolt("@slack/socket-mode/package.json") as { version: string };
+    expect(
+      majorOf(version),
+      `@slack/socket-mode left verified major ${VERIFIED_SOCKET_MODE_MAJOR} (installed ${version}). Re-verify SocketModeClient still hands webClientOptions.agent to SlackWebSocket as ws httpAgent, then bump VERIFIED_SOCKET_MODE_MAJOR.`,
+    ).toBe(VERIFIED_SOCKET_MODE_MAJOR);
   });
 });

--- a/extensions/slack/src/monitor/provider-support.self-filter.test.ts
+++ b/extensions/slack/src/monitor/provider-support.self-filter.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { shouldSkipRemoteClawSlackSelfEvent } from "./provider-support.js";
 
-// The Bolt app is created with `ignoreSelf: false` and a global middleware that
-// calls `shouldSkipRemoteClawSlackSelfEvent` (see createSlackBoltApp). Dropping
-// every self-attributed event would swallow the assistant DM `message_changed`
-// edits that carry a real human sender in `metadata.event_payload.user`, so the
-// self-filter is deliberately scoped: it skips genuine bot noise but keeps the
-// message_changed passthrough. These cases pin that scoping.
+// `shouldSkipRemoteClawSlackSelfEvent` decides whether to drop a self-attributed Slack
+// event. It is deliberately scoped rather than a blanket self-drop: swallowing every
+// self-attributed event would also swallow the assistant DM `message_changed` edits that
+// carry a real human sender in `metadata.event_payload.user`, so it skips genuine bot
+// noise but keeps the message_changed passthrough. These cases pin that scoping.
 const CONTEXT = { botUserId: "U_BOT", botId: "B_BOT" };
 
 describe("shouldSkipRemoteClawSlackSelfEvent", () => {

--- a/extensions/slack/src/monitor/provider-support.ts
+++ b/extensions/slack/src/monitor/provider-support.ts
@@ -7,10 +7,6 @@ type SlackAppConstructor = typeof import("@slack/bolt").App;
 type SlackHttpReceiverConstructor = typeof import("@slack/bolt").HTTPReceiver;
 type SlackSocketModeReceiverConstructor = typeof import("@slack/bolt").SocketModeReceiver;
 type SlackSocketModeReceiverOptions = ConstructorParameters<SlackSocketModeReceiverConstructor>[0];
-type SlackSocketModeConfig = Pick<
-  SlackSocketModeReceiverOptions,
-  "clientPingTimeout" | "serverPingTimeout" | "pingPongLoggingEnabled"
->;
 type SlackSdkLogger = NonNullable<SlackSocketModeReceiverOptions["logger"]>;
 type SlackSdkLogLevel = ReturnType<SlackSdkLogger["getLevel"]>;
 type SlackSocketModeLogger = SlackSdkLogger & {
@@ -18,9 +14,6 @@ type SlackSocketModeLogger = SlackSdkLogger & {
 };
 type SlackSocketDisconnect = Awaited<ReturnType<typeof waitForSlackSocketDisconnect>>;
 
-const REMOTECLAW_SLACK_CLIENT_PING_TIMEOUT_MS = 15_000;
-const REMOTECLAW_SLACK_SOCKET_START_FAILED_EVENT = "unable_to_socket_mode_start";
-const REMOTECLAW_SLACK_NATIVE_RECONNECT_OBSERVER_KEY = "__remoteclawNativeReconnectFailureObserver";
 const SLACK_SOCKET_PONG_TIMEOUT_WARNING_PREFIX = "A pong wasn't received from the server";
 const SLACK_SOCKET_PING_TIMEOUT_WARNING_PREFIX = "A ping wasn't received from the server";
 const SLACK_SOCKET_LOG_LEVEL_IGNORED_WARNING_RE =
@@ -50,66 +43,6 @@ function isConstructorFunction<
   T extends Constructor,
 >(value: unknown): value is T {
   return typeof value === "function";
-}
-
-function installSlackNativeReconnectFailureObserver(receiver: unknown) {
-  if (!receiver || typeof receiver !== "object") {
-    return;
-  }
-  const client = Reflect.get(receiver, "client");
-  if (!client || typeof client !== "object") {
-    return;
-  }
-  if (Reflect.get(client, REMOTECLAW_SLACK_NATIVE_RECONNECT_OBSERVER_KEY)) {
-    return;
-  }
-  const delayReconnectAttempt = Reflect.get(client, "delayReconnectAttempt");
-  const emit = Reflect.get(client, "emit");
-  if (typeof delayReconnectAttempt !== "function" || typeof emit !== "function") {
-    return;
-  }
-
-  Reflect.set(client, REMOTECLAW_SLACK_NATIVE_RECONNECT_OBSERVER_KEY, true);
-  Reflect.set(
-    client,
-    "delayReconnectAttempt",
-    function patchedDelayReconnectAttempt(this: object, callback: unknown) {
-      if (typeof callback !== "function") {
-        return delayReconnectAttempt.call(this, callback);
-      }
-      const failureCount = Number(Reflect.get(this, "numOfConsecutiveReconnectionFailures") ?? 0);
-      const nextFailureCount = failureCount + 1;
-      Reflect.set(this, "numOfConsecutiveReconnectionFailures", nextFailureCount);
-      const pingTimeoutMs = Number(Reflect.get(this, "clientPingTimeoutMS"));
-      const delayMs =
-        (Number.isFinite(pingTimeoutMs) && pingTimeoutMs >= 0
-          ? pingTimeoutMs
-          : REMOTECLAW_SLACK_CLIENT_PING_TIMEOUT_MS) * nextFailureCount;
-      const logger = Reflect.get(this, "logger") as { debug?: (message: string) => void };
-      logger?.debug?.(
-        `Before trying to reconnect, this client will wait for ${delayMs} milliseconds`,
-      );
-      return new Promise((resolve, reject) => {
-        setTimeout(() => {
-          if (Reflect.get(this, "shuttingDown")) {
-            logger?.debug?.("Client shutting down, will not attempt reconnect.");
-            resolve(undefined);
-            return;
-          }
-          logger?.debug?.("Continuing with reconnect...");
-          emit.call(this, "reconnecting");
-          Promise.resolve(callback.call(this)).then(resolve, (error: unknown) => {
-            if (callback === Reflect.get(this, "start")) {
-              emit.call(this, REMOTECLAW_SLACK_SOCKET_START_FAILED_EVENT, error);
-              resolve(undefined);
-              return;
-            }
-            reject(error);
-          });
-        }, delayMs);
-      });
-    },
-  );
 }
 
 function resolveSlackBoltModule(value: unknown): SlackBoltResolvedExports | null {
@@ -291,63 +224,6 @@ export function shouldSkipRemoteClawSlackSelfEvent(args: SlackSelfFilterArgs): b
     typeof event.type === "string" &&
     !eventsWhichShouldBeKept.has(event.type),
   );
-}
-
-export function createSlackBoltApp(params: {
-  interop: SlackBoltResolvedExports;
-  slackMode: "socket" | "http";
-  botToken: string;
-  appToken?: string;
-  signingSecret?: string;
-  slackWebhookPath: string;
-  clientOptions: Record<string, unknown>;
-  socketMode?: SlackSocketModeConfig;
-}) {
-  const socketModeLogger = createSlackSocketModeLogger();
-  const socketModeReceiverOptions: SlackSocketModeReceiverOptions = {
-    appToken: params.appToken ?? "",
-    autoReconnectEnabled: true,
-    clientPingTimeout:
-      params.socketMode?.clientPingTimeout ?? REMOTECLAW_SLACK_CLIENT_PING_TIMEOUT_MS,
-    logger: socketModeLogger,
-    installerOptions: {
-      clientOptions: params.clientOptions,
-    },
-  };
-  if (params.socketMode?.serverPingTimeout !== undefined) {
-    socketModeReceiverOptions.serverPingTimeout = params.socketMode.serverPingTimeout;
-  }
-  if (params.socketMode?.pingPongLoggingEnabled !== undefined) {
-    socketModeReceiverOptions.pingPongLoggingEnabled = params.socketMode.pingPongLoggingEnabled;
-  }
-
-  const receiver =
-    params.slackMode === "socket"
-      ? new params.interop.SocketModeReceiver(socketModeReceiverOptions)
-      : new params.interop.HTTPReceiver({
-          signingSecret: params.signingSecret ?? "",
-          endpoints: params.slackWebhookPath,
-        });
-  if (params.slackMode === "socket") {
-    installSlackNativeReconnectFailureObserver(receiver);
-  }
-  const app = new params.interop.App({
-    token: params.botToken,
-    receiver,
-    clientOptions: params.clientOptions,
-    ignoreSelf: false,
-    // Bolt eagerly starts an auth.test promise in the constructor when token
-    // verification is enabled. Invalid tokens can reject before any listener
-    // consumes that promise, tripping RemoteClaw's fatal unhandled-rejection path.
-    tokenVerificationEnabled: false,
-  });
-  app.use(async (args) => {
-    if (shouldSkipRemoteClawSlackSelfEvent(args)) {
-      return;
-    }
-    await args.next();
-  });
-  return { app, receiver, socketModeLogger };
 }
 
 export function createSlackSocketDisconnectWaiter(app: unknown, abortSignal?: AbortSignal) {


### PR DESCRIPTION
## Summary

Two low-severity follow-ups from the independent security review of the Slack proxy-egress fix
(#2954, which routed the Web API + Socket Mode clients through `HTTP(S)_PROXY` with `NO_PROXY`
exclusion). Both harden the proxy-egress surface; neither is an active vulnerability today.

1. **Tripwire the un-asserted tail of the Socket-Mode agent-forwarding chain** (test-only).
2. **Remove the dead `createSlackBoltApp`** and its private-only closure (dead-code hygiene).

Closes #2996.

## 1 — Socket-Mode WS-agent tripwire (`client.socket-mode-proxy.test.ts`)

The existing proxy tests pin the agent only up to `SocketModeClient.webClientOptions.agent` — the
last seam observable without opening a live WebSocket. The final hops
(`SocketModeClient → SlackWebSocket → ws httpAgent`) live inside `@slack/socket-mode` and run only
against the live network. A `@slack/bolt` or `@slack/socket-mode` **major** that renamed or dropped
the private `installerOptions.clientOptions → webClientOptions.agent → httpAgent` forwarding would
leave those tests **green while the socket silently egressed direct** (the #2954 regression: Web API
still proxied, bot token unproxied, nothing else failing).

This adds a version-major tripwire (issue option 1) that fails when `@slack/bolt` leaves major `4`
or `@slack/socket-mode` leaves major `2`, with an **actionable** re-verify message naming the exact
forwarding chain and the constant to bump — subsuming issue option 3 (the re-verify requirement is
now enforced in CI, not a passive doc note). `@slack/socket-mode` is transitive under pnpm's strict
layout, so its version resolves from `@slack/bolt`'s own location.

Verified it is a real gate (not a rubber stamp): simulating a major drift (`VERIFIED_..._MAJOR` set
wrong) fails with, e.g.:

```
AssertionError: @slack/socket-mode left verified major 9 (installed 2.0.7). Re-verify SocketModeClient
still hands webClientOptions.agent to SlackWebSocket as ws httpAgent, then bump VERIFIED_SOCKET_MODE_MAJOR.
```

## 2 — Remove dead `createSlackBoltApp` (`provider-support.ts`)

`createSlackBoltApp` built a bolt `App` with an explicit `SocketModeReceiver` / `installerOptions`,
bypassing the live Socket-Mode path (`provider.ts` → `new App({ socketMode: true })`). It had **zero
callers repo-wide** — the only reference was a stale prose comment in the self-filter test.

**Zero-caller evidence** (repo-wide `git grep` on the pre-change tree):

```
$ git grep -n "createSlackBoltApp"
extensions/slack/src/monitor/provider-support.self-filter.test.ts:5:// ... (see createSlackBoltApp). Dropping   <- prose comment only
extensions/slack/src/monitor/provider-support.ts:296:export function createSlackBoltApp(params: {       <- the definition
```

Removed together with the module-private helpers it **exclusively owned** (else `oxlint no-unused-vars`
breaks — this is closure of the named removal, not scope creep):

| Removed symbol | Kind | Sole owner |
|---|---|---|
| `installSlackNativeReconnectFailureObserver` | module-private fn | `createSlackBoltApp` |
| `REMOTECLAW_SLACK_CLIENT_PING_TIMEOUT_MS` | const | the above two |
| `REMOTECLAW_SLACK_SOCKET_START_FAILED_EVENT` | const | the observer |
| `REMOTECLAW_SLACK_NATIVE_RECONNECT_OBSERVER_KEY` | const | the observer |
| `SlackSocketModeConfig` (local) | type | `createSlackBoltApp` param |

**Why this is behavior-neutral:**
- The live path (`provider.ts`) never called `createSlackBoltApp` and never installed the observer —
  it handles the reconnect-rejection concern via `registerSlackSocketUnhandledRejectionHandler`.
- Self-events are filtered live via `shouldDropMismatchedSlackEvent` (`context.ts`), **not** the
  removed function's middleware.
- The `unable_to_socket_mode_start` consumers (`provider.ts`, `reconnect-policy.ts`) use the **string
  literal**, not the removed const.
- The live `src/config/types.slack.ts` `SlackSocketModeConfig` (a distinct, exported config type) is
  **untouched** — only the identically-named module-private `Pick<…>` in `extensions/slack` was removed.

The now-stale `createSlackBoltApp` reference in the self-filter test comment is rewritten to describe
the function's scoping contract without the removed wiring.

## Scope boundary / follow-up

`shouldSkipRemoteClawSlackSelfEvent` and `createSlackSocketModeLogger` are **kept** (exported + tested)
per the issue's explicit scope. Note that both are now **dead-exported** — their only non-test caller
was the removed `createSlackBoltApp` (the live self-filter uses `shouldDropMismatchedSlackEvent`).
Removing them (and the logger's ~120-line warning-suppression subsystem) is deliberately left out of
this tight-scoped PR; worth a separate hygiene follow-up.

## Testing

- `extensions/slack` suite: **560 passed / 22 skipped / 0 failed** (67 files), incl. the reconnect &
  unhandled-rejection suites that consume `unable_to_socket_mode_start`.
- Tripwire: 2 new tests pass at installed `@slack/bolt@4.7.3` / `@slack/socket-mode@2.0.7`; proven to
  fail on simulated major drift.
- `pnpm tsgo` → 0 errors · `pnpm lint` (oxlint type-aware) → 0 warnings / 0 errors · `pnpm format` clean.

Diff: **+52 / −130** across 3 files (test tripwire; provider-support removal; comment fix).
