### PR TITLE
fix(mattermost): carry GroupSpace in slash-command session ctx (#2975)

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-http.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.test.ts
@@ -1,10 +1,62 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { PassThrough } from "node:stream";
 import type { RemoteClawConfig, RuntimeEnv } from "remoteclaw/plugin-sdk/mattermost";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
+import type { MattermostChannel } from "./client.js";
+import type { MattermostCommandAuthDecision } from "./monitor-auth.js";
 import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import { createSlashCommandHttpHandler } from "./slash-http.js";
+
+// The GroupSpace session-metadata test below drives a fully authorized slash
+// request all the way into handleSlashCommandAsync. Stub the channel lookup and
+// the authorization decision so the request reaches the inbound-context builder
+// without a live Mattermost server. Real exports are preserved; only the two
+// functions on this path are overridden.
+vi.mock("./client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client.js")>();
+  return {
+    ...actual,
+    createMattermostClient: vi.fn(
+      () => ({}) as unknown as ReturnType<typeof actual.createMattermostClient>,
+    ),
+    fetchMattermostChannel: vi.fn(
+      async (): Promise<MattermostChannel> => ({
+        id: "c1",
+        name: "general",
+        display_name: "General",
+        type: "O",
+        team_id: "t1",
+      }),
+    ),
+  };
+});
+
+vi.mock("./monitor-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./monitor-auth.js")>();
+  return {
+    ...actual,
+    authorizeMattermostCommandInvocation: vi.fn(
+      (): MattermostCommandAuthDecision => ({
+        ok: true,
+        commandAuthorized: true,
+        channelInfo: {
+          id: "c1",
+          name: "general",
+          display_name: "General",
+          type: "O",
+          team_id: "t1",
+        },
+        kind: "channel",
+        chatType: "channel",
+        channelName: "general",
+        channelDisplay: "General",
+        roomLabel: "#general",
+      }),
+    ),
+  };
+});
 
 function createRequest(params: {
   method?: string;
@@ -172,5 +224,67 @@ describe("slash-http", () => {
     });
 
     expect(response.res.statusCode).toBe(408);
+  });
+});
+
+describe("slash-http session metadata", () => {
+  // Capture the inbound-context payload the slash path hands to
+  // finalizeInboundContext. That builder mutates-and-returns its argument
+  // without stripping unknown keys, so the captured object is the payload the
+  // session is recorded from.
+  let capturedCtx: Record<string, unknown> | undefined;
+
+  beforeEach(() => {
+    capturedCtx = undefined;
+    setMattermostRuntime({
+      channel: {
+        routing: {
+          resolveAgentRoute: () => ({
+            sessionKey: "mattermost:channel:c1",
+            accountId: "default",
+            agentId: "agent-1",
+          }),
+        },
+        commands: {
+          shouldHandleTextCommands: () => false,
+        },
+        text: {
+          hasControlCommand: () => false,
+          resolveTextChunkLimit: () => 4000,
+          resolveMarkdownTableMode: () => "auto",
+        },
+        pairing: {
+          readAllowFromStore: async () => [],
+        },
+        reply: {
+          finalizeInboundContext: (ctx: Record<string, unknown>) => {
+            capturedCtx = ctx;
+            return ctx;
+          },
+          createReplyDispatcherWithTyping: () => ({
+            dispatcher: {},
+            replyOptions: {},
+            markDispatchIdle: () => {},
+          }),
+          resolveHumanDelayConfig: () => ({}),
+          // No-op: never invoke `run`, so we capture the payload without
+          // exercising reply dispatch/delivery.
+          withReplyDispatcher: async () => {},
+        },
+      },
+    } as unknown as Parameters<typeof setMattermostRuntime>[0]);
+  });
+
+  it("carries GroupSpace (the invoking team id) on the slash-command session payload — parity with the message path (monitor.ts:548)", async () => {
+    await runSlashRequest({
+      registeredCommands: [cmd()],
+      body: "token=known-token&team_id=t1&channel_id=c1&user_id=u1&user_name=alice&command=%2Foc_status&text=status",
+    });
+
+    // Regression guard for #2975: the slash path previously omitted GroupSpace,
+    // so slash-initiated sessions lost workspace-scope parity with the message
+    // path. It must now equal the invoking team id, exactly as monitor.ts sets it.
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.GroupSpace).toBe("t1");
   });
 });

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -400,6 +400,12 @@ async function handleSlashCommandAsync(params: {
     ChatType: chatType,
     ConversationLabel: fromLabel,
     GroupSubject: kind !== "direct" ? channelDisplay || roomLabel : undefined,
+    // Workspace-scope parity with the message path (monitor.ts:548 / :1126) —
+    // slash-initiated sessions must carry GroupSpace so downstream group-space
+    // scoping (session `space`, gateway group inheritance, require-mention)
+    // resolves the same as message-initiated ones. `teamId` is a non-nullable
+    // string here (payload.team_id). (#2975)
+    GroupSpace: teamId,
     SenderName: senderName,
     SenderId: senderId,
     Provider: "mattermost" as const,


### PR DESCRIPTION
Closes #2975.

## Problem

The Mattermost **slash-command** inbound path built its session context payload (`ctxPayload` handed to `finalizeInboundContext` in `handleSlashCommandAsync`) with `GroupSubject` but **omitted `GroupSpace`**, while the **message / monitor** path sets `GroupSpace: teamId` (`extensions/mattermost/src/mattermost/monitor.ts:548` and `:1126`).

Slash-initiated sessions therefore lost workspace-scope parity with message-initiated sessions on the same workspace. `GroupSpace` feeds group-space scoping downstream — session `space` metadata (`src/config/sessions/metadata.ts`), gateway group inheritance (`src/gateway/server-methods/agent.ts`), and require-mention resolution (`src/auto-reply/reply/groups.ts`) — so the two entry points resolved group-space scoping inconsistently.

Same-shape defect as the Slack fix in #2958.

## Fix

Add `GroupSpace: teamId,` to the slash `ctxPayload`, alongside the existing `GroupSubject`:

- **Bare and unconditional**, byte-identical to the message path (`GroupSpace: teamId`, no `|| undefined`, not gated on `kind`). Deliberately mirrors the *Mattermost message path*, not the Slack form (`ctx.teamId || undefined`).
- `teamId` is a non-nullable `string` here (`payload.team_id`, declared `teamId: string`), so the field is well-typed.

Scope is exactly this one field — `GroupChannel` (also set on the message path) is intentionally **not** added; it's out of scope for this parity fix.

## Test

New `describe("slash-http session metadata")` in `slash-http.test.ts` drives a fully-authorized slash request through the exported `createSlashCommandHttpHandler` (reusing the existing `runSlashRequest`/`cmd` helpers), captures the payload handed to `finalizeInboundContext` via a mock runtime, and asserts `GroupSpace === "t1"` (the invoking team id).

Regression guard verified: with the source field removed the test fails with `AssertionError: expected undefined to be 't1'`; with the fix applied the suite is green.

## Verification

- `slash-http.test.ts`: **8 passed** (7 existing + 1 new).
- `pnpm tsgo`: clean. `pnpm lint` (oxlint --type-aware): 0 warnings, 0 errors. oxfmt: clean.
- Not quarantined → runs in the CI `test-extensions` lane.

## Severity / security

**LOW** — metadata/consistency parity, not an isolation/authorization boundary: the session key already incorporates the team id, and the newly-populated value is shape-identical to what the message path already produces for channel sessions (every downstream consumer already exercises it). Empty-string/DM cases are already-equivalent to the prior `undefined` (`metadata.ts` gates on `if (space)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
