### PR TITLE
fix(ui): rebrand Control UI service-worker build-id env sites desynced by v5.28 sync (#3024)

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -91,7 +91,7 @@ export const BUILD_ALL_STEPS = [
     kind: "pnpm",
     pnpmArgs: ["ui:build"],
     // No build-all cache: ui/vite.config.ts derives the Control UI build ID
-    // from package.json, git HEAD, and OPENCLAW_CONTROL_UI_BUILD_ID env, so a
+    // from package.json, git HEAD, and REMOTECLAW_CONTROL_UI_BUILD_ID env, so a
     // file-input signature cannot exactly invalidate generated assets and a
     // warm hit could restore stale service-worker/app cache metadata.
     cache: undefined,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -95,7 +95,7 @@ export async function startControlUiE2eServer(): Promise<ControlUiE2eServer> {
     clearScreen: false,
     configFile: false,
     define: {
-      OPENCLAW_CONTROL_UI_BUILD_ID: JSON.stringify("e2e"),
+      REMOTECLAW_CONTROL_UI_BUILD_ID: JSON.stringify("e2e"),
     },
     logLevel: "error",
     optimizeDeps: {

--- a/ui/src/ui/service-worker-cache.test.ts
+++ b/ui/src/ui/service-worker-cache.test.ts
@@ -4,12 +4,13 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+const read = (rel: string): string => fs.readFileSync(path.join(here, rel), "utf8");
 
 describe("Control UI service worker cache versioning", () => {
   it("registers the service worker with a build id and bounds prior build caches", () => {
-    const mainSource = fs.readFileSync(path.join(here, "../main.ts"), "utf8");
-    const serviceWorkerSource = fs.readFileSync(path.join(here, "../../public/sw.js"), "utf8");
-    const viteConfigSource = fs.readFileSync(path.join(here, "../../vite.config.ts"), "utf8");
+    const mainSource = read("../main.ts");
+    const serviceWorkerSource = read("../../public/sw.js");
+    const viteConfigSource = read("../../vite.config.ts");
 
     expect(mainSource).toContain('swUrl.searchParams.set("v"');
     expect(mainSource).toContain('updateViaCache: "none"');
@@ -22,5 +23,60 @@ describe("Control UI service worker cache versioning", () => {
     expect(serviceWorkerSource).toContain("caches.delete");
     expect(viteConfigSource).toContain("source.replace(placeholder, JSON.stringify(buildId))");
     expect(serviceWorkerSource).not.toContain('const CACHE_NAME = "remoteclaw-control-v1"');
+  });
+
+  // #3024: the v2026.5.28 sync re-applied ui/vite.config.ts from upstream without the fork's
+  // uppercase env rebrand, desyncing it from the fork-owned sw.js and main.ts. Both halves
+  // below are extracted from their owning file rather than pinned as literals here, so a
+  // rename on either side surfaces as a desync instead of quietly passing.
+  it("keeps the build-id placeholder and define key in sync with their consumers", () => {
+    const mainSource = read("../main.ts");
+    const serviceWorkerSource = read("../../public/sw.js");
+    const viteConfigSource = read("../../vite.config.ts");
+
+    // The token sw.js actually embeds must be the exact string vite.config.ts substitutes.
+    // A mismatch makes the replace a no-op, which fails `pnpm ui:build` (publish lanes only).
+    const swToken = /const EMBEDDED_CACHE_VERSION = "(__[A-Z0-9_]+__)";/.exec(
+      serviceWorkerSource,
+    )?.[1];
+    expect(
+      swToken,
+      "sw.js must declare EMBEDDED_CACHE_VERSION from a __TOKEN__ placeholder",
+    ).toBeTruthy();
+    expect(viteConfigSource).toContain(`const placeholder = '"${swToken}"'`);
+
+    // Substitution is `String.replace(string, ...)`, which rewrites only the FIRST occurrence.
+    // sw.js therefore depends on the assignment preceding the "was I built?" sentinel compare —
+    // reorder them and the build would silently substitute the sentinel instead.
+    const assignmentAt = serviceWorkerSource.indexOf(`const EMBEDDED_CACHE_VERSION = "${swToken}"`);
+    const sentinelCompareAt = serviceWorkerSource.indexOf(
+      `EMBEDDED_CACHE_VERSION !== "${swToken}"`,
+    );
+    expect(assignmentAt).toBeLessThan(sentinelCompareAt);
+
+    // The identifier main.ts declares and reads must be the key vite defines. Otherwise vite
+    // never substitutes it and the prod bundle ships a bare undeclared global, throwing
+    // ReferenceError at module scope on every production page load in a secure context.
+    const buildIdGlobal = /declare const ([A-Z0-9_]+): string \| undefined;/.exec(mainSource)?.[1];
+    expect(buildIdGlobal, "main.ts must declare the injected build-id global").toBeTruthy();
+    expect(mainSource).toContain(`swUrl.searchParams.set("v", ${buildIdGlobal} || "dev")`);
+    expect(viteConfigSource).toContain(`${buildIdGlobal}: JSON.stringify(controlUiBuildId)`);
+
+    // Sibling injectors must define the same key. Neither is covered by a CI lane
+    // (*.e2e.test.ts is excluded from every vitest config), so this is their only guard.
+    const e2eHelperSource = read("../test-helpers/control-ui-e2e.ts");
+    const mockDevSource = read("../../../scripts/control-ui-mock-dev.ts");
+    expect(e2eHelperSource).toContain(`${buildIdGlobal}: JSON.stringify(`);
+    expect(mockDevSource).toContain(`${buildIdGlobal}: JSON.stringify(`);
+
+    // The env overrides vite reads must carry the fork prefix; a sync re-applying upstream's
+    // file flips these to OPENCLAW_* and the documented knobs go silently dead.
+    for (const envName of [
+      "REMOTECLAW_CONTROL_UI_BUILD_ID",
+      "REMOTECLAW_VERSION",
+      "REMOTECLAW_CONTROL_UI_BASE_PATH",
+    ]) {
+      expect(viteConfigSource).toContain(`process.env.${envName}`);
+    }
   });
 });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -74,7 +74,7 @@ function readGitShortSha(): string | null {
 
 function resolveControlUiBuildId(): string {
   const explicit =
-    process.env.OPENCLAW_CONTROL_UI_BUILD_ID?.trim() || process.env.OPENCLAW_VERSION?.trim();
+    process.env.REMOTECLAW_CONTROL_UI_BUILD_ID?.trim() || process.env.REMOTECLAW_VERSION?.trim();
   if (explicit) {
     return normalizeBuildId(explicit);
   }
@@ -91,7 +91,9 @@ function controlUiServiceWorkerBuildIdPlugin(buildId: string): Plugin {
       const swPath = path.join(outDir, "sw.js");
       const publicSwPath = path.join(here, "public/sw.js");
       const source = fs.readFileSync(fs.existsSync(swPath) ? swPath : publicSwPath, "utf8");
-      const placeholder = '"__OPENCLAW_CONTROL_UI_BUILD_ID__"';
+      // Must stay byte-identical to the token in ui/public/sw.js — a mismatch makes the
+      // replace below a no-op and fails the build. Guarded by service-worker-cache.test.ts.
+      const placeholder = '"__REMOTECLAW_CONTROL_UI_BUILD_ID__"';
       const updated = source.replace(placeholder, JSON.stringify(buildId));
       if (updated === source) {
         throw new Error(`Control UI service worker build id placeholder missing in ${swPath}`);
@@ -103,13 +105,15 @@ function controlUiServiceWorkerBuildIdPlugin(buildId: string): Plugin {
 }
 
 export default defineConfig(() => {
-  const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
+  const envBase = process.env.REMOTECLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
   const controlUiBuildId = resolveControlUiBuildId();
   return {
     base,
     define: {
-      OPENCLAW_CONTROL_UI_BUILD_ID: JSON.stringify(controlUiBuildId),
+      // Key must match the identifier ui/src/main.ts declares and reads; otherwise vite
+      // never substitutes it and the prod bundle throws ReferenceError on that global.
+      REMOTECLAW_CONTROL_UI_BUILD_ID: JSON.stringify(controlUiBuildId),
     },
     publicDir: path.resolve(here, "public"),
     optimizeDeps: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -67,6 +67,9 @@ export default defineConfig({
       "ui/src/ui/controllers/agents.test.ts",
       "ui/src/ui/controllers/chat.test.ts",
       "ui/src/ui/app-tool-stream.node.test.ts",
+      // Guards the Control UI service-worker build-id contract that otherwise only the
+      // publish lanes' `pnpm ui:build` exercises — see #3024.
+      "ui/src/ui/service-worker-cache.test.ts",
     ],
     setupFiles: ["test/setup.ts"],
     exclude: [


### PR DESCRIPTION
## Summary

Fixes #3024 — `publish-next` (and any release tag via `publish-latest`) went red at the v2026.5.28 sync merge (#3022) with:

> Error: Control UI service worker build id placeholder missing in `dist/control-ui/sw.js`

### Root cause (not silenced — fixed at the injection site)

The v5.28 sync re-applied `ui/vite.config.ts` wholesale from upstream OpenClaw **without the fork's uppercase `OPENCLAW_` → `REMOTECLAW_` env rebrand**. That desynced the service-worker build-id placeholder token in `vite.config.ts` (`"__OPENCLAW_CONTROL_UI_BUILD_ID__"`) from the fork-owned token in `ui/public/sw.js` (`"__REMOTECLAW_CONTROL_UI_BUILD_ID__"`). The `closeBundle` `String.replace(placeholder, …)` became a no-op → `updated === source` → the plugin threw.

**Why the PR gates missed it**: the standalone `build` job runs only `pnpm build` (never `pnpm ui:build`), and `test-ui-smoke` runs vitest browser mode (dev, not prod), so neither builds the Control UI. **Why rebrand-gate missed it**: `scripts/ci/rebrand-allowlist.txt` carries a blanket bare `OPENCLAW_` substring pattern that exempts every matching line.

### Second (latent) defect fixed in the same change

`vite.config.ts` `define:` emitted key `OPENCLAW_CONTROL_UI_BUILD_ID`, but `ui/src/main.ts` declares and reads `REMOTECLAW_CONTROL_UI_BUILD_ID`. Vite therefore never substituted it and the **prod bundle shipped a bare undeclared global** → `ReferenceError` at module scope on production load (secure context). Pre-existing since the sync that rebranded `main.ts`; confirmed by inspecting the built bundle. Also closes the silently-dead documented knob `REMOTECLAW_CONTROL_UI_BASE_PATH` (`docs/web/control-ui.md:426`).

## Changes

- **`ui/vite.config.ts`** — re-apply the fork rebrand to the 4 reverted sites: env reads (`REMOTECLAW_CONTROL_UI_BUILD_ID` / `REMOTECLAW_VERSION`), placeholder token, base-path env, and the `define` key.
- **`ui/src/test-helpers/control-ui-e2e.ts`**, **`scripts/build-all.mjs`** — same stale name (define key / comment).
- **`ui/src/ui/service-worker-cache.test.ts`** — new regression test cross-checking that the placeholder token, `define` key, and env names **agree with their consumers** (tokens are *extracted* from each owning file, not pinned as literals, so a rename on either side desyncs loudly). Also guards the sibling define sites and the assignment-before-sentinel ordering in `sw.js`.
- **`vitest.config.ts`** — wire that test into the root `pnpm test` lane. It previously ran in **no CI lane**, so it would otherwise have been a dead gate.

## Verification

- **Reproduced** pre-fix: `pnpm ui:build` → byte-identical error to CI.
- **AC #1**: `pnpm build && pnpm ui:build` → exit 0; `dist/control-ui/sw.js` gets a real build id (`0.8.0-<sha>`) substituted.
- **AC #2 / #3**: `prepack` = `pnpm build && pnpm ui:build` is exactly the step both `publish-next` and `publish-latest` run via `npm publish`, so a green run validates both lanes.
- **Necropsy** (discriminating): re-introducing each desync individually (placeholder / define-key / sibling define / sw.js ordering / env prefix) makes the new test **FAIL**; restored → passes. Undefined-regex guards fail loudly (no vacuous pass).
- **`pnpm check`** clean; fork-integrity gates (rebrand / zombie-import / stub-debt / throwing-stub / obsolescence) clean.
- **Unit lane**: +2 passing tests, **0 introduced failures** (the 24 pre-existing failures across 3 files are identical on a clean tree at HEAD).
- Fresh-context adversarial validate + polish both run; validate `VERDICT: CLEAN`.

## Follow-up (deferred, not in this PR)

Narrow the blanket `OPENCLAW_` pattern in `scripts/ci/rebrand-allowlist.txt` — it is what let this class through rebrand-gate. Repo-wide (many legitimate internal `OPENCLAW_*` vars remain), so tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
