### PR TITLE
docs(slack): drop unfurlLinks/unfurlMedia config keys — never implemented (#2987)

### DIFF
--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -457,8 +457,6 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         ephemeral: true,
       },
       typingReaction: "hourglass_flowing_sand",
-      unfurlLinks: false,
-      unfurlMedia: false,
       textChunkLimit: 4000,
       chunkMode: "length",
       streaming: {
@@ -491,7 +489,6 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - `configWrites: false` blocks Slack-initiated config writes.
 - Optional `channels.slack.defaultAccount` overrides default account selection when it matches a configured account id.
 - `channels.slack.streaming.mode` is the canonical Slack stream mode key. `channels.slack.streaming.nativeTransport` controls Slack's native streaming transport. Legacy `streamMode`, boolean `streaming`, and `nativeStreaming` values remain runtime aliases; run `remoteclaw doctor --fix` to rewrite persisted config.
-- `unfurlLinks` and `unfurlMedia` pass Slack's `chat.postMessage` link and media unfurl booleans through for bot replies. `unfurlLinks` defaults to `false` so outbound bot links do not expand inline unless enabled; `unfurlMedia` is omitted unless configured. Set either value at `channels.slack.accounts.<accountId>` to override the top-level value for one account.
 - Use `user:<id>` (DM) or `channel:<id>` for delivery targets.
 
 **Reaction notification modes:** `off`, `own` (default), `all`, `allowlist` (from `reactionAllowlist`).


### PR DESCRIPTION
## Summary

`docs/gateway/config-channels.md` documented two Slack config keys — `channels.slack.unfurlLinks`
and `unfurlMedia` — that never existed in the fork's config type or zod schema. Setting either was
a silent no-op (a config-lie). This removes the documented-but-dead surface so docs and code agree.

Closes #2987.

## The config-lie (evidence, grounded against live source)

- **Documented as config** (removed here): `docs/gateway/config-channels.md` — a sample block
  (`unfurlLinks: false` / `unfurlMedia: false`) plus a paragraph describing them as
  `channels.slack.accounts.<accountId>` keys.
- **Not in the config type**: `src/config/types.slack.ts` `SlackAccountConfig` has no unfurl keys
  (`grep unfurl` = 0).
- **Not in the zod schema**: `src/config/zod-schema.providers-core.ts` `SlackAccountSchema`
  (`.strict()`) has no unfurl keys.
- **`unfurlMedia` never reached the API at all**: `extensions/slack/src/send.ts` builds no
  `unfurl_media` key anywhere.
- **The send-level `unfurlLinks` seam has no live caller**: `SlackSendOpts.unfurlLinks`
  (`send.ts:68`) is only exercised by tests; nothing in the config/delivery path feeds it, so
  `params.unfurlLinks` is always `undefined` → the hardcoded `?? false` at the send-call site
  (`send.ts:186`).
- **Provenance**: the doc lines arrived via content-only doc syncs (#2829, #2840), ahead of the
  config plumbing this fork gutted from upstream.

## Decision: WIRE-or-REMOVE → REMOVE (the smaller correct change)

Both directions make docs and code agree. REMOVE was chosen because wiring is non-trivial:

- config-type keys + strict-zod-schema keys (top-level and per-account),
- a new per-account resolution helper (mirroring `resolveMarkdownTableMode`) crossing the
  `extensions/slack` → `src/config` boundary,
- threading `unfurlMedia` through `SlackSendOpts` / `postSlackMessageBestEffort` / the payload,
- precedence semantics between the (currently dead) send-level override and config,
- plus a precedence test.

That re-introduces gutted upstream feature-parity plumbing the minimalist fork has not adopted.
Deleting 3 doc lines is the strictly smaller change that resolves the lie.

## Preserved (out of scope)

The live `unfurl_links: false` payload default at `extensions/slack/src/send.ts:186` is a tested
regression fix (#2986) and is **kept unchanged** — bot replies still do not expand inline link
previews by default (covered by `send.identity-fallback.test.ts`, un-quarantined in #2962). Its
rationale already lives in the `send.ts:185` code comment; a config-key doc entry for a
non-configurable behavior would re-invite the exact "how do I change it?" question that produced
the lie.

## Verification

- Diff: **1 file, 3 deletions** (docs only).
- `grep unfurl docs/` → **0** after the change (no orphans; generated `config-baseline.json` also
  clean).
- `pnpm format:docs:check` → PASS (479 files); pre-commit gates (lobster-leak, models-write,
  css-class-drift) → PASS.
- Fresh-context adversarial review (`documentation-guardian`) → **CLEAN** on all checks, including
  keys-genuinely-absent and #2986-default-preserved.
