### PR TITLE
fix(deps): correct pi-tui scope in dependency-ownership.json (#3023)

### DIFF
--- a/scripts/lib/dependency-ownership.json
+++ b/scripts/lib/dependency-ownership.json
@@ -16,7 +16,7 @@
       "class": "core-runtime",
       "risk": ["native", "terminal"]
     },
-    "@earendil-works/pi-tui": {
+    "@mariozechner/pi-tui": {
       "owner": "capability:tui-pi",
       "class": "tui-runtime",
       "risk": ["tui-runtime"]


### PR DESCRIPTION
Refs #3023 — addresses **acceptance item (1) only**. Item (2) is deliberately left open (see below), so this intentionally does **not** use a closing keyword.

## What

`scripts/lib/dependency-ownership.json` keyed its pi-tui entry as `@earendil-works/pi-tui`, but the installed dependency is `@mariozechner/pi-tui` (`package.json:394`). One-line key rename; metadata values untouched.

```diff
-    "@earendil-works/pi-tui": {
+    "@mariozechner/pi-tui": {
       "owner": "capability:tui-pi",
       "class": "tui-runtime",
       "risk": ["tui-runtime"]
```

The package name was verified against `package.json` directly rather than taken from the issue body.

## Why it mattered

Consumers match on package name (`ownershipFor(dependencyOwnership, name)`), so the ownership/risk metadata never attached to the real package. The single stale key produced **two** symptoms at once: a false `ownershipGaps` entry for the real package *and* a false `staleOwnershipRecords` entry for the phantom one.

## Evidence

Verified empirically against **both** manifest consumers, with identical results:

| Signal | `dependency-ownership-surface-report.mjs` | `sbom-risk-report.mjs` |
|---|---|---|
| `ownershipGaps` | 36 → 35 (removed exactly `@mariozechner/pi-tui`) | 36 → 35 (same) |
| `staleOwnershipRecords` | 12 → 11 (removed exactly `@earendil-works/pi-tui`) | 12 → 11 (same) |
| added to either list | `[]` | `[]` |
| `rootOwnershipRecordCount` | 35 → 35 | 35 → 35 |
| pi-tui `owner` | `null` → `"capability:tui-pi"` | `null` → `"capability:tui-pi"` |

`rootOwnershipRecordCount` holding at 35 with `added: []` on every list is the complement invariant — it proves this is a pure rename, not an add-plus-remove that could have disturbed other entries.

The other two scripts named in the issue are unaffected, and worth correcting for the record:
- `root-dependency-ownership-audit.mjs` does **not** read the manifest at all (it derives ownership from `package.json` plus a source scan).
- `generate-dependency-release-evidence.mjs` consumes the *report outputs* by filename, not the manifest.

Gates: `pnpm check` (format + typecheck + lint + fork-integrity lint gates) — exit 0.

## Scope

Item (2) — migrating off the deprecated `@mariozechner/pi-tui@0.55.0` to `@earendil-works/pi-tui` — is a maintainer decision affecting ~19 files under `src/tui/`, and is **out of scope here**. The issue stays open for it.

- [x] (1) `dependency-ownership.json` names `@mariozechner/pi-tui`, matching the actual `package.json` dependency
- [ ] (2) Maintainer decision on migrating off deprecated `@mariozechner/pi-tui@0.55.0` — still open

Note: `@earendil-works/pi-coding-agent` in `scripts/control-ui-i18n.ts:92` is a **different** package and is correctly untouched.

## Observations (not actioned — each needs a maintainer call)

Surfacing these because they explain how this drift survived, but fixing either would require decisions on ~46 unrelated entries:

1. **The manifest carries substantial other drift**: 35 remaining ownership gaps and 11 remaining stale records after this fix. Not touched — each needs its own judgement.
2. **Nothing runs these scripts.** No `package.json` script, CI workflow, or test references any of the four. The manifest already ships its own drift detectors (`ownershipGaps` / `staleOwnershipRecords`, with `--check` exit-1 modes) — they simply never run, which is why this went unnoticed. Wiring `--check` into CI would fail immediately on the 35 pre-existing gaps, so it is a real cleanup project rather than a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)