### PR TITLE
fix(mattermost): resolve accessGroup: allowlist entries to their members (#2982)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-auth.access-groups.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.access-groups.test.ts
@@ -1,0 +1,116 @@
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/mattermost";
+import { describe, expect, it } from "vitest";
+import { isMattermostSenderAllowed } from "./monitor-auth.js";
+
+// Necropsy regression for #2982: `accessGroup:<name>` allowlist entries must expand to their
+// configured members at the Mattermost admit seam. These tests exercise the REAL matcher
+// (`resolveAllowlistMatchSimple` is NOT mocked here, unlike monitor-auth.test.ts), so reverting the
+// expansion turns "admits a member" red — the discriminating signal against the pre-fix corpse,
+// where an `accessGroup:` reference reached the literal matcher as an inert token and denied every
+// member (fail-closed).
+describe("mattermost access-group allowlist resolution (#2982)", () => {
+  const accessGroups: RemoteClawConfig["accessGroups"] = {
+    Ops: {
+      type: "message.senders",
+      members: { "*": ["ops-user-id"], "chan-1": ["ops-chan1-id"] },
+    },
+  };
+
+  it("admits a member of an allowlisted access group (corpse: pre-fix wrongly denied)", () => {
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "ops-user-id",
+        senderName: "Alice Ops",
+        allowFrom: ["accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("scopes channel-specific members to their channel", () => {
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "ops-chan1-id",
+        allowFrom: ["accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-1",
+      }),
+    ).toBe(true);
+    // The chan-1-scoped member is NOT a member from a different channel.
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "ops-chan1-id",
+        allowFrom: ["accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-2",
+      }),
+    ).toBe(false);
+  });
+
+  it("denies a non-member (fail-closed, no over-admit)", () => {
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "outsider-id",
+        senderName: "Outsider",
+        allowFrom: ["accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("matches on the non-spoofable sender id, not a spoofable display name", () => {
+    // The attacker sets their display name to a member's stable id; their actual id differs. With
+    // dangerous name-matching OFF (the default), only the id is compared → denied. This proves
+    // member expansion did not trade the original fail-closed gap for a display-name spoof.
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "attacker-id",
+        senderName: "ops-user-id",
+        allowFrom: ["accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-1",
+        allowNameMatching: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("still honours direct entries mixed with an access-group reference", () => {
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "direct-user",
+        allowFrom: ["direct-user", "accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("admits a name-listed member only when dangerous name-matching is enabled (parity with direct entries)", () => {
+    const namedGroup: RemoteClawConfig["accessGroups"] = {
+      Ops: { type: "message.senders", members: { "*": ["alice"] } },
+    };
+    // The member is written as a username, and the sender's id differs from it. This admits ONLY
+    // when the operator has opted into dangerous name-matching — identical to a direct entry, so
+    // member expansion introduces no name-match behavior of its own.
+    const params = {
+      senderId: "u-123",
+      senderName: "Alice",
+      allowFrom: ["accessGroup:Ops"] as string[],
+      accessGroups: namedGroup,
+      channelId: "chan-1",
+    };
+    expect(isMattermostSenderAllowed({ ...params, allowNameMatching: false })).toBe(false);
+    expect(isMattermostSenderAllowed({ ...params, allowNameMatching: true })).toBe(true);
+  });
+
+  it("leaves an access-group reference inert when no group config is supplied (unchanged fail-closed)", () => {
+    expect(
+      isMattermostSenderAllowed({
+        senderId: "ops-user-id",
+        allowFrom: ["accessGroup:Ops"],
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -2,6 +2,7 @@ import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/mattermost";
 import {
   ACCESS_GROUP_ALLOW_FROM_PREFIX,
   evaluateSenderGroupAccessForPolicy,
+  expandAccessGroupAllowFromEntries,
   isDangerousNameMatchingEnabled,
   parseAccessGroupAllowFromEntry,
   resolveAllowlistMatchSimple,
@@ -60,8 +61,23 @@ export function isMattermostSenderAllowed(params: {
   senderName?: string;
   allowFrom: string[];
   allowNameMatching?: boolean;
+  accessGroups?: RemoteClawConfig["accessGroups"];
+  channelId?: string;
 }): boolean {
-  const allowFrom = normalizeMattermostAllowList(params.allowFrom);
+  // Expand `accessGroup:<name>` references into their configured member entries BEFORE matching.
+  // Without this, an access-group reference reaches the literal matcher as an inert token
+  // (`accessgroup:<name>`) that no real sender id/name can equal — silently denying every group
+  // member (fail-closed). Members flow through the same matcher as direct entries, so id-first,
+  // non-spoofable matching is preserved (a member written as a name matches only when the caller
+  // enables dangerous name-matching). When `accessGroups`/`channelId` are absent, behavior is
+  // unchanged and unexpanded references stay inert.
+  const allowFrom = normalizeMattermostAllowList(
+    expandAccessGroupAllowFromEntries({
+      entries: params.allowFrom,
+      accessGroups: params.accessGroups,
+      channelId: params.channelId,
+    }),
+  );
   if (allowFrom.length === 0) {
     return false;
   }
@@ -185,12 +201,16 @@ export function authorizeMattermostCommandInvocation(params: {
     senderName,
     allowFrom: commandDmAllowFrom,
     allowNameMatching,
+    accessGroups: cfg.accessGroups,
+    channelId,
   });
   const groupAllowedForCommands = isMattermostSenderAllowed({
     senderId,
     senderName,
     allowFrom: commandGroupAllowFrom,
     allowNameMatching,
+    accessGroups: cfg.accessGroups,
+    channelId,
   });
 
   const commandGate = resolveControlCommandGate({
@@ -251,6 +271,8 @@ export function authorizeMattermostCommandInvocation(params: {
           senderName,
           allowFrom,
           allowNameMatching,
+          accessGroups: cfg.accessGroups,
+          channelId,
         }),
     });
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -832,6 +832,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           senderName,
           allowFrom,
           allowNameMatching,
+          accessGroups: cfg.accessGroups,
+          channelId,
         }),
     });
     const effectiveAllowFrom = accessDecision.effectiveAllowFrom;
@@ -849,12 +851,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       senderName,
       allowFrom: commandDmAllowFrom,
       allowNameMatching,
+      accessGroups: cfg.accessGroups,
+      channelId,
     });
     const groupAllowedForCommands = isMattermostSenderAllowed({
       senderId,
       senderName,
       allowFrom: effectiveGroupAllowFrom,
       allowNameMatching,
+      accessGroups: cfg.accessGroups,
+      channelId,
     });
     const commandGate = resolveControlCommandGate({
       useAccessGroups,
@@ -1349,6 +1355,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           senderName,
           allowFrom,
           allowNameMatching,
+          accessGroups: cfg.accessGroups,
+          channelId,
         }),
     });
     if (reactionAccess.decision !== "allow") {

--- a/src/channels/allow-from.test.ts
+++ b/src/channels/allow-from.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { AccessGroupsConfig } from "../config/types.access-groups.js";
 import {
+  expandAccessGroupAllowFromEntries,
   firstDefined,
   isSenderIdAllowed,
   mergeDmAllowFromSources,
@@ -67,6 +69,81 @@ describe("resolveGroupAllowFromSources", () => {
         fallbackToAllowFrom: false,
       }),
     ).toStrictEqual([]);
+  });
+});
+
+describe("expandAccessGroupAllowFromEntries", () => {
+  const accessGroups: AccessGroupsConfig = {
+    Ops: {
+      type: "message.senders",
+      members: { "*": ["ops-shared-id"], "chan-1": ["ops-chan1-id"] },
+    },
+    // A dynamic group type is not resolvable from static config on this path.
+    Viewers: {
+      type: "discord.channelAudience",
+      guildId: "g1",
+      channelId: "c1",
+    },
+  };
+
+  it("passes non-access-group entries through unchanged", () => {
+    expect(
+      expandAccessGroupAllowFromEntries({ entries: ["user-1", "*", 42], accessGroups }),
+    ).toEqual(["user-1", "*", "42"]);
+  });
+
+  it("expands a static message.senders reference to its shared + channel-scoped members", () => {
+    expect(
+      expandAccessGroupAllowFromEntries({
+        entries: ["accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-1",
+      }),
+    ).toEqual(["ops-shared-id", "ops-chan1-id"]);
+  });
+
+  it("includes only shared members when no channelId is supplied", () => {
+    expect(
+      expandAccessGroupAllowFromEntries({ entries: ["accessGroup:Ops"], accessGroups }),
+    ).toEqual(["ops-shared-id"]);
+  });
+
+  it("keeps direct entries alongside expanded members", () => {
+    expect(
+      expandAccessGroupAllowFromEntries({
+        entries: ["direct-id", "accessGroup:Ops"],
+        accessGroups,
+        channelId: "chan-2",
+      }),
+    ).toEqual(["direct-id", "ops-shared-id"]);
+  });
+
+  it("drops references to missing groups (fail-closed)", () => {
+    expect(
+      expandAccessGroupAllowFromEntries({ entries: ["accessGroup:Nope"], accessGroups }),
+    ).toEqual([]);
+  });
+
+  it("drops references to unsupported dynamic group types (fail-closed)", () => {
+    expect(
+      expandAccessGroupAllowFromEntries({ entries: ["accessGroup:Viewers"], accessGroups }),
+    ).toEqual([]);
+  });
+
+  it("does not recurse into a nested access-group member (returns the literal)", () => {
+    const nested: AccessGroupsConfig = {
+      Outer: { type: "message.senders", members: { "*": ["accessGroup:Inner"] } },
+      Inner: { type: "message.senders", members: { "*": ["inner-id"] } },
+    };
+    expect(
+      expandAccessGroupAllowFromEntries({ entries: ["accessGroup:Outer"], accessGroups: nested }),
+    ).toEqual(["accessGroup:Inner"]);
+  });
+
+  it("drops all references when accessGroups is absent (unexpanded, fail-closed)", () => {
+    expect(expandAccessGroupAllowFromEntries({ entries: ["accessGroup:Ops", "u1"] })).toEqual([
+      "u1",
+    ]);
   });
 });
 

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -1,3 +1,4 @@
+import type { AccessGroupsConfig } from "../config/types.access-groups.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 
 export const ACCESS_GROUP_ALLOW_FROM_PREFIX = "accessGroup:";
@@ -9,6 +10,48 @@ export function parseAccessGroupAllowFromEntry(entry: string): string | null {
   }
   const name = trimmed.slice(ACCESS_GROUP_ALLOW_FROM_PREFIX.length).trim();
   return name.length > 0 ? name : null;
+}
+
+/**
+ * Expand `accessGroup:<name>` allowlist references into their concrete member sender entries so a
+ * simple literal matcher (e.g. {@link resolveAllowlistMatchSimple}) can admit group members. Only
+ * static `message.senders` groups contribute members: the operator-configured shared `members["*"]`
+ * bucket plus any channel-scoped `members[channelId]` bucket. A reference to a missing group, or to
+ * a dynamic group type (e.g. `discord.channelAudience`) that is not resolvable from static config,
+ * contributes NO members and is dropped — fail-closed, matching the shared ingress kernel
+ * (`message-access/state.ts` `groupSenderEntries`).
+ *
+ * Non-`accessGroup:` entries pass through unchanged. Member entries are returned verbatim so the
+ * caller normalizes and matches them through the SAME matcher as direct entries — preserving
+ * id-first, non-spoofable matching (a member written as a display name matches only when the caller
+ * enables dangerous name-matching, exactly like a direct entry). No recursion: a nested
+ * `accessGroup:` inside a member list is returned as a literal, consistent with the shared kernel.
+ */
+export function expandAccessGroupAllowFromEntries(params: {
+  entries: readonly (string | number)[];
+  accessGroups?: AccessGroupsConfig | null;
+  channelId?: string | null;
+}): string[] {
+  const expanded: string[] = [];
+  for (const rawEntry of params.entries) {
+    const entry = String(rawEntry);
+    const groupName = parseAccessGroupAllowFromEntry(entry);
+    if (groupName == null) {
+      expanded.push(entry);
+      continue;
+    }
+    const group = params.accessGroups?.[groupName];
+    if (!group || group.type !== "message.senders") {
+      continue;
+    }
+    // `members["*"]` is the channel-scope key for entries SHARED across all channels — not an
+    // allowlist wildcard. A wildcard only arises if the operator lists `"*"` as a member VALUE,
+    // which is explicit and symmetric with a direct `allowFrom: ["*"]`.
+    const sharedMembers = group.members["*"] ?? [];
+    const channelMembers = params.channelId ? (group.members[params.channelId] ?? []) : [];
+    expanded.push(...sharedMembers, ...channelMembers);
+  }
+  return expanded;
 }
 
 export function mergeDmAllowFromSources(params: {

--- a/src/config/types.remoteclaw.ts
+++ b/src/config/types.remoteclaw.ts
@@ -2,6 +2,7 @@ import type {
   SilentReplyPolicyShape,
   SilentReplyRewriteShape,
 } from "../shared/silent-reply-policy.js";
+import type { AccessGroupsConfig } from "./types.access-groups.js";
 import type { AgentBinding, AgentsConfig } from "./types.agents.js";
 import type { AuthConfig } from "./types.auth.js";
 import type { DiagnosticsConfig, LoggingConfig, SessionConfig, WebConfig } from "./types.base.js";
@@ -115,6 +116,12 @@ export type RemoteClawConfig = {
   audio?: AudioConfig;
   messages?: MessagesConfig;
   commands?: CommandsConfig;
+  /**
+   * Named sender access groups referenceable from any channel allowlist via
+   * `accessGroup:<name>`. Static `message.senders` groups carry an operator-configured
+   * member set; dynamic groups (e.g. `discord.channelAudience`) resolve per platform.
+   */
+  accessGroups?: AccessGroupsConfig;
   session?: SessionConfig;
   web?: WebConfig;
   channels?: ChannelsConfig;

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -13,6 +13,7 @@ export type { ReplyPayload } from "../auto-reply/types.js";
 export type { ChatType } from "../channels/chat-type.js";
 export {
   ACCESS_GROUP_ALLOW_FROM_PREFIX,
+  expandAccessGroupAllowFromEntries,
   parseAccessGroupAllowFromEntry,
 } from "../channels/allow-from.js";
 export { resolveControlCommandGate } from "../channels/command-gating.js";


### PR DESCRIPTION
## Problem

Mattermost allowlist entries of the form `accessGroup:<name>` were never resolved to their member
users. Such an entry reached the admit seam as an inert literal — `resolveAllowlistMatchSimple`
lowercases it to `accessgroup:<name>` and does a literal set-membership check, and no real sender id
or username can equal that token. Result: an operator who configures an access group in a Mattermost
allowlist has **every member of that group silently denied** (fail-closed).

Both live admit paths were affected: slash-command auth (`authorizeMattermostCommandInvocation`) and
message/reaction ingress (`monitor.ts`) — both funnel through `isMattermostSenderAllowed`.

## Fix

Expand `accessGroup:<name>` references into their configured members **at the seam**
(`isMattermostSenderAllowed`), before the literal match — mirroring the shared ingress kernel's
`groupSenderEntries` (`src/channels/message-access/state.ts`):

- A new pure helper `expandAccessGroupAllowFromEntries({ entries, accessGroups, channelId })`
  (`src/channels/allow-from.ts`, exported via `plugin-sdk/mattermost`) expands only static
  `message.senders` groups — the shared `members["*"]` bucket plus the channel-scoped
  `members[channelId]` bucket.
- Missing groups, and dynamic types (`discord.channelAudience`) not resolvable from static config,
  contribute **no members** — the reference is dropped (fail-closed, unchanged). No recursion.
- Members flow through the **same id-first matcher** as direct entries, so a member written as a
  display name matches only when the operator has enabled dangerous name-matching. **No new spoof
  surface** is introduced.
- Adds the missing `accessGroups` field to `RemoteClawConfig` — the JSON schema already accepts it;
  only the hand-written type omitted it.

The `configured`/empty-allowlist checks upstream still run on the **raw** (unexpanded) lists, so an
`accessGroup:` token that expands to nothing keeps `configured=true, allowed=false` — it blocks, and
never flips a configured allowlist into an open one.

## Scope

Confined to the resolution seam. Policy gates, effective-list computation, and command gating are
untouched.

## Tests

- **Necropsy** (`extensions/mattermost/src/mattermost/monitor-auth.access-groups.test.ts`) — exercises
  the **real** matcher (no mock). Asserts a group member is admitted, a non-member is denied, a
  display-name spoof (name == a member's id, real id differs, name-matching off) is denied, and
  channel-scoped members stay scoped. Confirmed to **fail against the pre-fix corpse** (member wrongly
  denied) and pass after.
- **Unit** (`src/channels/allow-from.test.ts`) — the pure expansion helper: passthrough, shared +
  channel-scoped expansion, missing/dynamic drop, no-recursion, absent-config fail-closed.

## Verification

- `pnpm tsgo` clean · `pnpm lint` 0/0 · `oxfmt --check` clean · pre-commit `pnpm check` (incl. all
  fork-integrity gates: rebrand/lobster/css-drift/…) passed.
- Unit lane 16/16 · extensions lane: this suite + existing `monitor-auth.test.ts` 10/10 · full
  Mattermost suite 177/177 (no regression).
