### PR TITLE
fix(net): honor NO_PROXY and managed-proxy CA on feishu + discord WS proxy agents (#2995)

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -7,6 +7,7 @@ import WebSocket from "ws";
 import type { DiscordAccountConfig } from "../../../../src/config/types.js";
 import { danger } from "../../../../src/globals.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
+import { resolveActiveManagedProxyTlsOptions } from "../../../../src/infra/net/proxy/managed-proxy-undici.js";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
 import { validateDiscordProxyUrl } from "../proxy-fetch.js";
 import { normalizeDiscordGatewayInfoTimeoutMs } from "./timeouts.js";
@@ -304,7 +305,14 @@ export function createDiscordGatewayPlugin(params: {
     // The bot token rides this leg too — on the WS IDENTIFY and on the /gateway/bot metadata
     // fetch — so the proxy is held to the same loopback-only bar as the REST path.
     validateDiscordProxyUrl(proxy);
-    const wsAgent = new HttpsProxyAgent<string>(proxy);
+    // An intercepting managed proxy terminates TLS with its own CA; mirror the REST
+    // path (createHttp1ProxyAgent → addActiveManagedProxyTlsOptions) so the token-bearing
+    // gateway WS handshake trusts it. No-op when the managed proxy is inactive or does not
+    // match this proxy URL, so cert validation is unchanged for non-managed proxies. The
+    // config proxy is loopback-only (validateDiscordProxyUrl), so — like the REST path — it
+    // is not subject to NO_PROXY (that governs the env-proxy path, not an explicit override).
+    const wsProxyCa = resolveActiveManagedProxyTlsOptions({ proxyUrl: proxy })?.ca;
+    const wsAgent = new HttpsProxyAgent<string>(proxy, wsProxyCa ? { ca: wsProxyCa } : undefined);
     const fetchAgent = new ProxyAgent(proxy);
 
     params.runtime.log?.("discord: gateway proxy enabled");

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -60,11 +63,13 @@ const {
   class HttpsProxyAgent {
     static lastCreated: HttpsProxyAgent | undefined;
     proxyUrl: string;
-    constructor(proxyUrl: string) {
+    options: unknown;
+    constructor(proxyUrl: string, options?: unknown) {
       if (proxyUrl === "bad-proxy") {
         throw new Error("bad proxy");
       }
       this.proxyUrl = proxyUrl;
+      this.options = options;
       HttpsProxyAgent.lastCreated = this;
       wsProxyAgentSpy(proxyUrl);
     }
@@ -114,6 +119,16 @@ vi.mock("undici", () => ({
 vi.mock("ws", () => ({
   default: MockWebSocket,
 }));
+
+const tempDirs: string[] = [];
+
+function writeTempCa(contents: string): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "remoteclaw-discord-gateway-proxy-ca-"));
+  tempDirs.push(dir);
+  const caFile = path.join(dir, "proxy-ca.pem");
+  writeFileSync(caFile, contents, "utf8");
+  return caFile;
+}
 
 describe("createDiscordGatewayPlugin", () => {
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;
@@ -206,6 +221,9 @@ describe("createDiscordGatewayPlugin", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("uses safe gateway metadata lookup without proxy", async () => {
@@ -278,6 +296,58 @@ describe("createDiscordGatewayPlugin", () => {
       expect.objectContaining({ agent: getLastAgent() }),
     );
     expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  // #2995: the gateway WS carries the bot token, so when a managed proxy that matches the
+  // configured (loopback) proxy is active, the WS agent must trust its CA — mirroring the REST
+  // path (createHttp1ProxyAgent → addActiveManagedProxyTlsOptions).
+  it("applies the managed proxy CA to the gateway WebSocket agent when the managed proxy is active", async () => {
+    // The managed CA only applies to a TLS-terminating (https) proxy, so the loopback proxy is
+    // https here (proxy-tls.ts isHttpsProxyUrl gate).
+    const caFile = writeTempCa("discord-gateway-managed-proxy-ca");
+    vi.stubEnv("HTTPS_PROXY", "https://127.0.0.1:8443");
+    vi.stubEnv("https_proxy", "https://127.0.0.1:8443");
+    vi.stubEnv("REMOTECLAW_PROXY_ACTIVE", "1");
+    vi.stubEnv("REMOTECLAW_PROXY_CA_FILE", caFile);
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "https://127.0.0.1:8443" },
+      runtime,
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("https://127.0.0.1:8443");
+    expect((getLastAgent() as { options?: unknown } | undefined)?.options).toEqual({
+      ca: "discord-gateway-managed-proxy-ca",
+    });
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  // #2995 + #2960: no managed proxy active → no CA override, so cert validation is unchanged for
+  // a non-managed proxy.
+  it("builds the gateway WebSocket agent without a CA when no managed proxy is active", async () => {
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("REMOTECLAW_PROXY_ACTIVE", "");
+    vi.stubEnv("REMOTECLAW_PROXY_CA_FILE", "");
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://127.0.0.1:8080" },
+      runtime,
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://127.0.0.1:8080");
+    expect((getLastAgent() as { options?: unknown } | undefined)?.options).toBeUndefined();
     expect(runtime.error).not.toHaveBeenCalled();
   });
 

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
 import type { ResolvedFeishuAccount } from "./types.js";
@@ -32,7 +35,16 @@ const mockBaseHttpInstance = vi.hoisted(() => ({
   head: vi.fn().mockResolvedValue({}),
   options: vi.fn().mockResolvedValue({}),
 }));
-const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
+const proxyEnvKeys = [
+  "https_proxy",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "HTTP_PROXY",
+  "no_proxy",
+  "NO_PROXY",
+  "REMOTECLAW_PROXY_ACTIVE",
+  "REMOTECLAW_PROXY_CA_FILE",
+] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];
 const registerFeishuDocToolsMock = vi.hoisted(() => vi.fn());
 const registerFeishuChatToolsMock = vi.hoisted(() => vi.fn());
@@ -134,10 +146,23 @@ function firstWsClientOptions(): { agent?: unknown; wsConfig?: unknown } {
   return { agent: options.agent, wsConfig: options.wsConfig };
 }
 
+const tempDirs: string[] = [];
+
+function writeTempCa(contents: string): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "remoteclaw-feishu-ws-proxy-ca-"));
+  tempDirs.push(dir);
+  const caFile = path.join(dir, "proxy-ca.pem");
+  writeFileSync(caFile, contents, "utf8");
+  return caFile;
+}
+
 beforeAll(async () => {
   vi.doMock("@larksuiteoapi/node-sdk", () => ({
     AppType: { SelfBuild: "self" },
-    Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
+    // Numeric to match the real SDK enum (Domain.Feishu === 0, Domain.Lark === 1). A
+    // regression that stringifies resolveDomain() for the NO_PROXY target — instead of the
+    // URL-returning resolveDomainUrl() — would yield "0"/"1" and fail the NO_PROXY test below.
+    Domain: { Feishu: 0, Lark: 1 },
     LoggerLevel: { info: "info" },
     Client: clientCtorMock,
     WSClient: wsClientCtorMock,
@@ -169,10 +194,7 @@ beforeEach(() => {
   setFeishuClientRuntimeForTest({
     sdk: {
       AppType: { SelfBuild: "self" } as never,
-      Domain: {
-        Feishu: "https://open.feishu.cn",
-        Lark: "https://open.larksuite.com",
-      } as never,
+      Domain: { Feishu: 0, Lark: 1 } as never,
       LoggerLevel: { info: "info" } as never,
       Client: clientCtorMock as never,
       WSClient: wsClientCtorMock as never,
@@ -186,6 +208,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
   for (const key of proxyEnvKeys) {
     const value = priorProxyEnv[key];
     if (value === undefined) {
@@ -393,6 +418,46 @@ describe("createFeishuWSClient proxy handling", () => {
     await createFeishuWSClient(baseAccount);
 
     expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    const options = firstWsClientOptions();
+    expect(options.agent).toEqual({ proxied: true });
+  });
+
+  it("does not set a ws proxy agent when NO_PROXY excludes the Feishu domain", async () => {
+    process.env.https_proxy = "http://proxy.example:8001";
+    // baseAccount.domain is "feishu" → resolveDomainUrl → https://open.feishu.cn.
+    process.env.NO_PROXY = "open.feishu.cn";
+
+    await createFeishuWSClient(baseAccount);
+
+    expect(proxyAgentCtorMock).not.toHaveBeenCalled();
+    const options = firstWsClientOptions();
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("applies the managed proxy CA to the ws proxy agent when the managed proxy is active", async () => {
+    const caFile = writeTempCa("feishu-ws-managed-proxy-ca");
+    process.env.https_proxy = "https://127.0.0.1:8443";
+    process.env.HTTPS_PROXY = "https://127.0.0.1:8443";
+    process.env.REMOTECLAW_PROXY_ACTIVE = "1";
+    process.env.REMOTECLAW_PROXY_CA_FILE = caFile;
+
+    await createFeishuWSClient(baseAccount);
+
+    expect(proxyAgentCtorMock).toHaveBeenCalledWith("https://127.0.0.1:8443", {
+      ca: "feishu-ws-managed-proxy-ca",
+    });
+    const options = firstWsClientOptions();
+    expect(options.agent).toEqual({ proxied: true });
+  });
+
+  it("does not apply a CA when no managed proxy is active", async () => {
+    process.env.https_proxy = "http://proxy.example:8001";
+
+    await createFeishuWSClient(baseAccount);
+
+    // Second constructor arg is undefined → no CA override, so cert validation for a
+    // non-managed proxy is unchanged (#2960 no-op).
+    expect(proxyAgentCtorMock).toHaveBeenCalledWith("http://proxy.example:8001", undefined);
     const options = firstWsClientOptions();
     expect(options.agent).toEqual({ proxied: true });
   });

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -1,5 +1,7 @@
 import * as Lark from "@larksuiteoapi/node-sdk";
 import { HttpsProxyAgent } from "https-proxy-agent";
+import { matchesNoProxy, resolveEnvHttpProxyUrl } from "../../../src/infra/net/proxy-env.js";
+import { resolveActiveManagedProxyTlsOptions } from "../../../src/infra/net/proxy/managed-proxy-undici.js";
 import type { FeishuConfig, FeishuDomain, ResolvedFeishuAccount } from "./types.js";
 
 type FeishuClientSdk = Pick<
@@ -36,14 +38,32 @@ type FeishuHttpInstanceLike = Pick<
   "request" | "get" | "post" | "put" | "patch" | "delete" | "head" | "options"
 >;
 
-function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
-  const proxyUrl =
-    process.env.https_proxy ||
-    process.env.HTTPS_PROXY ||
-    process.env.http_proxy ||
-    process.env.HTTP_PROXY;
-  if (!proxyUrl) return undefined;
-  return new httpsProxyAgentCtor(proxyUrl);
+/**
+ * Build an HTTPS proxy agent from the standard proxy env vars for the Feishu
+ * long-connection WebSocket. Mirrors the Slack path (`resolveSlackProxyAgent`):
+ * honor NO_PROXY for the target Feishu/Lark host, and apply the active
+ * managed-proxy CA so a TLS-terminating managed proxy is trusted.
+ *
+ * `targetUrl` is the resolved Feishu/Lark domain the long connection reaches, so
+ * an operator can exclude it via NO_PROXY exactly as they would any other host.
+ *
+ * Returns `undefined` when no proxy is configured, when NO_PROXY excludes the
+ * target host, or when the proxy URL is unusable — each of which leaves Feishu on
+ * a direct connection, matching the behavior before a proxy was configured.
+ */
+function getWsProxyAgent(targetUrl: string): HttpsProxyAgent<string> | undefined {
+  try {
+    const proxyUrl = resolveEnvHttpProxyUrl("https");
+    if (!proxyUrl || matchesNoProxy(targetUrl)) {
+      return undefined;
+    }
+    // An intercepting managed proxy terminates TLS with its own CA; without it
+    // the long-connection handshake fails certificate validation.
+    const ca = resolveActiveManagedProxyTlsOptions({ proxyUrl })?.ca;
+    return new httpsProxyAgentCtor(proxyUrl, ca ? { ca } : undefined);
+  } catch {
+    return undefined;
+  }
 }
 
 // Multi-account client cache
@@ -61,6 +81,24 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
   }
   if (domain === "feishu" || !domain) {
     return feishuClientSdk.Domain.Feishu;
+  }
+  return domain.replace(/\/+$/, ""); // Custom URL for private deployment
+}
+
+/**
+ * The egress URL the Feishu/Lark long connection reaches, used as the NO_PROXY
+ * match target. NOT `resolveDomain`: that returns the Lark SDK's `Domain` enum,
+ * which is NUMERIC at runtime (`Domain.Feishu === 0`, `Domain.Lark === 1`), so
+ * `String(resolveDomain(...))` yields "0"/"1" — not a URL — and NO_PROXY would
+ * never match. The base URLs mirror the SDK's own domain mapping
+ * (`@larksuiteoapi/node-sdk`: Feishu → open.feishu.cn, Lark → open.larksuite.com).
+ */
+function resolveDomainUrl(domain: FeishuDomain | undefined): string {
+  if (domain === "lark") {
+    return "https://open.larksuite.com";
+  }
+  if (domain === "feishu" || !domain) {
+    return "https://open.feishu.cn";
   }
   return domain.replace(/\/+$/, ""); // Custom URL for private deployment
 }
@@ -186,7 +224,7 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
     throw new Error(`Feishu credentials not configured for account "${accountId}"`);
   }
 
-  const agent = getWsProxyAgent();
+  const agent = getWsProxyAgent(resolveDomainUrl(domain));
   return new feishuClientSdk.WSClient({
     appId,
     appSecret,


### PR DESCRIPTION
## Summary

Closes #2995. The **feishu** long-connection and **discord** gateway WebSocket proxy agents built an `HttpsProxyAgent` from the proxy URL **without** the egress hardening the Slack path (`resolveSlackProxyAgent`) already applies — they did not honor `NO_PROXY` and did not apply the active managed-proxy CA. Both WS legs carry bot credentials (discord `IDENTIFY` carries the bot token; feishu long-connection carries app auth), so this aligns them with the same `NO_PROXY` + managed-CA contract the Slack Web API / Socket Mode and the shared undici HTTP runtime already honor (the CA helper landed in #2984 / #3007).

Consumes the `resolveActiveManagedProxyTlsOptions(...)` / `matchesNoProxy(...)` shared helpers — no second CA/NO_PROXY implementation is forked.

## Changes

### feishu — `extensions/feishu/src/client.ts` (`getWsProxyAgent`)
Proxy is **env-derived**. Now mirrors `resolveSlackProxyAgent`:
- resolves the proxy via the shared `resolveEnvHttpProxyUrl("https")`,
- returns `undefined` (direct connection) when `NO_PROXY` excludes the resolved Feishu/Lark host,
- applies `resolveActiveManagedProxyTlsOptions({ proxyUrl })?.ca` to the agent's TLS options.

The `NO_PROXY` target is derived by a new `resolveDomainUrl()` helper. **This is load-bearing:** the Lark SDK `Domain` enum is *numeric at runtime* (`Domain.Feishu === 0`), so `String(resolveDomain(domain))` yields `"0"`/`"1"` — not a URL — and `matchesNoProxy` would silently never match (a dead check for the default domains). `resolveDomainUrl` returns the real egress URL (`https://open.feishu.cn` / `https://open.larksuite.com`, matching the SDK's own `formatDomain` mapping), independent of the enum. The test SDK mock is switched to the real numeric enum so this can't regress to a vacuous string-mock pass.

### discord — `extensions/discord/src/monitor/gateway-plugin.ts` (gateway `wsAgent`)
Proxy is **config-derived** (`discordConfig.proxy`, loopback-only, SSRF-validated). Now applies `resolveActiveManagedProxyTlsOptions({ proxyUrl: proxy })?.ca` to the gateway `wsAgent`, mirroring discord's own REST path (`rest-fetch.ts` → `createHttp1ProxyAgent` → `addActiveManagedProxyTlsOptions`). The SSRF `validateDiscordProxyUrl` guard still runs first (unchanged).

## ⚠️ Keystone decision — flagged for security review

The issue text suggested applying `NO_PROXY` to **both** channels via "the shared env helper." Grounding against live source shows that is a **false premise for discord**: its WS proxy is **not** env-derived — it is an explicit, loopback-only `discordConfig.proxy`. This PR therefore applies:

- **feishu → `NO_PROXY` + managed CA** (env-derived; `https-proxy-agent` does not honor `NO_PROXY` natively, so an explicit `matchesNoProxy` is the correct mirror), and
- **discord → managed CA only** (no `NO_PROXY`).

Rationale for the discord divergence (please confirm during review):
1. Discord's **own REST path** does **not** `NO_PROXY`-gate the config proxy (`rest-fetch.ts` sends it straight through `createHttp1ProxyAgent`; only the *env*-proxy REST branch honors `NO_PROXY`, natively via undici's `EnvHttpProxyAgent`). Adding `NO_PROXY` to the WS would make **REST proxied but WS bypassed** — an internal inconsistency.
2. It would let a **global `NO_PROXY`** env var silently disable an **explicit per-channel** loopback proxy config (a footgun).

This mirrors discord's HTTP-path derivation and keeps REST/WS consistent. If reviewers prefer `NO_PROXY` on discord too, it's a small follow-up — surfaced here so the decision is explicit, not silent.

## Safety (managed CA does not weaken validation for non-managed hosts)

`resolveActiveManagedProxyTlsOptions` returns `undefined` (→ no `{ ca }`, so default cert validation) unless a managed proxy is **active AND its URL exactly matches** the proxy URL AND the proxy is `https:` (double gate: `managed-proxy-undici.ts` URL match + `proxy-tls.ts` `isHttpsProxyUrl`). This is the #2960 dispatcher-preservation no-op — inactive managed proxy ⇒ nothing changes.

## Tests (discriminating, both channels)

- **feishu**: `NO_PROXY` excludes the Feishu domain → no agent; managed CA applied when active; no CA when inactive (2nd ctor arg `undefined`).
- **discord**: managed CA applied to the gateway `wsAgent` when active; no CA when inactive; SSRF still rejects remote proxies (pre-existing test preserved).

## Verification

- `pnpm build` ✓ · `pnpm tsgo` ✓ (0 errors) · `pnpm check` ✓ (lint + lobster-leak + css-drift) · fork gates ✓ (zombie-import, throwing-stub-callers, stub-debt)
- Targeted suites green: `extensions/feishu/src/client.test.ts` + `extensions/discord/src/monitor/provider.proxy.test.ts` — 30/30. Affected runtime-caller tests (feishu `monitor.startup` / `monitor.webhook-security`, discord `provider` / `provider.unhandled-rejection`) — green, no regression.
- An independent fresh-context adversarial pass caught the numeric-enum `NO_PROXY` defect (now fixed) and re-verified CLEAN with a counterfactual (reverting the fix fails the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
