### PR TITLE
feat(sms): outbound spine — Twilio REST send + signature helper (1/5, #3029)

### DIFF
--- a/extensions/sms/src/send.test.ts
+++ b/extensions/sms/src/send.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedSmsAccount } from "./types.js";
+
+type SendModule = typeof import("./send.js");
+
+let sendSmsTextChunks: SendModule["sendSmsTextChunks"];
+let toSmsPlainText: SendModule["toSmsPlainText"];
+
+const sendSmsViaTwilio = vi.hoisted(() => vi.fn(async ({ to }) => ({ sid: `SM-${to}`, to })));
+
+beforeEach(async () => {
+  vi.resetModules();
+  sendSmsViaTwilio.mockClear();
+  vi.doMock("./twilio.js", () => ({
+    sendSmsViaTwilio,
+  }));
+  ({ sendSmsTextChunks, toSmsPlainText } = await import("./send.js"));
+});
+
+afterEach(() => {
+  vi.doUnmock("./twilio.js");
+});
+
+function createAccount(textChunkLimit: number): ResolvedSmsAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    accountSid: "AC123",
+    authToken: "secret",
+    fromNumber: "+15557654321",
+    messagingServiceSid: "",
+    defaultTo: "",
+    webhookPath: "/webhooks/sms",
+    publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+    dangerouslyDisableSignatureValidation: false,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    textChunkLimit,
+  };
+}
+
+describe("sendSmsTextChunks", () => {
+  it("splits long SMS text before sending to Twilio", async () => {
+    await sendSmsTextChunks({
+      account: createAccount(5),
+      to: "+15551234567",
+      text: "alpha beta",
+    });
+
+    expect(sendSmsViaTwilio).toHaveBeenCalledTimes(2);
+    expect(sendSmsViaTwilio.mock.calls.map(([call]) => call.text)).toEqual(["alpha", "beta"]);
+  });
+
+  it("flattens markdown before sending SMS chunks", async () => {
+    expect(
+      toSmsPlainText("**Hi** [docs](https://example.com)\n\n```bash\napprove 123\n```\nthere"),
+    ).toBe("Hi docs (https://example.com)\n\napprove 123\nthere");
+  });
+});

--- a/extensions/sms/src/send.ts
+++ b/extensions/sms/src/send.ts
@@ -1,0 +1,47 @@
+import { stripMarkdown } from "../../../src/line/markdown-to-line.js";
+import { chunkTextForOutbound } from "../../../src/plugin-sdk/text-chunking.js";
+import { sendSmsViaTwilio } from "./twilio.js";
+import type { ResolvedSmsAccount, SmsSendResult } from "./types.js";
+
+export function toSmsPlainText(text: string): string {
+  const withoutFencedCodeMarkers = text.replace(
+    /```[^\n]*\n?([\s\S]*?)```/g,
+    (_match, body: string) => body.trim(),
+  );
+  const withReadableLinks = withoutFencedCodeMarkers.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+    (_match, label: string, url: string) => {
+      const cleanLabel = label.trim();
+      const cleanUrl = url.trim();
+      return cleanLabel && cleanLabel !== cleanUrl ? `${cleanLabel} (${cleanUrl})` : cleanUrl;
+    },
+  );
+  return stripMarkdown(withReadableLinks)
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export async function sendSmsTextChunks(params: {
+  account: ResolvedSmsAccount;
+  to: string;
+  text: string;
+}): Promise<SmsSendResult[]> {
+  const text = toSmsPlainText(params.text);
+  if (!text) {
+    throw new Error("SMS send requires non-empty text.");
+  }
+  const chunks = chunkTextForOutbound(text, params.account.textChunkLimit).filter(Boolean);
+  const sendChunks = chunks.length ? chunks : [text];
+  const results: SmsSendResult[] = [];
+  for (const textLocal of sendChunks) {
+    results.push(
+      await sendSmsViaTwilio({
+        account: params.account,
+        to: params.to,
+        text: textLocal,
+      }),
+    );
+  }
+  return results;
+}

--- a/extensions/sms/src/status.test.ts
+++ b/extensions/sms/src/status.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatSmsProbeLines, probeSmsAccount } from "./status.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+function createAccount(overrides: Partial<ResolvedSmsAccount> = {}): ResolvedSmsAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    accountSid: "AC123",
+    authToken: "secret",
+    fromNumber: "+15557654321",
+    messagingServiceSid: "",
+    defaultTo: "",
+    webhookPath: "/webhooks/sms",
+    publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+    dangerouslyDisableSignatureValidation: false,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    textChunkLimit: 1500,
+    ...overrides,
+  };
+}
+
+function createFetch(responses: Array<unknown>): typeof fetch {
+  return vi.fn(async () => {
+    const payload = responses.shift();
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe("SMS status probe", () => {
+  it("reports a healthy Twilio SMS webhook", async () => {
+    const fetchImpl = createFetch([
+      {
+        incoming_phone_numbers: [
+          {
+            phone_number: "+15557654321",
+            sms_url: "https://gateway.example.com/webhooks/sms",
+            sms_method: "POST",
+            voice_url: "https://gateway.example.com/voice/webhook",
+          },
+        ],
+      },
+      {
+        messages: [
+          {
+            sid: "SM123",
+            direction: "inbound",
+            status: "received",
+            to: "+15557654321",
+            from: "+15551234567",
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount(),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      webhook: {
+        status: "matches",
+        configuredUrl: "https://gateway.example.com/webhooks/sms",
+        voiceUrl: "https://gateway.example.com/voice/webhook",
+      },
+      recentInbound: {
+        sid: "SM123",
+        status: "received",
+      },
+    });
+    const result = await probeSmsAccount({
+      account: createAccount(),
+      timeoutMs: 1000,
+      options: {
+        fetchImpl: createFetch([
+          {
+            incoming_phone_numbers: [
+              {
+                phone_number: "+15557654321",
+                sms_url: "https://gateway.example.com/webhooks/sms",
+                sms_method: "POST",
+              },
+            ],
+          },
+          {
+            messages: [
+              {
+                sid: "SM456",
+                direction: "inbound",
+                status: "received",
+                to: "+15557654321",
+                from: "+15551234567",
+              },
+            ],
+          },
+        ]),
+      },
+    });
+    expect(result.recentInbound).not.toHaveProperty("from");
+    expect(result.recentInbound).not.toHaveProperty("to");
+  });
+
+  it("detects a Twilio SMS webhook URL mismatch", async () => {
+    const fetchImpl = createFetch([
+      {
+        incoming_phone_numbers: [
+          {
+            phone_number: "+15557654321",
+            sms_url: "https://old.example.com/webhooks/sms",
+            sms_method: "POST",
+          },
+        ],
+      },
+      { messages: [] },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount(),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error:
+        "Twilio number +15557654321 points SMS webhooks at https://old.example.com/webhooks/sms; expected https://gateway.example.com/webhooks/sms.",
+      webhook: {
+        status: "url-mismatch",
+      },
+    });
+  });
+
+  it("surfaces Twilio 11200 recent inbound failures and Funnel hints", async () => {
+    const fetchImpl = createFetch([
+      {
+        incoming_phone_numbers: [
+          {
+            phone_number: "+15557654321",
+            sms_url: "https://mac-studio.example.ts.net/webhooks/sms",
+            sms_method: "POST",
+          },
+        ],
+      },
+      {
+        messages: [
+          {
+            sid: "SM11200",
+            direction: "inbound",
+            status: "received",
+            to: "+15557654321",
+            from: "+15551234567",
+            error_code: 11200,
+          },
+        ],
+      },
+    ]);
+
+    const result = await probeSmsAccount({
+      account: createAccount({
+        publicWebhookUrl: "https://mac-studio.example.ts.net/webhooks/sms",
+      }),
+      timeoutMs: 1000,
+      options: { fetchImpl },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "Recent inbound SMS SM11200 has Twilio error 11200.",
+      recentInbound: {
+        sid: "SM11200",
+        errorCode: "11200",
+      },
+    });
+    expect(result.hints).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Tailscale Funnel must expose the exact SMS path"),
+        expect.stringContaining("Twilio error 11200 means Twilio could not reach"),
+      ]),
+    );
+  });
+
+  it("validates Twilio Messaging Service webhook settings", async () => {
+    const fetchImpl = createFetch([
+      {
+        sid: "MG123",
+        inbound_request_url: "https://gateway.example.com/webhooks/sms",
+        inbound_method: "POST",
+        use_inbound_webhook_on_number: false,
+      },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount({
+          fromNumber: "",
+          messagingServiceSid: "MG123",
+        }),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      webhook: {
+        status: "messaging-service-matches",
+        serviceSid: "MG123",
+        configuredUrl: "https://gateway.example.com/webhooks/sms",
+      },
+    });
+  });
+
+  it("does not report Messaging Service defer-to-number probes as healthy", async () => {
+    const fetchImpl = createFetch([
+      {
+        sid: "MG123",
+        inbound_request_url: "https://gateway.example.com/webhooks/sms",
+        inbound_method: "POST",
+        use_inbound_webhook_on_number: true,
+      },
+    ]);
+
+    await expect(
+      probeSmsAccount({
+        account: createAccount({
+          fromNumber: "",
+          messagingServiceSid: "MG123",
+        }),
+        timeoutMs: 1000,
+        options: { fetchImpl },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error:
+        "Twilio Messaging Service defers inbound webhooks to sender phone numbers; configure fromNumber or disable defer-to-sender before probing.",
+      webhook: {
+        status: "unavailable",
+      },
+    });
+  });
+
+  it("formats probe details for channel capability output", () => {
+    expect(
+      formatSmsProbeLines({
+        ok: false,
+        error: "Recent inbound SMS SM11200 has Twilio error 11200.",
+        webhook: { status: "matches", configuredUrl: "https://gateway.example.com/webhooks/sms" },
+        recentInbound: { sid: "SM11200", status: "received", errorCode: "11200" },
+        hints: ["Check the public route."],
+      }),
+    ).toEqual([
+      {
+        text: "Probe: failed (Recent inbound SMS SM11200 has Twilio error 11200.)",
+        tone: "error",
+      },
+      { text: "Twilio SMS webhook: https://gateway.example.com/webhooks/sms" },
+      { text: "Recent inbound: received error=11200", tone: "warn" },
+      { text: "Check the public route.", tone: "warn" },
+    ]);
+  });
+});

--- a/extensions/sms/src/status.ts
+++ b/extensions/sms/src/status.ts
@@ -1,0 +1,355 @@
+import {
+  listTwilioIncomingPhoneNumbers,
+  listTwilioMessages,
+  retrieveTwilioMessagingService,
+  type TwilioIncomingPhoneNumber,
+  type TwilioMessagingService,
+  type TwilioMessageLogEntry,
+} from "./twilio.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+const TWILIO_ERROR_WEBHOOK_REACHABILITY = "11200";
+
+type ChannelCapabilitiesDisplayLine = {
+  text: string;
+  tone?: "default" | "muted" | "success" | "warn" | "error";
+};
+
+export type SmsTwilioWebhookProbe =
+  | {
+      status: "skipped";
+      reason: string;
+    }
+  | {
+      status: "unavailable";
+      reason: string;
+    }
+  | {
+      status: "number-not-found";
+      expectedNumber: string;
+    }
+  | {
+      status: "missing";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "method-mismatch";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "url-mismatch";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "matches";
+      phoneNumber: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+      voiceUrl: string;
+    }
+  | {
+      status: "messaging-service-missing";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "messaging-service-method-mismatch";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "messaging-service-url-mismatch";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    }
+  | {
+      status: "messaging-service-matches";
+      serviceSid: string;
+      expectedUrl: string;
+      configuredUrl: string;
+      configuredMethod: string;
+    };
+
+export type SmsProbe = {
+  ok: boolean;
+  error?: string;
+  webhook: SmsTwilioWebhookProbe;
+  recentInbound?: Pick<
+    TwilioMessageLogEntry,
+    "sid" | "direction" | "status" | "errorCode" | "dateCreated" | "dateSent"
+  >;
+  hints: string[];
+};
+
+type ProbeOptions = {
+  fetchImpl?: typeof fetch;
+};
+
+function addTailscaleHint(account: ResolvedSmsAccount, hints: string[]): void {
+  let host;
+  try {
+    host = new URL(account.publicWebhookUrl).hostname;
+  } catch {
+    return;
+  }
+  if (!host.endsWith(".ts.net")) {
+    return;
+  }
+  hints.push(
+    `Tailscale Funnel must expose the exact SMS path: tailscale funnel --bg --set-path ${account.webhookPath} http://127.0.0.1:<gateway-port>${account.webhookPath}`,
+  );
+}
+
+function compareTwilioWebhook(
+  account: ResolvedSmsAccount,
+  phoneNumber: TwilioIncomingPhoneNumber | undefined,
+): SmsTwilioWebhookProbe {
+  if (!account.fromNumber) {
+    return {
+      status: "skipped",
+      reason: "Messaging Service senders do not have one phone-number SMS webhook to inspect.",
+    };
+  }
+  if (!phoneNumber) {
+    return { status: "number-not-found", expectedNumber: account.fromNumber };
+  }
+  const configuredMethod = phoneNumber.smsMethod.toUpperCase();
+  if (!phoneNumber.smsUrl) {
+    return {
+      status: "missing",
+      phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+      expectedUrl: account.publicWebhookUrl,
+      configuredMethod,
+    };
+  }
+  if (configuredMethod && configuredMethod !== "POST") {
+    return {
+      status: "method-mismatch",
+      phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: phoneNumber.smsUrl,
+      configuredMethod,
+    };
+  }
+  if (phoneNumber.smsUrl !== account.publicWebhookUrl) {
+    return {
+      status: "url-mismatch",
+      phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: phoneNumber.smsUrl,
+      configuredMethod,
+    };
+  }
+  return {
+    status: "matches",
+    phoneNumber: phoneNumber.phoneNumber || account.fromNumber,
+    expectedUrl: account.publicWebhookUrl,
+    configuredUrl: phoneNumber.smsUrl,
+    configuredMethod,
+    voiceUrl: phoneNumber.voiceUrl,
+  };
+}
+
+function compareTwilioMessagingService(
+  account: ResolvedSmsAccount,
+  service: TwilioMessagingService,
+): SmsTwilioWebhookProbe {
+  if (service.useInboundWebhookOnNumber) {
+    return {
+      status: "unavailable",
+      reason:
+        "Twilio Messaging Service defers inbound webhooks to sender phone numbers; configure fromNumber or disable defer-to-sender before probing.",
+    };
+  }
+  const configuredMethod = service.inboundMethod.toUpperCase();
+  if (!service.inboundRequestUrl) {
+    return {
+      status: "messaging-service-missing",
+      serviceSid: service.sid || account.messagingServiceSid,
+      expectedUrl: account.publicWebhookUrl,
+      configuredMethod,
+    };
+  }
+  if (configuredMethod && configuredMethod !== "POST") {
+    return {
+      status: "messaging-service-method-mismatch",
+      serviceSid: service.sid || account.messagingServiceSid,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: service.inboundRequestUrl,
+      configuredMethod,
+    };
+  }
+  if (service.inboundRequestUrl !== account.publicWebhookUrl) {
+    return {
+      status: "messaging-service-url-mismatch",
+      serviceSid: service.sid || account.messagingServiceSid,
+      expectedUrl: account.publicWebhookUrl,
+      configuredUrl: service.inboundRequestUrl,
+      configuredMethod,
+    };
+  }
+  return {
+    status: "messaging-service-matches",
+    serviceSid: service.sid || account.messagingServiceSid,
+    expectedUrl: account.publicWebhookUrl,
+    configuredUrl: service.inboundRequestUrl,
+    configuredMethod,
+  };
+}
+
+function recentInboundSummary(
+  messages: TwilioMessageLogEntry[],
+): SmsProbe["recentInbound"] | undefined {
+  const message = messages[0];
+  if (!message) {
+    return undefined;
+  }
+  return {
+    sid: message.sid,
+    direction: message.direction,
+    status: message.status,
+    errorCode: message.errorCode,
+    dateCreated: message.dateCreated,
+    dateSent: message.dateSent,
+  };
+}
+
+function webhookError(probe: SmsTwilioWebhookProbe): string | undefined {
+  switch (probe.status) {
+    case "matches":
+    case "skipped":
+      return undefined;
+    case "unavailable":
+      return probe.reason;
+    case "number-not-found":
+      return `Twilio account does not list ${probe.expectedNumber} as an incoming phone number.`;
+    case "missing":
+      return `Twilio number ${probe.phoneNumber} has no SMS webhook URL configured.`;
+    case "method-mismatch":
+      return `Twilio number ${probe.phoneNumber} uses ${probe.configuredMethod || "an unknown method"} for SMS webhooks; use POST.`;
+    case "url-mismatch":
+      return `Twilio number ${probe.phoneNumber} points SMS webhooks at ${probe.configuredUrl}; expected ${probe.expectedUrl}.`;
+    case "messaging-service-missing":
+      return `Twilio Messaging Service ${probe.serviceSid} has no inbound request URL configured.`;
+    case "messaging-service-method-mismatch":
+      return `Twilio Messaging Service ${probe.serviceSid} uses ${probe.configuredMethod || "an unknown method"} for inbound webhooks; use POST.`;
+    case "messaging-service-url-mismatch":
+      return `Twilio Messaging Service ${probe.serviceSid} points inbound webhooks at ${probe.configuredUrl}; expected ${probe.expectedUrl}.`;
+    case "messaging-service-matches":
+      return undefined;
+  }
+  return undefined;
+}
+
+export async function probeSmsAccount(params: {
+  account: ResolvedSmsAccount;
+  timeoutMs: number;
+  options?: ProbeOptions;
+}): Promise<SmsProbe> {
+  const hints: string[] = [];
+  addTailscaleHint(params.account, hints);
+  const webhook: SmsTwilioWebhookProbe = params.account.fromNumber
+    ? compareTwilioWebhook(
+        params.account,
+        (
+          await listTwilioIncomingPhoneNumbers({
+            account: params.account,
+            phoneNumber: params.account.fromNumber,
+            fetchImpl: params.options?.fetchImpl,
+            timeoutMs: params.timeoutMs,
+          })
+        )[0],
+      )
+    : params.account.messagingServiceSid
+      ? compareTwilioMessagingService(
+          params.account,
+          await retrieveTwilioMessagingService({
+            account: params.account,
+            serviceSid: params.account.messagingServiceSid,
+            fetchImpl: params.options?.fetchImpl,
+            timeoutMs: params.timeoutMs,
+          }),
+        )
+      : {
+          status: "unavailable",
+          reason: "Twilio SMS probe requires fromNumber or messagingServiceSid.",
+        };
+  const messages = params.account.fromNumber
+    ? await listTwilioMessages({
+        account: params.account,
+        to: params.account.fromNumber,
+        pageSize: 3,
+        fetchImpl: params.options?.fetchImpl,
+        timeoutMs: params.timeoutMs,
+      })
+    : [];
+  const recentInbound = recentInboundSummary(messages);
+  if (recentInbound?.errorCode === TWILIO_ERROR_WEBHOOK_REACHABILITY) {
+    hints.push(
+      "Twilio error 11200 means Twilio could not reach the SMS webhook. Check the public URL, tunnel/Funnel route, and Twilio Messaging webhook method.",
+    );
+  }
+  const error =
+    webhookError(webhook) ??
+    (recentInbound?.errorCode === TWILIO_ERROR_WEBHOOK_REACHABILITY
+      ? `Recent inbound SMS ${recentInbound.sid} has Twilio error 11200.`
+      : undefined);
+  return {
+    ok: !error,
+    ...(error ? { error } : {}),
+    webhook,
+    ...(recentInbound ? { recentInbound } : {}),
+    hints,
+  };
+}
+
+export function formatSmsProbeLines(probe: unknown): ChannelCapabilitiesDisplayLine[] {
+  if (!probe || typeof probe !== "object") {
+    return [];
+  }
+  const smsProbe = probe as Partial<SmsProbe>;
+  const lines: ChannelCapabilitiesDisplayLine[] = [];
+  if (smsProbe.ok === true) {
+    lines.push({ text: "Probe: ok", tone: "success" });
+  } else if (smsProbe.ok === false) {
+    lines.push({
+      text: `Probe: failed${smsProbe.error ? ` (${smsProbe.error})` : ""}`,
+      tone: "error",
+    });
+  }
+  if (
+    smsProbe.webhook?.status === "matches" ||
+    smsProbe.webhook?.status === "messaging-service-matches"
+  ) {
+    lines.push({ text: `Twilio SMS webhook: ${smsProbe.webhook.configuredUrl}` });
+  } else if (smsProbe.webhook?.status && smsProbe.webhook.status !== "skipped") {
+    lines.push({ text: `Twilio SMS webhook: ${smsProbe.webhook.status}`, tone: "warn" });
+  }
+  if (smsProbe.recentInbound?.sid) {
+    const error = smsProbe.recentInbound.errorCode
+      ? ` error=${smsProbe.recentInbound.errorCode}`
+      : "";
+    lines.push({
+      text: `Recent inbound: ${smsProbe.recentInbound.status || "unknown"}${error}`,
+      tone: smsProbe.recentInbound.errorCode ? "warn" : "muted",
+    });
+  }
+  for (const hint of smsProbe.hints ?? []) {
+    lines.push({ text: hint, tone: "warn" });
+  }
+  return lines;
+}

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -534,7 +534,7 @@ describe("Twilio SMS helpers", () => {
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
       expect.objectContaining({
         auditContext: "sms-twilio-api",
-        policy: { allowedHostnames: ["api.twilio.com"] },
+        policy: { hostnameAllowlist: ["api.twilio.com"] },
         timeoutMs: 30_000,
         url: "https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json",
       }),

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -1,0 +1,629 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildTwilioInboundMessage,
+  computeTwilioSignature,
+  listTwilioIncomingPhoneNumbers,
+  listTwilioMessages,
+  parseTwilioFormBody,
+  resolveTwilioWebhookSignatureUrl,
+  retrieveTwilioMessagingService,
+  sendSmsViaTwilio,
+  TwilioSmsApiError,
+  verifyTwilioSignature,
+} from "./twilio.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+// Fork-native re-home: the SSRF-guarded egress helper lives at
+// src/infra/net/fetch-guard (upstream imported the gutted plugin-sdk/ssrf-runtime).
+vi.mock("../../../src/infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+}));
+
+function createAccount(overrides: Partial<ResolvedSmsAccount> = {}): ResolvedSmsAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    accountSid: "AC123",
+    authToken: "secret",
+    fromNumber: "+15557654321",
+    messagingServiceSid: "",
+    defaultTo: "",
+    webhookPath: "/webhooks/sms",
+    publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+    dangerouslyDisableSignatureValidation: false,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    textChunkLimit: 1500,
+    ...overrides,
+  };
+}
+
+function readUrlEncodedRequestBody(init: RequestInit | undefined): URLSearchParams {
+  if (typeof init?.body === "string") {
+    return new URLSearchParams(init.body);
+  }
+  if (init?.body instanceof URLSearchParams) {
+    return init.body;
+  }
+  throw new Error("Expected Twilio request body to be URL-encoded.");
+}
+
+describe("Twilio SMS helpers", () => {
+  afterEach(() => {
+    fetchWithSsrFGuardMock.mockReset();
+  });
+
+  it("parses Twilio form bodies and inbound messages", () => {
+    const form = parseTwilioFormBody(
+      "From=%2B15551234567&To=%2B15557654321&Body=hello+there&MessageSid=SM123",
+    );
+
+    expect(form).toEqual({
+      From: "+15551234567",
+      To: "+15557654321",
+      Body: "hello there",
+      MessageSid: "SM123",
+    });
+    expect(buildTwilioInboundMessage(form)).toEqual({
+      from: "+15551234567",
+      to: "+15557654321",
+      body: "hello there",
+      messageSid: "SM123",
+      accountSid: "",
+    });
+  });
+
+  it("validates the X-Twilio-Signature against Twilio's published vector", () => {
+    // Twilio's canonical documented example. The signing string is the request
+    // URL followed by the POST params sorted by key and concatenated as key+value
+    // with no separators; HMAC-SHA1 keyed by the auth token, base64-encoded.
+    // The expected signature below is Twilio's published value, independently
+    // cross-checked with `openssl dgst -sha1 -hmac 12345` — NOT self-computed.
+    const url = "https://mycompany.com/myapp.php?foo=1&bar=2";
+    const authToken = "12345";
+    const form = {
+      CallSid: "CA1234567890ABCDE",
+      Caller: "+14158675310",
+      Digits: "1234",
+      From: "+14158675310",
+      To: "+18005551212",
+    };
+    const KNOWN_SIGNATURE = "GvWf1cFY/Q7PnoempGyD5oXAezc=";
+
+    // Reproduces Twilio's published signature byte-for-byte (spec conformance).
+    expect(computeTwilioSignature({ url, authToken, form })).toBe(KNOWN_SIGNATURE);
+
+    // Accepts the valid signature.
+    expect(verifyTwilioSignature({ signature: KNOWN_SIGNATURE, url, authToken, form })).toBe(true);
+
+    // Rejects a tampered signature of identical length (exercises the
+    // constant-time compare, not merely a length short-circuit).
+    expect(
+      verifyTwilioSignature({
+        signature: "HvWf1cFY/Q7PnoempGyD5oXAezc=",
+        url,
+        authToken,
+        form,
+      }),
+    ).toBe(false);
+
+    // Rejects a tampered payload (a param changed after signing).
+    expect(
+      verifyTwilioSignature({
+        signature: KNOWN_SIGNATURE,
+        url,
+        authToken,
+        form: { ...form, Digits: "9999" },
+      }),
+    ).toBe(false);
+
+    // Rejects a spoofed request URL.
+    expect(
+      verifyTwilioSignature({
+        signature: KNOWN_SIGNATURE,
+        url: "https://evil.example.com/myapp.php?foo=1&bar=2",
+        authToken,
+        form,
+      }),
+    ).toBe(false);
+
+    // Rejects the wrong auth token.
+    expect(
+      verifyTwilioSignature({ signature: KNOWN_SIGNATURE, url, authToken: "67890", form }),
+    ).toBe(false);
+
+    // Rejects missing and malformed signatures.
+    expect(verifyTwilioSignature({ signature: undefined, url, authToken, form })).toBe(false);
+    expect(verifyTwilioSignature({ signature: "", url, authToken, form })).toBe(false);
+    expect(verifyTwilioSignature({ signature: "not-base64!!", url, authToken, form })).toBe(false);
+  });
+
+  it("verifies Twilio signatures over sorted form fields", () => {
+    const form = {
+      Body: "hello",
+      From: "+15551234567",
+      MessageSid: "SM123",
+      To: "+15557654321",
+    };
+    const signature = computeTwilioSignature({
+      url: "https://gateway.example.com/webhooks/sms",
+      authToken: "secret",
+      form,
+    });
+
+    expect(
+      verifyTwilioSignature({
+        signature,
+        url: "https://gateway.example.com/webhooks/sms",
+        authToken: "secret",
+        form,
+      }),
+    ).toBe(true);
+    expect(
+      verifyTwilioSignature({
+        signature,
+        url: "https://gateway.example.com/webhooks/sms/other",
+        authToken: "secret",
+        form,
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves signed form values before signature verification", () => {
+    const form = parseTwilioFormBody(
+      "From=%2B15551234567&To=%2B15557654321&Body=+hello+&MessageSid=SM123&WaId=",
+    );
+    const signature = computeTwilioSignature({
+      url: "https://gateway.example.com/webhooks/sms",
+      authToken: "secret",
+      form,
+    });
+
+    expect(form.Body).toBe(" hello ");
+    expect(form.WaId).toBe("");
+    expect(
+      verifyTwilioSignature({
+        signature,
+        url: "https://gateway.example.com/webhooks/sms",
+        authToken: "secret",
+        form,
+      }),
+    ).toBe(true);
+    expect(buildTwilioInboundMessage(form)?.body).toBe(" hello ");
+  });
+
+  it("sends SMS through Twilio's Messages API", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            sid: "SM456",
+            to: "+15551234567",
+            from: "+15557654321",
+            status: "queued",
+          }),
+          {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      sendSmsViaTwilio({
+        account: {
+          accountId: "default",
+          enabled: true,
+          accountSid: "AC123",
+          authToken: "secret",
+          fromNumber: "+15557654321",
+          messagingServiceSid: "",
+          defaultTo: "",
+          webhookPath: "/webhooks/sms",
+          publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+          dangerouslyDisableSignatureValidation: false,
+          dmPolicy: "pairing",
+          allowFrom: [],
+          textChunkLimit: 1500,
+        },
+        to: "+15551234567",
+        text: "hello",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      sid: "SM456",
+      to: "+15551234567",
+      from: "+15557654321",
+      status: "queued",
+    });
+
+    const firstFetchCall = fetchImpl.mock.calls[0];
+    expect(firstFetchCall).toBeDefined();
+    if (!firstFetchCall) {
+      throw new Error("Expected Twilio fetch call");
+    }
+    const [url, init] = firstFetchCall;
+    expect(url).toBe("https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json");
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("Expected Twilio request init");
+    }
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toMatchObject({
+      authorization: `Basic ${Buffer.from("AC123:secret").toString("base64")}`,
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    const body = readUrlEncodedRequestBody(init);
+    expect(body.get("From")).toBe("+15557654321");
+    expect(body.get("To")).toBe("+15551234567");
+    expect(body.get("Body")).toBe("hello");
+  });
+
+  it("lists Twilio phone-number webhook settings", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            incoming_phone_numbers: [
+              {
+                sid: "PN123",
+                phone_number: "+15557654321",
+                sms_url: "https://gateway.example.com/webhooks/sms",
+                sms_method: "POST",
+                voice_url: "https://gateway.example.com/voice/webhook",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      listTwilioIncomingPhoneNumbers({
+        account: createAccount(),
+        phoneNumber: "+15557654321",
+        fetchImpl,
+      }),
+    ).resolves.toEqual([
+      {
+        sid: "PN123",
+        phoneNumber: "+15557654321",
+        smsUrl: "https://gateway.example.com/webhooks/sms",
+        smsMethod: "POST",
+        voiceUrl: "https://gateway.example.com/voice/webhook",
+      },
+    ]);
+
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://api.twilio.com/2010-04-01/Accounts/AC123/IncomingPhoneNumbers.json?PhoneNumber=%2B15557654321",
+    );
+    expect(init?.headers).toMatchObject({
+      authorization: `Basic ${Buffer.from("AC123:secret").toString("base64")}`,
+    });
+  });
+
+  it("lists recent Twilio messages for diagnostics", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            messages: [
+              {
+                sid: "SM123",
+                direction: "inbound",
+                status: "received",
+                to: "+15557654321",
+                from: "+15551234567",
+                error_code: 11200,
+                body: "hello",
+                date_created: "Sun, 31 May 2026 10:00:00 +0000",
+                date_sent: null,
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      listTwilioMessages({
+        account: createAccount(),
+        to: "+15557654321",
+        pageSize: 3,
+        fetchImpl,
+      }),
+    ).resolves.toEqual([
+      {
+        sid: "SM123",
+        direction: "inbound",
+        status: "received",
+        to: "+15557654321",
+        from: "+15551234567",
+        errorCode: "11200",
+        body: "hello",
+        dateCreated: "Sun, 31 May 2026 10:00:00 +0000",
+        dateSent: "",
+      },
+    ]);
+
+    const [url] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json?To=%2B15557654321&PageSize=3",
+    );
+  });
+
+  it("retrieves Twilio Messaging Service webhook settings", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            sid: "MG123",
+            inbound_request_url: "https://gateway.example.com/webhooks/sms",
+            inbound_method: "POST",
+            use_inbound_webhook_on_number: false,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(
+      retrieveTwilioMessagingService({
+        account: createAccount({ messagingServiceSid: "MG123", fromNumber: "" }),
+        serviceSid: "MG123",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      sid: "MG123",
+      inboundRequestUrl: "https://gateway.example.com/webhooks/sms",
+      inboundMethod: "POST",
+      useInboundWebhookOnNumber: false,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    expect(url).toBe("https://messaging.twilio.com/v1/Services/MG123");
+    expect(init?.headers).toMatchObject({
+      authorization: `Basic ${Buffer.from("AC123:secret").toString("base64")}`,
+    });
+  });
+
+  it("can send through a Twilio Messaging Service SID", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ sid: "SM789" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await sendSmsViaTwilio({
+      account: {
+        accountId: "default",
+        enabled: true,
+        accountSid: "AC123",
+        authToken: "secret",
+        fromNumber: "",
+        messagingServiceSid: "MG123",
+        defaultTo: "",
+        webhookPath: "/webhooks/sms",
+        publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+        dangerouslyDisableSignatureValidation: false,
+        dmPolicy: "pairing",
+        allowFrom: [],
+        textChunkLimit: 1500,
+      },
+      to: "+15551234567",
+      text: "hello",
+      fetchImpl,
+    });
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const body = readUrlEncodedRequestBody(init);
+    expect(body.get("MessagingServiceSid")).toBe("MG123");
+    expect(body.get("To")).toBe("+15551234567");
+    expect(body.get("Body")).toBe("hello");
+  });
+
+  it("prefers an explicit from number when both sender options are resolved", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ sid: "SM999" }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await sendSmsViaTwilio({
+      account: {
+        accountId: "default",
+        enabled: true,
+        accountSid: "AC123",
+        authToken: "secret",
+        fromNumber: "+15557654321",
+        messagingServiceSid: "MG123",
+        defaultTo: "",
+        webhookPath: "/webhooks/sms",
+        publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+        dangerouslyDisableSignatureValidation: false,
+        dmPolicy: "pairing",
+        allowFrom: [],
+        textChunkLimit: 1500,
+      },
+      to: "+15551234567",
+      text: "hello",
+      fetchImpl,
+    });
+
+    const [, init] = fetchImpl.mock.calls[0] ?? [];
+    const body = readUrlEncodedRequestBody(init);
+    expect(body.get("From")).toBe("+15557654321");
+    expect(body.get("MessagingServiceSid")).toBeNull();
+  });
+
+  it("throws structured Twilio errors from JSON error bodies", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: 21610,
+            message: "The message From/To pair violates a blacklist rule.",
+          }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      name: "TwilioSmsApiError",
+      httpStatus: 400,
+      twilioCode: 21610,
+      responseText: JSON.stringify({
+        code: 21610,
+        message: "The message From/To pair violates a blacklist rule.",
+      }),
+    });
+  });
+
+  it("includes non-JSON Twilio error text in send failures", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response("upstream unavailable", { status: 503 }),
+    );
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Twilio SMS send failed (503): upstream unavailable");
+  });
+
+  it("releases guarded Twilio egress on failed send responses", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("upstream unavailable", { status: 503 }),
+      release,
+    });
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Twilio SMS send failed (503): upstream unavailable");
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditContext: "sms-twilio-api",
+        policy: { allowedHostnames: ["api.twilio.com"] },
+        timeoutMs: 30_000,
+        url: "https://api.twilio.com/2010-04-01/Accounts/AC123/Messages.json",
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed JSON from successful Twilio sends", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response("not json", { status: 201 }));
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Twilio SMS send returned malformed JSON.");
+  });
+
+  it("releases guarded Twilio egress on malformed successful send responses", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("not json", { status: 201 }),
+      release,
+    });
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Twilio SMS send returned malformed JSON.");
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes a typed Twilio SMS API error", () => {
+    const error = new TwilioSmsApiError(
+      429,
+      JSON.stringify({ code: 20429, message: "Too many requests" }),
+    );
+
+    expect(error).toBeInstanceOf(TwilioSmsApiError);
+    expect(error.message).toBe("Twilio SMS send failed (429): Too many requests");
+    expect(error.httpStatus).toBe(429);
+    expect(error.twilioCode).toBe(20429);
+  });
+
+  it("requires successful Twilio sends to include a Message SID", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ status: "queued" }), { status: 201 }),
+    );
+
+    await expect(
+      sendSmsViaTwilio({
+        account: createAccount(),
+        to: "+15551234567",
+        text: "hello",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("Twilio SMS send response did not include a Message SID.");
+  });
+
+  it("preserves the configured public webhook path when adding a request query", () => {
+    expect(
+      resolveTwilioWebhookSignatureUrl({
+        req: { url: "/webhooks/sms?foo=bar" } as never,
+        publicWebhookUrl: "https://gateway.example.com/base",
+      }),
+    ).toBe("https://gateway.example.com/base?foo=bar");
+  });
+
+  it("keeps an explicit configured public webhook query", () => {
+    expect(
+      resolveTwilioWebhookSignatureUrl({
+        req: { url: "/webhooks/sms?foo=request" } as never,
+        publicWebhookUrl: "https://gateway.example.com/base?foo=configured",
+      }),
+    ).toBe("https://gateway.example.com/base?foo=configured");
+  });
+
+  it("does not reserialize the configured public webhook URL", () => {
+    expect(
+      resolveTwilioWebhookSignatureUrl({
+        req: { url: "/webhooks/sms" } as never,
+        publicWebhookUrl: "https://gateway.example.com:443/webhooks/sms",
+      }),
+    ).toBe("https://gateway.example.com:443/webhooks/sms");
+  });
+});

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -1,0 +1,522 @@
+// Twilio REST client + fork-native X-Twilio-Signature validation helper.
+//
+// Fork-native rewrite: the upstream SMS adapter imported gutted channel-framework
+// platform modules this fork removed. It re-homes onto the low-level surfaces the
+// fork actually keeps:
+//   - `fetchWithSsrFGuard`       from src/infra/net/fetch-guard (SSRF-guarded egress)
+//   - `readRequestBodyWithLimit` from src/infra/http-body       (kept body reader)
+// The X-Twilio-Signature validation is a LOCAL node:crypto implementation
+// (HMAC-SHA1 + constant-time timingSafeEqual). It gates the future PUBLIC inbound
+// webhook (PR 4) — Twilio's servers authenticate their POSTs with this signature
+// and cannot present the gateway operator credential.
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import * as querystring from "node:querystring";
+import { readRequestBodyWithLimit } from "../../../src/infra/http-body.js";
+import { fetchWithSsrFGuard } from "../../../src/infra/net/fetch-guard.js";
+import type { ResolvedSmsAccount, SmsInboundMessage, SmsSendResult } from "./types.js";
+
+const TWILIO_ACCOUNTS_URL = "https://api.twilio.com/2010-04-01/Accounts";
+const TWILIO_MESSAGING_URL = "https://messaging.twilio.com/v1";
+const TWILIO_API_HOSTNAME = "api.twilio.com";
+const TWILIO_MESSAGING_HOSTNAME = "messaging.twilio.com";
+const TWILIO_API_TIMEOUT_MS = 30_000;
+const WEBHOOK_BODY_LIMIT_BYTES = 32 * 1024;
+const WEBHOOK_BODY_TIMEOUT_MS = 5_000;
+
+type ParsedTwilioApiError = {
+  code?: number;
+  message?: string;
+};
+
+type TwilioApiResponse = {
+  ok: boolean;
+  status: number;
+  text: string;
+};
+
+type TwilioMessagePayload = {
+  sid?: string;
+  to?: string;
+  from?: string;
+  status?: string;
+};
+
+export type TwilioIncomingPhoneNumber = {
+  sid: string;
+  phoneNumber: string;
+  smsUrl: string;
+  smsMethod: string;
+  voiceUrl: string;
+};
+
+export type TwilioMessageLogEntry = {
+  sid: string;
+  direction: string;
+  status: string;
+  to: string;
+  from: string;
+  errorCode: string;
+  body: string;
+  dateCreated: string;
+  dateSent: string;
+};
+
+export type TwilioMessagingService = {
+  sid: string;
+  inboundRequestUrl: string;
+  inboundMethod: string;
+  useInboundWebhookOnNumber: boolean;
+};
+
+function firstString(value: unknown): string {
+  if (Array.isArray(value)) {
+    return firstString(value[0]);
+  }
+  return typeof value === "string" ? value : "";
+}
+
+function firstTrimmedString(value: unknown): string {
+  return firstString(value).trim();
+}
+
+function firstStringish(value: unknown): string {
+  const first = Array.isArray(value) ? value[0] : value;
+  if (typeof first === "string") {
+    return first;
+  }
+  return typeof first === "number" ? String(first) : "";
+}
+
+function parseTwilioApiError(text: string): ParsedTwilioApiError {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    const record = parsed as Record<string, unknown>;
+    return {
+      code: typeof record.code === "number" ? record.code : undefined,
+      message: typeof record.message === "string" ? record.message : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function parseTwilioSuccessPayload(text: string): TwilioMessagePayload {
+  if (!text.trim()) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("Twilio SMS send returned malformed JSON.");
+    }
+    const record = parsed as Record<string, unknown>;
+    return {
+      sid: typeof record.sid === "string" ? record.sid : undefined,
+      to: typeof record.to === "string" ? record.to : undefined,
+      from: typeof record.from === "string" ? record.from : undefined,
+      status: typeof record.status === "string" ? record.status : undefined,
+    };
+  } catch (cause) {
+    if (cause instanceof Error && cause.message === "Twilio SMS send returned malformed JSON.") {
+      throw cause;
+    }
+    throw new Error("Twilio SMS send returned malformed JSON.", { cause });
+  }
+}
+
+function requestSearch(req: IncomingMessage): string {
+  try {
+    return new URL(req.url ?? "/", "http://localhost").search;
+  } catch {
+    return "";
+  }
+}
+
+function configuredUrlHasQuery(url: string): boolean {
+  const hashIndex = url.indexOf("#");
+  const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  return beforeHash.includes("?");
+}
+
+export function resolveTwilioWebhookSignatureUrl(params: {
+  req: IncomingMessage;
+  publicWebhookUrl: string;
+}): string {
+  if (configuredUrlHasQuery(params.publicWebhookUrl)) {
+    return params.publicWebhookUrl;
+  }
+  const search = requestSearch(params.req);
+  if (!search) {
+    return params.publicWebhookUrl;
+  }
+  const hashIndex = params.publicWebhookUrl.indexOf("#");
+  if (hashIndex === -1) {
+    return `${params.publicWebhookUrl}${search}`;
+  }
+  return `${params.publicWebhookUrl.slice(0, hashIndex)}${search}${params.publicWebhookUrl.slice(hashIndex)}`;
+}
+
+export class TwilioSmsApiError extends Error {
+  readonly httpStatus: number;
+  readonly responseText: string;
+  readonly twilioCode?: number;
+
+  constructor(httpStatus: number, responseText: string, operation = "send") {
+    const parsed = parseTwilioApiError(responseText);
+    const detail = parsed.message ?? (responseText || "unknown");
+    super(`Twilio SMS ${operation} failed (${httpStatus}): ${detail}`);
+    this.name = "TwilioSmsApiError";
+    this.httpStatus = httpStatus;
+    this.responseText = responseText;
+    this.twilioCode = parsed.code;
+  }
+}
+
+export function parseTwilioFormBody(body: string): Record<string, string> {
+  const parsed = querystring.parse(body);
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    out[key] = firstString(value);
+  }
+  return out;
+}
+
+export function computeTwilioSignature(params: {
+  url: string;
+  authToken: string;
+  form: Record<string, string>;
+}): string {
+  const data =
+    params.url +
+    Object.keys(params.form)
+      .toSorted()
+      .map((key) => `${key}${params.form[key] ?? ""}`)
+      .join("");
+  return createHmac("sha1", params.authToken).update(data).digest("base64");
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function verifyTwilioSignature(params: {
+  signature: string | undefined;
+  url: string;
+  authToken: string;
+  form: Record<string, string>;
+}): boolean {
+  if (!params.signature || !params.url || !params.authToken) {
+    return false;
+  }
+  return safeEqual(
+    params.signature,
+    computeTwilioSignature({
+      url: params.url,
+      authToken: params.authToken,
+      form: params.form,
+    }),
+  );
+}
+
+export function buildTwilioInboundMessage(form: Record<string, string>): SmsInboundMessage | null {
+  const from = firstTrimmedString(form.From);
+  const to = firstTrimmedString(form.To);
+  const body = firstString(form.Body);
+  const accountSid = firstTrimmedString(form.AccountSid);
+  const messageSid =
+    firstTrimmedString(form.MessageSid) ||
+    firstTrimmedString(form.SmsSid) ||
+    firstTrimmedString(form.SmsMessageSid);
+  if (!from || !to || !body || !messageSid) {
+    return null;
+  }
+  return { accountSid, from, to, body, messageSid };
+}
+
+export async function readTwilioWebhookForm(req: IncomingMessage): Promise<Record<string, string>> {
+  const body = await readRequestBodyWithLimit(req, {
+    maxBytes: WEBHOOK_BODY_LIMIT_BYTES,
+    timeoutMs: WEBHOOK_BODY_TIMEOUT_MS,
+  });
+  return parseTwilioFormBody(body);
+}
+
+export function respondTwiml(res: ServerResponse, statusCode: number, body = ""): void {
+  res.statusCode = statusCode;
+  res.setHeader("content-type", "text/xml; charset=utf-8");
+  res.end(body || "<Response></Response>");
+}
+
+function twilioApiUrl(accountSid: string, path: string, query?: URLSearchParams): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${TWILIO_ACCOUNTS_URL}/${encodeURIComponent(accountSid)}${normalizedPath}`);
+  if (query) {
+    url.search = query.toString();
+  }
+  return url.toString();
+}
+
+function twilioMessagingUrl(path: string, query?: URLSearchParams): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = new URL(`${TWILIO_MESSAGING_URL}${normalizedPath}`);
+  if (query) {
+    url.search = query.toString();
+  }
+  return url.toString();
+}
+
+function basicAuthHeader(account: ResolvedSmsAccount): string {
+  return `Basic ${Buffer.from(`${account.accountSid}:${account.authToken}`).toString("base64")}`;
+}
+
+function normalizeRequestHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers.map(([key, value]) => [key, value]));
+  }
+  return Object.fromEntries(Object.entries(headers));
+}
+
+async function requestTwilioApi(params: {
+  url: string;
+  account: ResolvedSmsAccount;
+  allowedHostname: string;
+  init?: RequestInit;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioApiResponse> {
+  const init = {
+    ...params.init,
+    headers: {
+      ...normalizeRequestHeaders(params.init?.headers),
+      authorization: basicAuthHeader(params.account),
+    },
+  } satisfies RequestInit;
+  if (params.fetchImpl) {
+    const response = await params.fetchImpl(params.url, init);
+    return {
+      ok: response.ok,
+      status: response.status,
+      text: await response.text(),
+    };
+  }
+
+  // The gateway egress path is SSRF-guarded and pinned to the Twilio hostname.
+  // HTTPS is enforced structurally: every Twilio URL is a hardcoded https://
+  // constant and the guard restricts egress to `allowedHostnames`, rejecting any
+  // non-http(s) protocol. (The fork's GuardedFetchOptions has no `requireHttps`.)
+  const guarded = await fetchWithSsrFGuard({
+    url: params.url,
+    init,
+    auditContext: "sms-twilio-api",
+    policy: { allowedHostnames: [params.allowedHostname] },
+    timeoutMs: params.timeoutMs ?? TWILIO_API_TIMEOUT_MS,
+  });
+  try {
+    return {
+      ok: guarded.response.ok,
+      status: guarded.response.status,
+      text: await guarded.response.text(),
+    };
+  } finally {
+    await guarded.release();
+  }
+}
+
+function parseTwilioIncomingPhoneNumber(
+  record: Record<string, unknown>,
+): TwilioIncomingPhoneNumber {
+  return {
+    sid: firstTrimmedString(record.sid),
+    phoneNumber: firstTrimmedString(record.phone_number ?? record.phoneNumber),
+    smsUrl: firstTrimmedString(record.sms_url ?? record.smsUrl),
+    smsMethod: firstTrimmedString(record.sms_method ?? record.smsMethod),
+    voiceUrl: firstTrimmedString(record.voice_url ?? record.voiceUrl),
+  };
+}
+
+function parseTwilioMessageLogEntry(record: Record<string, unknown>): TwilioMessageLogEntry {
+  return {
+    sid: firstTrimmedString(record.sid),
+    direction: firstTrimmedString(record.direction),
+    status: firstTrimmedString(record.status),
+    to: firstTrimmedString(record.to),
+    from: firstTrimmedString(record.from),
+    errorCode: firstStringish(record.error_code ?? record.errorCode).trim(),
+    body: firstString(record.body),
+    dateCreated: firstTrimmedString(record.date_created ?? record.dateCreated),
+    dateSent: firstTrimmedString(record.date_sent ?? record.dateSent),
+  };
+}
+
+function parseTwilioMessagingService(record: Record<string, unknown>): TwilioMessagingService {
+  return {
+    sid: firstTrimmedString(record.sid),
+    inboundRequestUrl: firstTrimmedString(record.inbound_request_url ?? record.inboundRequestUrl),
+    inboundMethod: firstTrimmedString(record.inbound_method ?? record.inboundMethod),
+    useInboundWebhookOnNumber: Boolean(
+      record.use_inbound_webhook_on_number ?? record.useInboundWebhookOnNumber,
+    ),
+  };
+}
+
+function parseTwilioListPayload<T>(
+  text: string,
+  key: string,
+  parseEntry: (record: Record<string, unknown>) => T,
+): T[] {
+  if (!text.trim()) {
+    return [];
+  }
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== "object") {
+    return [];
+  }
+  const items = (parsed as Record<string, unknown>)[key];
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .filter((item): item is Record<string, unknown> =>
+      Boolean(item && typeof item === "object" && !Array.isArray(item)),
+    )
+    .map(parseEntry);
+}
+
+export async function listTwilioIncomingPhoneNumbers(params: {
+  account: ResolvedSmsAccount;
+  phoneNumber?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioIncomingPhoneNumber[]> {
+  const query = new URLSearchParams();
+  if (params.phoneNumber) {
+    query.set("PhoneNumber", params.phoneNumber);
+  }
+  const response = await requestTwilioApi({
+    account: params.account,
+    url: twilioApiUrl(params.account.accountSid, "/IncomingPhoneNumbers.json", query),
+    allowedHostname: TWILIO_API_HOSTNAME,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text, "phone-number lookup");
+  }
+  return parseTwilioListPayload(
+    response.text,
+    "incoming_phone_numbers",
+    parseTwilioIncomingPhoneNumber,
+  );
+}
+
+export async function retrieveTwilioMessagingService(params: {
+  account: ResolvedSmsAccount;
+  serviceSid: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioMessagingService> {
+  const response = await requestTwilioApi({
+    account: params.account,
+    url: twilioMessagingUrl(`/Services/${encodeURIComponent(params.serviceSid)}`),
+    allowedHostname: TWILIO_MESSAGING_HOSTNAME,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text, "messaging-service lookup");
+  }
+  const parsed: unknown = JSON.parse(response.text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Twilio Messaging Service lookup returned malformed JSON.");
+  }
+  return parseTwilioMessagingService(parsed as Record<string, unknown>);
+}
+
+export async function listTwilioMessages(params: {
+  account: ResolvedSmsAccount;
+  to?: string;
+  from?: string;
+  pageSize?: number;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<TwilioMessageLogEntry[]> {
+  const query = new URLSearchParams();
+  if (params.to) {
+    query.set("To", params.to);
+  }
+  if (params.from) {
+    query.set("From", params.from);
+  }
+  query.set("PageSize", String(params.pageSize ?? 5));
+  const response = await requestTwilioApi({
+    account: params.account,
+    url: twilioApiUrl(params.account.accountSid, "/Messages.json", query),
+    allowedHostname: TWILIO_API_HOSTNAME,
+    fetchImpl: params.fetchImpl,
+    timeoutMs: params.timeoutMs,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text, "message lookup");
+  }
+  return parseTwilioListPayload(response.text, "messages", parseTwilioMessageLogEntry);
+}
+
+export async function sendSmsViaTwilio(params: {
+  account: ResolvedSmsAccount;
+  to: string;
+  text: string;
+  fetchImpl?: typeof fetch;
+}): Promise<SmsSendResult> {
+  if (!params.account.fromNumber && !params.account.messagingServiceSid) {
+    throw new Error("Twilio SMS send requires fromNumber or messagingServiceSid.");
+  }
+  const body = new URLSearchParams({
+    To: params.to,
+    Body: params.text,
+  });
+  if (params.account.fromNumber) {
+    body.set("From", params.account.fromNumber);
+  } else {
+    body.set("MessagingServiceSid", params.account.messagingServiceSid);
+  }
+  const init = {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body,
+  } satisfies RequestInit;
+  const response = await requestTwilioApi({
+    account: params.account,
+    url: twilioApiUrl(params.account.accountSid, "/Messages.json"),
+    allowedHostname: TWILIO_API_HOSTNAME,
+    init,
+    fetchImpl: params.fetchImpl,
+  });
+  if (!response.ok) {
+    throw new TwilioSmsApiError(response.status, response.text);
+  }
+  const payload = parseTwilioSuccessPayload(response.text);
+  const sid = payload.sid?.trim();
+  if (!sid) {
+    throw new Error("Twilio SMS send response did not include a Message SID.");
+  }
+  return {
+    sid,
+    to: payload.to?.trim() || params.to,
+    ...(payload.from?.trim() ? { from: payload.from.trim() } : {}),
+    ...(payload.status?.trim() ? { status: payload.status.trim() } : {}),
+  };
+}

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -312,15 +312,16 @@ async function requestTwilioApi(params: {
     };
   }
 
-  // The gateway egress path is SSRF-guarded and pinned to the Twilio hostname.
-  // HTTPS is enforced structurally: every Twilio URL is a hardcoded https://
-  // constant and the guard restricts egress to `allowedHostnames`, rejecting any
-  // non-http(s) protocol. (The fork's GuardedFetchOptions has no `requireHttps`.)
+  // The gateway egress path is SSRF-guarded and pinned to the Twilio hostname
+  // via `hostnameAllowlist` (egress allowlist — any hostname not on the list is
+  // rejected, and the pinned host stays subject to the private-IP rebinding
+  // re-check). HTTPS is enforced structurally: every Twilio URL is a hardcoded
+  // https:// constant. (The fork's GuardedFetchOptions has no `requireHttps`.)
   const guarded = await fetchWithSsrFGuard({
     url: params.url,
     init,
     auditContext: "sms-twilio-api",
-    policy: { allowedHostnames: [params.allowedHostname] },
+    policy: { hostnameAllowlist: [params.allowedHostname] },
     timeoutMs: params.timeoutMs ?? TWILIO_API_TIMEOUT_MS,
   });
   try {

--- a/extensions/sms/src/types.ts
+++ b/extensions/sms/src/types.ts
@@ -1,0 +1,54 @@
+import type { SecretInput } from "../../../src/plugin-sdk/secret-input-runtime.js";
+
+export type SmsChannelConfigFields = {
+  enabled?: boolean;
+  accountSid?: string;
+  authToken?: SecretInput;
+  fromNumber?: string;
+  messagingServiceSid?: string;
+  defaultTo?: string;
+  webhookPath?: string;
+  publicWebhookUrl?: string;
+  dangerouslyDisableSignatureValidation?: boolean;
+  dmPolicy?: "pairing" | "open" | "allowlist" | "disabled";
+  allowFrom?: string | Array<string | number>;
+  textChunkLimit?: number;
+};
+
+export interface SmsChannelConfig extends SmsChannelConfigFields {
+  accounts?: Record<string, SmsAccountRaw>;
+  defaultAccount?: string;
+}
+
+export interface SmsAccountRaw extends SmsChannelConfigFields {}
+
+export interface ResolvedSmsAccount {
+  accountId: string;
+  enabled: boolean;
+  accountSid: string;
+  authToken: string;
+  fromNumber: string;
+  messagingServiceSid: string;
+  defaultTo: string;
+  webhookPath: string;
+  publicWebhookUrl: string;
+  dangerouslyDisableSignatureValidation: boolean;
+  dmPolicy: "pairing" | "open" | "allowlist" | "disabled";
+  allowFrom: string[];
+  textChunkLimit: number;
+}
+
+export interface SmsInboundMessage {
+  messageSid: string;
+  accountSid: string;
+  from: string;
+  to: string;
+  body: string;
+}
+
+export type SmsSendResult = {
+  sid: string;
+  to: string;
+  from?: string;
+  status?: string;
+};


### PR DESCRIPTION
## Summary

**PR 1/5** of the Twilio SMS channel adapter — the **outbound spine**. Fork-native
**rewrite**, not a port: the v2026.6.1 sync landed SMS hollow, and upstream's files
import the gutted `plugin-sdk` channel-framework platform. These four files are
rebuilt on the fork's own kept surfaces.

No public endpoint is added here. No gutted-platform module is imported.

## What's included

| File | Purpose | Fork change vs upstream |
|------|---------|-------------------------|
| `status.ts` (+test) | Twilio delivery-status / webhook-config probe | verbatim port (zero non-relative imports) |
| `types.ts` | SMS config + resolved-account types | `SecretInput` re-homed onto kept `plugin-sdk/secret-input-runtime` |
| `send.ts` (+test) | SMS segmentation + markdown→plain-text | `chunkTextForOutbound` + `stripMarkdown` from kept `plugin-sdk/text-chunking` and `line/markdown-to-line` |
| `twilio.ts` (+test) | Twilio REST client + **X-Twilio-Signature validator** | local HMAC signature helper; egress + body-reader re-homed onto kept infra |

## Security (load-bearing)

The **`X-Twilio-Signature`** validator in `twilio.ts` is a **LOCAL `node:crypto`**
implementation:

- **HMAC-SHA1** over `(request URL) + (POST params sorted by key, concatenated
  key+value)`, base64-encoded, keyed by the Twilio auth token.
- Constant-time compare via **`crypto.timingSafeEqual`** (never `===`); rejects
  on missing / malformed / length-mismatched / wrong-token / spoofed-URL /
  tampered-payload signatures.
- A unit test asserts **Twilio's published signature vector** (URL + 5 POST params
  + token → `GvWf1cFY/Q7PnoempGyD5oXAezc=`), proving **accept-valid** and rejecting
  every tamper. The expected value was independently cross-checked with
  `openssl dgst -sha1 -hmac` — it is not self-computed.

**This helper gates the future PUBLIC inbound webhook (PR 4)** — Twilio's servers
POST to that endpoint and cannot present the gateway-operator credential, so the
endpoint must self-authenticate with this signature. **It warrants an independent
security review before the inbound PR merges** (per #3029). Please review the
helper here even though no endpoint is wired yet.

## Judgment calls for review (fork surfaces diverged from what the brief assumed)

The brief's stated import renames did not all match the fork's actual kept surfaces.
Flagging each, per the brief's request:

1. **`ssrf-runtime-internal` is GUTTED**, not kept. It's an empty sentinel
   (`SSRF_RUNTIME_INTERNAL_GUTTED = true`) and does **not** export
   `fetchWithSsrFGuard`. That function lives at `src/infra/net/fetch-guard.ts`
   (re-exported through per-channel plugin-sdk barrels). SMS has no barrel yet
   (PR 3), so `twilio.ts` imports it **relatively** — the pattern mattermost
   (`../../../../src/infra/net/fetch-guard.js`) and telegram already use.
2. **`requireHttps` was dropped.** The fork's `GuardedFetchOptions` has no such
   field (upstream's did). HTTPS stays enforced structurally: every Twilio URL is
   a hardcoded `https://` constant, egress is pinned to `allowedHostnames`, and the
   guard rejects non-http(s) protocols. The test assertion was updated to match.
3. **`webhook-ingress` → kept body reader, not a local copy.** The brief said
   "replace with a LOCAL implementation." Upstream's `webhook-ingress` provided
   `readRequestBodyWithLimit` (HTTP body reading with size/timeout limits) — **not**
   signature validation (which was always local `node:crypto`). The fork *keeps*
   that reader at `src/infra/http-body.ts` (issue #3029 lists `webhook-request-guards`
   among the kept building blocks). I imported the kept, already-tested function
   rather than duplicate ~100 lines of body-limit logic. Signature validation is
   local, as required. **If you'd prefer an inlined copy, it's a trivial swap.**
4. **`stripMarkdown` moved.** The fork's `text-chunking` exports only
   `chunkTextForOutbound`; `stripMarkdown` now lives in `line/markdown-to-line.ts`.
   `send.ts` imports each from its real home.
5. **Import style.** All un-barreled core internals use relative `../../../src/...`
   imports (proven across telegram/mattermost/discord and robust across `tsgo`,
   `vitest`, and the package `exports` firewall), rather than bare
   `remoteclaw/plugin-sdk/*` subpaths that aren't in the exports map.

`readTwilioWebhookForm` / `respondTwiml` are included (faithful to the upstream file
boundary) but have no callers/tests yet — PR 4's `webhook.ts` consumes them.

## Deferred to later PRs (per #3029)

- **PR 2** — config / identity (`config-schema`, `accounts`, `secret-contract`).
- **PR 3** — channel definition + registration (`channel.ts`, `index.ts`, manifest,
  api barrels, bundled-channel catalog entry).
- **PR 4** — inbound spine (`webhook`, `inbound`, `gateway`): the PUBLIC endpoint that
  validates `X-Twilio-Signature` in-handler. **Independent security review required.**
- **PR 5** — test-harness port + docs.

## Gates (all green locally)

- `pnpm check` — **green** (oxfmt clean; `tsgo` typecheck clean, incl. test files;
  oxlint type-aware 0/0; all fork-integrity greps clean).
- SMS unit tests — **28 passed** across `status` / `send` / `twilio` (incl. the
  signature-vector test).
- Gutted-module import scan over `extensions/sms/` — **empty**.
- Residual-`openclaw` scan over the four source files — **empty**.
- Standalone fork gates (rebrand, zombie-import, stub-debt, throwing-stub-callers,
  obsolescence-audit) — **all pass**.

## Do not merge

Hold for the orchestrator's **independent security review of the signature helper**.

Refs #3029

🤖 Generated with [Claude Code](https://claude.com/claude-code)
