### PR TITLE
fix(telegram): apply named-account group isolation on reaction + command surfaces (#3001)

### DIFF
--- a/extensions/telegram/src/bot-handlers.reaction-named-account.test.ts
+++ b/extensions/telegram/src/bot-handlers.reaction-named-account.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  enqueueSystemEventSpy,
+  getLoadConfigMock,
+  getOnHandler,
+  onSpy,
+} from "./bot.create-telegram-bot.test-harness.js";
+import { createTelegramBot } from "./bot.js";
+
+/**
+ * #3001 gap A — named-account group isolation on the REACTION surface.
+ *
+ * NECROPSY. Before the fix, the reaction handler resolved its target session with the bare
+ * `resolveAgentRoute()`, which fails OPEN to `fallback.legacyRoute` on a policy drop and never
+ * applied the named-account group gate the inbound MESSAGE path
+ * enforces (`shouldDropNamedAccountGroupMessage`, #2961 scenario C). A reaction added in a
+ * named-account group matched only via the operator catch-all — a non-`binding.*` tier —
+ * therefore routed a "reaction added" system event into the first agent's session: the same
+ * cross-account isolation loss #2961 closed on the message path.
+ *
+ * The first case is DISCRIMINATING: the catch-all supplies a route (`alpha`), so a scenario-D
+ * null-drop cannot account for the isolation — only the named-account gate can, and the
+ * pre-fix reaction path did not apply it, so it enqueued the event and this case FAILED. The
+ * reaction-auth layer does not save it: `TELEGRAM_EVENT_AUTH_RULES.reaction` sets
+ * `enforceGroupAllowlistAuthorization: false`, so an open group passes the auth layer and the
+ * drop must come from the named-account gate. The two controls pin the gate to named accounts
+ * (not the default account) and to non-binding tiers (an explicit binding still delivers).
+ */
+
+const GROUP_CHAT_ID = -1001234567890;
+const GROUP_PEER_ID = String(GROUP_CHAT_ID);
+
+const loadConfig = getLoadConfigMock();
+
+/** Two agents (no sole-agent promotion) + a catch-all: the route RESOLVES on a non-binding tier. */
+const catchAllCfg = {
+  agents: { list: [{ id: "alpha" }, { id: "beta" }] },
+  routing: { unmatched: { agent: "alpha" } },
+  channels: { telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" } },
+  messages: { groupChat: { mentionPatterns: [] } },
+};
+
+/** Same, PLUS an explicit binding of the named account's group -> a `binding.*` tier. */
+const boundNamedAccountCfg = {
+  ...catchAllCfg,
+  bindings: [
+    {
+      agentId: "beta",
+      match: { channel: "telegram", accountId: "work", peer: { kind: "group", id: GROUP_PEER_ID } },
+    },
+  ],
+};
+
+function groupReaction() {
+  return {
+    chat: { id: GROUP_CHAT_ID, type: "supergroup", title: "Test Group" },
+    message_id: 42,
+    user: { id: 7, first_name: "Alice", username: "alice" },
+    date: 1_700_000_000,
+    old_reaction: [],
+    new_reaction: [{ type: "emoji", emoji: "👍" }],
+  };
+}
+
+async function fireGroupReaction(params: { cfg: unknown; accountId?: string }) {
+  onSpy.mockClear();
+  enqueueSystemEventSpy.mockClear();
+  loadConfig.mockReturnValue(params.cfg);
+  createTelegramBot({ token: "tok", accountId: params.accountId });
+  const handler = getOnHandler("message_reaction") as (
+    ctx: Record<string, unknown>,
+  ) => Promise<void>;
+  await handler({ update: { update_id: 900 }, messageReaction: groupReaction() });
+}
+
+describe("#3001 reaction surface — named-account group isolation", () => {
+  it("drops a named-account group reaction that only matched via the catch-all", async () => {
+    // DISCRIMINATING necropsy: the route resolves (catch-all -> alpha, `unmatched.catchAll`),
+    // so scenario-D does NOT apply — only the named-account gate drops it. FAILS pre-fix.
+    await fireGroupReaction({ cfg: catchAllCfg, accountId: "work" });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
+  it("delivers the same catch-all group reaction for the default account", async () => {
+    // Control: pins the gate to NAMED accounts only. Also the canary that the open group
+    // passes the reaction-auth layer, so the discriminating drop above is the gate, not auth.
+    await fireGroupReaction({ cfg: catchAllCfg, accountId: "default" });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers a named-account group reaction that matched an explicit binding", async () => {
+    // Control: pins the gate to NON-binding tiers — an operator who binds the named account's
+    // group explicitly still gets their reaction traffic.
+    await fireGroupReaction({ cfg: boundNamedAccountCfg, accountId: "work" });
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/telegram/src/bot-handlers.ts
+++ b/extensions/telegram/src/bot-handlers.ts
@@ -16,7 +16,6 @@ import { danger, logVerbose, warn } from "../../../src/globals.js";
 import { enqueueSystemEvent } from "../../../src/infra/system-events.js";
 import { MediaFetchError } from "../../../src/media/fetch.js";
 import { readChannelAllowFromStore } from "../../../src/pairing/pairing-store.js";
-import { resolveAgentRoute } from "../../../src/routing/resolve-route.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   isSenderAllowed,
@@ -33,12 +32,14 @@ import {
 import { resolveMedia } from "./bot/delivery.js";
 import {
   getTelegramTextParts,
-  buildTelegramGroupPeerId,
-  buildTelegramParentPeer,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
+import {
+  resolveTelegramConversationRoute,
+  shouldDropNamedAccountGroupMessage,
+} from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import {
   evaluateTelegramGroupBaseAccess,
@@ -644,16 +645,34 @@ export const registerTelegramHandlers = ({
       const resolvedThreadId = isForum
         ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
         : undefined;
-      const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
-      const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
-      // Fresh config for bindings lookup; other routing inputs are payload-derived.
-      const route = resolveAgentRoute({
+      // Route reactions through the SAME policy-aware resolver the inbound message path uses
+      // (#3001 gap A). The bare resolveAgentRoute() this replaced failed OPEN to
+      // fallback.legacyRoute on a policy drop and never applied the named-account group gate,
+      // so a reaction in a named-account group matched via a non-binding tier leaked a
+      // "reaction added" system event into the first agent's session. Fresh config for
+      // bindings lookup; other routing inputs are payload-derived.
+      const conversationRoute = resolveTelegramConversationRoute({
         cfg: loadConfig(),
-        channel: "telegram",
         accountId,
-        peer: { kind: isGroup ? "group" : "direct", id: peerId },
-        parentPeer,
+        chatId,
+        isGroup,
+        resolvedThreadId,
+        senderId,
       });
+      if (!conversationRoute) {
+        // #2961 scenario D — routing.unmatched drop policy: nothing matched, no sole agent,
+        // no operator catch-all. Telemetry already fired inside handleUnmatched().
+        return;
+      }
+      const route = conversationRoute.route;
+      if (isGroup && shouldDropNamedAccountGroupMessage(route)) {
+        // #2961 scenario C — a named-account group route on a non-binding tier is not this
+        // account's traffic; drop the reaction rather than route it cross-account.
+        logVerbose(
+          `telegram: dropped reaction in named-account group without an explicit binding (chat=${chatId})`,
+        );
+        return;
+      }
       const sessionKey = route.sessionKey;
 
       // Enqueue system event for each added reaction.

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -45,7 +45,6 @@ import {
   type CanonicalInboundMessageHookContext,
 } from "../../../src/hooks/message-hook-mappers.js";
 import { recordChannelActivity } from "../../../src/infra/channel-activity.js";
-import { DEFAULT_ACCOUNT_ID, type ResolvedAgentRoute } from "../../../src/routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../src/routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../src/security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -72,7 +71,10 @@ import {
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { StickerMetadata, TelegramContext } from "./bot/types.js";
-import { resolveTelegramConversationRoute } from "./conversation-route.js";
+import {
+  resolveTelegramConversationRoute,
+  shouldDropNamedAccountGroupMessage,
+} from "./conversation-route.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { evaluateTelegramGroupBaseAccess } from "./group-access.js";
@@ -135,35 +137,6 @@ export type BuildTelegramMessageContextParams = {
   /** Global (per-account) handler for sendChatAction 401 backoff (#27092). */
   sendChatActionHandler: import("./sendchataction-401-backoff.js").TelegramSendChatActionHandler;
 };
-
-/**
- * #2961 scenario C — named-account group isolation (cross-account authorization).
- *
- * A non-default ("named") account is an explicitly configured, distinct bot identity, so
- * per #2961 it "must have an explicit binding to handle group traffic".
- *
- * Upstream keyed this gate on `matchedBy === "default"` — the phantom default-agent tier
- * this fork DELETED (see `src/routing/resolve-route.ts`: sole-agent promotion exists
- * "without reintroducing the phantom 'default' agent fallback"). A verbatim port would be
- * dead code that can never fire, because no fork tier is ever named "default". The
- * fork-native equivalent is the tier CLASS: a route that did not match an explicit
- * `binding.*` tier only landed on this agent via an operator catch-all
- * (`unmatched.catchAll`), sole-agent promotion (`fallback.soleAgent`), or the legacy
- * fail-open (`fallback.legacyRoute`) — none of which is an operator declaring "this named
- * account handles this group".
- *
- * This gate is DISTINCT from the scenario-D drop rather than a restatement of it: D fires
- * when the route resolves to NOTHING (the resolver returned null); C fires when the route
- * resolves perfectly well, but on a non-binding tier. A named-account group message under
- * a configured catch-all is delivered past D and dropped only here.
- *
- * DMs are deliberately not gated — the isolation boundary #2961 names is group traffic.
- */
-function shouldDropNamedAccountGroupMessage(route: ResolvedAgentRoute): boolean {
-  const isNamedAccount = route.accountId !== DEFAULT_ACCOUNT_ID;
-  const matchedExplicitBinding = route.matchedBy.startsWith("binding.");
-  return isNamedAccount && !matchedExplicitBinding;
-}
 
 /**
  * Resolve `ingest` for a group, honoring the `groups["*"]` wildcard default so a specific

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -61,7 +61,10 @@ import {
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
-import { resolveTelegramConversationRoute } from "./conversation-route.js";
+import {
+  resolveTelegramConversationRoute,
+  shouldDropNamedAccountGroupMessage,
+} from "./conversation-route.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
@@ -468,6 +471,16 @@ export const registerTelegramNativeCommands = ({
       return null;
     }
     let { route, configuredBinding } = conversationRoute;
+    if (isGroup && shouldDropNamedAccountGroupMessage(route)) {
+      // #2961 scenario C parity (#3001 gap B): a named-account group route on a non-binding
+      // tier is not this account's traffic. Commands are account-scoped so this is not a
+      // cross-account leak, but the isolation posture is applied consistently with the inbound
+      // message (bot-message-context.ts) and reaction (bot-handlers.ts) paths.
+      logVerbose(
+        `telegram native command: dropped named-account group command without an explicit binding (chat=${chatId})`,
+      );
+      return null;
+    }
     if (configuredBinding) {
       const ensured = await ensureConfiguredAcpRouteReady({
         cfg,

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -4,6 +4,7 @@ import type { RemoteClawConfig } from "../../../src/config/config.js";
 import { logVerbose } from "../../../src/globals.js";
 import { getSessionBindingService } from "../../../src/infra/outbound/session-binding-service.js";
 import {
+  DEFAULT_ACCOUNT_ID,
   buildAgentSessionKey,
   deriveLastRoutePolicy,
   pickFirstExistingAgentId,
@@ -19,6 +20,39 @@ import {
   buildTelegramParentPeer,
   resolveTelegramDirectPeerId,
 } from "./bot/helpers.js";
+
+/**
+ * #2961 scenario C — named-account group isolation (cross-account authorization).
+ *
+ * A non-default ("named") account is an explicitly configured, distinct bot identity, so
+ * per #2961 it "must have an explicit binding to handle group traffic".
+ *
+ * Upstream keyed this gate on `matchedBy === "default"` — the phantom default-agent tier
+ * this fork DELETED (see `src/routing/resolve-route.ts`: sole-agent promotion exists
+ * "without reintroducing the phantom 'default' agent fallback"). A verbatim port would be
+ * dead code that can never fire, because no fork tier is ever named "default". The
+ * fork-native equivalent is the tier CLASS: a route that did not match an explicit
+ * `binding.*` tier only landed on this agent via an operator catch-all
+ * (`unmatched.catchAll`), sole-agent promotion (`fallback.soleAgent`), or the legacy
+ * fail-open (`fallback.legacyRoute`) — none of which is an operator declaring "this named
+ * account handles this group".
+ *
+ * This gate is DISTINCT from the scenario-D drop rather than a restatement of it: D fires
+ * when the route resolves to NOTHING (the resolver returned null); C fires when the route
+ * resolves perfectly well, but on a non-binding tier. A named-account group message under
+ * a configured catch-all is delivered past D and dropped only here.
+ *
+ * DMs are deliberately not gated — the isolation boundary #2961 names is group traffic.
+ *
+ * Shared by the inbound message path (`bot-message-context.ts`), the reaction handler
+ * (`bot-handlers.ts`, #3001 gap A), and the native-command path (`bot-native-commands.ts`,
+ * #3001 gap B) so the isolation posture stays consistent across every group-traffic surface.
+ */
+export function shouldDropNamedAccountGroupMessage(route: ResolvedAgentRoute): boolean {
+  const isNamedAccount = route.accountId !== DEFAULT_ACCOUNT_ID;
+  const matchedExplicitBinding = route.matchedBy.startsWith("binding.");
+  return isNamedAccount && !matchedExplicitBinding;
+}
 
 export function resolveTelegramConversationRoute(params: {
   cfg: RemoteClawConfig;


### PR DESCRIPTION
## Summary

Extends #2961's named-account **group** routing isolation to two sibling Telegram surfaces that still bypassed it. #2961 hardened the inbound **message** path to drop named-account group traffic matched only on a non-`binding.*` tier (scenario C) after a fail-closed resolve (scenario D). The reaction and native-command surfaces did not receive the same treatment.

## A — Reaction handler (the real fail-open) — closed

`extensions/telegram/src/bot-handlers.ts`, `bot.on("message_reaction", …)` resolved its target session via the **bare `resolveAgentRoute`**, which:

- **fails OPEN** to `fallback.legacyRoute` on a policy drop (the exact behavior #2961 removed on the message path), and
- never applied `shouldDropNamedAccountGroupMessage`.

So a reaction added in a **named-account group** matched via a non-`binding.*` tier routed a "reaction added" system event into the first agent's session — the same cross-account isolation loss #2961 closed, on a lower-value surface. The reaction-auth layer does **not** cover this: `TELEGRAM_EVENT_AUTH_RULES.reaction` sets `enforceGroupAllowlistAuthorization: false`, so an open group passes it and the drop must come from the named-account gate.

**Fix:** route reactions through the policy-aware `resolveTelegramConversationRoute` (fail-closed null-drop) and apply `shouldDropNamedAccountGroupMessage`, mirroring the message path.

## B — Native-command path (parity) — closed

`extensions/telegram/src/bot-native-commands.ts` already routed through `resolveTelegramConversationRoute` + null-drop (not fail-open), but omitted the named-account gate. Commands are account-scoped, so this was **not** a cross-account leak — the gate is added for a consistent isolation posture across every group surface.

## Shared home

`shouldDropNamedAccountGroupMessage` is centralized (exported) in `conversation-route.ts` — the shared policy-aware routing module — as the single source of truth for all three group-traffic surfaces (message, reaction, command). Predicate body unchanged.

## Discriminating necropsy test

`extensions/telegram/src/bot-handlers.reaction-named-account.test.ts` (new; not quarantined → runs in the `test-extensions` CI lane). Its first case sends a named-account group reaction under an operator catch-all: the route **resolves** (catch-all → `alpha`, a non-`binding.*` tier), so a scenario-D null-drop cannot account for the isolation — only the named-account gate can. It **fails against the pre-fix reaction path** (the event was wrongly enqueued) and **passes after**. Two controls pin the gate to named-accounts-only (the default account still delivers) and non-binding-tiers-only (an explicit binding still delivers).

## Safety / blast radius

Only adds drop paths on group traffic that was previously mis-routed. Default-account and explicitly-bound group traffic are never dropped; DM reactions are never gated (the isolation boundary #2961 names is group traffic). One intended nuance: a named account bound **only** at thread/topic level now drops reactions, because Telegram omits `message_thread_id` on `MessageReactionUpdated` — this errs toward *drop*, replacing a pre-fix cross-account leak.

## Verification

- `pnpm check` (oxfmt + oxlint + tsgo + fork-integrity gates) — green
- Necropsy: fails pre-fix (1 failed / 2 passed), passes post-fix (3 passed)
- No regression: reaction (`bot.test.ts`), scenario-C/D + named-account-dm, and command-path suites pass

Closes #3001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
