### PR TITLE
feat(sms): config + identity (2/5, #3029)

### DIFF
--- a/extensions/sms/package.json
+++ b/extensions/sms/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "zod": "4.4.3"
+    "zod": "4.3.6"
   },
   "devDependencies": {},
   "remoteclaw": {

--- a/extensions/sms/src/accounts.test.ts
+++ b/extensions/sms/src/accounts.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { listSmsAccountIds, resolveSmsAccount } from "./accounts.js";
+import { SmsConfigSchema } from "./config-schema.js";
+
+const ENV_KEYS = [
+  "TWILIO_ACCOUNT_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SMS_FROM",
+  "TWILIO_MESSAGING_SERVICE_SID",
+  "SMS_PUBLIC_WEBHOOK_URL",
+  "SMS_WEBHOOK_PATH",
+  "SMS_ALLOWED_USERS",
+  "SMS_DANGEROUSLY_DISABLE_SIGNATURE_VALIDATION",
+  "SMS_TEXT_CHUNK_LIMIT",
+] as const;
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+describe("SMS account config", () => {
+  it("resolves default account config and pairing policy", () => {
+    const account = resolveSmsAccount({
+      channels: {
+        sms: {
+          accountSid: " AC123 ",
+          authToken: " token ",
+          fromNumber: "(555) 123-4567",
+          defaultTo: "sms:+1 (555) 000-1111",
+          publicWebhookUrl: " https://example.com/webhooks/sms ",
+        },
+      },
+    });
+
+    expect(account).toMatchObject({
+      accountId: "default",
+      accountSid: "AC123",
+      authToken: "token",
+      fromNumber: "+5551234567",
+      messagingServiceSid: "",
+      defaultTo: "+15550001111",
+      webhookPath: "/webhooks/sms",
+      publicWebhookUrl: "https://example.com/webhooks/sms",
+      dmPolicy: "pairing",
+      allowFrom: [],
+      textChunkLimit: 1500,
+    });
+  });
+
+  it("merges named accounts over the top-level defaults", () => {
+    const cfg = {
+      channels: {
+        sms: {
+          accountSid: "AC-parent",
+          authToken: "parent-token",
+          fromNumber: "+15550000000",
+          accounts: {
+            support: {
+              fromNumber: "+15551112222",
+              webhookPath: "/webhooks/sms/support",
+              dmPolicy: "allowlist",
+              allowFrom: ["sms:+15553334444"],
+            },
+          },
+        },
+      },
+    };
+
+    expect(listSmsAccountIds(cfg)).toEqual(["default", "support"]);
+    expect(resolveSmsAccount(cfg, "support")).toMatchObject({
+      accountId: "support",
+      accountSid: "AC-parent",
+      authToken: "parent-token",
+      fromNumber: "+15551112222",
+      webhookPath: "/webhooks/sms/support",
+      dmPolicy: "allowlist",
+      allowFrom: ["+15553334444"],
+    });
+  });
+
+  it("normalizes numeric allowFrom entries accepted by config schema", () => {
+    const cfg = {
+      channels: {
+        sms: {
+          accountSid: "AC-parent",
+          authToken: "parent-token",
+          fromNumber: "+15550000000",
+          allowFrom: [1_555_333_4444],
+        },
+      },
+    };
+
+    expect(SmsConfigSchema.parse(cfg.channels.sms).allowFrom).toEqual([1_555_333_4444]);
+    expect(resolveSmsAccount(cfg)).toMatchObject({
+      allowFrom: ["+15553334444"],
+    });
+  });
+
+  it("uses the configured default account when accountId is omitted", () => {
+    const cfg = {
+      channels: {
+        sms: {
+          defaultAccount: "support",
+          accounts: {
+            support: {
+              accountSid: "AC-support",
+              authToken: "support-token",
+              fromNumber: "+15551112222",
+              textChunkLimit: 700,
+            },
+          },
+        },
+      },
+    };
+
+    expect(resolveSmsAccount(cfg)).toMatchObject({
+      accountId: "support",
+      accountSid: "AC-support",
+      authToken: "support-token",
+      fromNumber: "+15551112222",
+      textChunkLimit: 700,
+    });
+  });
+
+  it("treats top-level enabled false as a channel kill switch", () => {
+    const cfg = {
+      channels: {
+        sms: {
+          enabled: false,
+          accounts: {
+            support: {
+              enabled: true,
+              accountSid: "AC-support",
+              authToken: "support-token",
+              fromNumber: "+15551112222",
+            },
+          },
+        },
+      },
+    };
+
+    expect(resolveSmsAccount(cfg, "support")).toMatchObject({
+      accountId: "support",
+      enabled: false,
+    });
+  });
+
+  it("uses env fallbacks for the default account only", () => {
+    process.env.TWILIO_ACCOUNT_SID = "AC-env";
+    process.env.TWILIO_AUTH_TOKEN = "env-token";
+    process.env.TWILIO_PHONE_NUMBER = "+15550001111";
+    process.env.TWILIO_MESSAGING_SERVICE_SID = "MG-env";
+    process.env.SMS_WEBHOOK_PATH = "/webhooks/sms/env";
+    process.env.SMS_PUBLIC_WEBHOOK_URL = "https://sms.example.com/webhook";
+    process.env.SMS_ALLOWED_USERS = "sms:+15552223333,+15554445555";
+    process.env.SMS_DANGEROUSLY_DISABLE_SIGNATURE_VALIDATION = "true";
+    process.env.SMS_TEXT_CHUNK_LIMIT = "800";
+
+    const cfg = { channels: { sms: { accounts: { support: { enabled: true } } } } };
+
+    expect(listSmsAccountIds(cfg)).toEqual(["default", "support"]);
+    expect(resolveSmsAccount(cfg)).toMatchObject({
+      accountSid: "AC-env",
+      authToken: "env-token",
+      fromNumber: "+15550001111",
+      messagingServiceSid: "MG-env",
+      webhookPath: "/webhooks/sms/env",
+      publicWebhookUrl: "https://sms.example.com/webhook",
+      dangerouslyDisableSignatureValidation: true,
+      allowFrom: ["+15552223333", "+15554445555"],
+      textChunkLimit: 800,
+    });
+    expect(resolveSmsAccount(cfg, "support")).toMatchObject({
+      accountId: "support",
+      accountSid: "",
+      authToken: "",
+      fromNumber: "",
+      messagingServiceSid: "",
+      webhookPath: "/webhooks/sms",
+      publicWebhookUrl: "",
+      dangerouslyDisableSignatureValidation: false,
+      allowFrom: [],
+      textChunkLimit: 1500,
+    });
+  });
+
+  it("coerces numeric allowFrom entries accepted by the config schema", () => {
+    const parsed = SmsConfigSchema.parse({
+      accountSid: "AC123",
+      authToken: "token",
+      fromNumber: "+15550001111",
+      allowFrom: [15551234567],
+    });
+
+    expect(resolveSmsAccount({ channels: { sms: parsed } })).toMatchObject({
+      allowFrom: ["+15551234567"],
+    });
+  });
+
+  it("discovers env-only SMS credentials as the implicit default account", () => {
+    process.env.TWILIO_ACCOUNT_SID = "AC-env";
+    process.env.TWILIO_AUTH_TOKEN = "env-token";
+    process.env.TWILIO_SMS_FROM = "+15550001111";
+
+    expect(listSmsAccountIds({})).toEqual(["default"]);
+    expect(resolveSmsAccount({})).toMatchObject({
+      accountId: "default",
+      accountSid: "AC-env",
+      authToken: "env-token",
+      fromNumber: "+15550001111",
+    });
+  });
+
+  it("uses TWILIO_SMS_FROM when the legacy from-number env var is blank", () => {
+    process.env.TWILIO_ACCOUNT_SID = "AC-env";
+    process.env.TWILIO_AUTH_TOKEN = "env-token";
+    process.env.TWILIO_PHONE_NUMBER = " ";
+    process.env.TWILIO_SMS_FROM = "+15550001111";
+
+    expect(resolveSmsAccount({})).toMatchObject({
+      fromNumber: "+15550001111",
+    });
+  });
+
+  it("accepts a Twilio Messaging Service SID instead of a from number", () => {
+    process.env.TWILIO_ACCOUNT_SID = "AC-env";
+    process.env.TWILIO_AUTH_TOKEN = "env-token";
+    process.env.TWILIO_MESSAGING_SERVICE_SID = "MG-env";
+
+    expect(listSmsAccountIds({})).toEqual(["default"]);
+    expect(resolveSmsAccount({})).toMatchObject({
+      accountSid: "AC-env",
+      authToken: "env-token",
+      fromNumber: "",
+      messagingServiceSid: "MG-env",
+    });
+  });
+
+  it("accepts secret references for Twilio auth tokens", () => {
+    expect(() =>
+      SmsConfigSchema.parse({
+        accountSid: "AC123",
+        authToken: { source: "env", provider: "default", id: "TWILIO_AUTH_TOKEN" },
+        fromNumber: "+15550001111",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      resolveSmsAccount({
+        channels: {
+          sms: {
+            accountSid: "AC123",
+            authToken: { source: "env", provider: "default", id: "TWILIO_AUTH_TOKEN" },
+            fromNumber: "+15550001111",
+          },
+        },
+      }),
+    ).toThrow('channels.sms.authToken: unresolved SecretRef "env:default:TWILIO_AUTH_TOKEN"');
+  });
+});

--- a/extensions/sms/src/accounts.ts
+++ b/extensions/sms/src/accounts.ts
@@ -1,0 +1,164 @@
+import {
+  normalizeStringEntries,
+  parseStrictInteger,
+} from "remoteclaw/plugin-sdk/string-coerce-runtime";
+import {
+  createAccountListHelpers,
+  resolveMergedAccountConfig,
+} from "../../../src/channels/plugins/account-helpers.js";
+import type { RemoteClawConfig } from "../../../src/config/config.js";
+import { resolveAccountEntry } from "../../../src/routing/account-lookup.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeOptionalAccountId,
+} from "../../../src/routing/session-key.js";
+import { normalizeSmsAllowFrom, normalizeSmsPhoneNumber } from "./phone.js";
+import { hasConfiguredSecretInput, normalizeResolvedSecretInputString } from "./secret-input.js";
+import type { ResolvedSmsAccount, SmsChannelConfig } from "./types.js";
+
+const CHANNEL_ID = "sms";
+const DEFAULT_WEBHOOK_PATH = "/webhooks/sms";
+const DEFAULT_TEXT_CHUNK_LIMIT = 1500;
+
+function getChannelConfig(cfg: RemoteClawConfig): SmsChannelConfig | undefined {
+  return cfg.channels?.[CHANNEL_ID] as SmsChannelConfig | undefined;
+}
+
+function parseList(raw: unknown): string[] {
+  if (!raw) {
+    return [];
+  }
+  const entries = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+      ? normalizeStringEntries(raw.split(","))
+      : [raw];
+  return entries.map((entry) => normalizeSmsAllowFrom(String(entry))).filter(Boolean);
+}
+
+function parseTextChunkLimit(raw: unknown): number {
+  if (typeof raw === "number" && Number.isSafeInteger(raw) && raw > 0) {
+    return raw;
+  }
+  if (typeof raw === "string" && /^\d+$/.test(raw.trim())) {
+    return parseStrictInteger(raw.trim()) ?? DEFAULT_TEXT_CHUNK_LIMIT;
+  }
+  return DEFAULT_TEXT_CHUNK_LIMIT;
+}
+
+function firstNonBlankEnv(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value?.trim());
+}
+
+function hasBaseAccount(channelCfg: SmsChannelConfig | undefined): boolean {
+  return Boolean(
+    channelCfg?.accountSid ||
+    hasConfiguredSecretInput(channelCfg?.authToken) ||
+    channelCfg?.fromNumber ||
+    channelCfg?.messagingServiceSid ||
+    process.env.TWILIO_ACCOUNT_SID ||
+    process.env.TWILIO_AUTH_TOKEN ||
+    process.env.TWILIO_PHONE_NUMBER ||
+    process.env.TWILIO_SMS_FROM ||
+    process.env.TWILIO_MESSAGING_SERVICE_SID,
+  );
+}
+
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers(CHANNEL_ID, {
+  hasImplicitDefaultAccount: (cfg) => hasBaseAccount(getChannelConfig(cfg)),
+});
+
+export const listSmsAccountIds = listAccountIds;
+export const resolveDefaultSmsAccountId = resolveDefaultAccountId;
+
+export function resolveSmsAccount(
+  cfg: RemoteClawConfig,
+  accountId?: string | null,
+): ResolvedSmsAccount {
+  const channelCfg = getChannelConfig(cfg) ?? {};
+  const id = normalizeOptionalAccountId(accountId) ?? resolveDefaultSmsAccountId(cfg);
+  const accountConfig = resolveAccountEntry(channelCfg.accounts, id);
+  const channelConfig: Record<string, unknown> & SmsChannelConfig = { ...channelCfg };
+  const accountEntries:
+    | Record<string, Partial<Record<string, unknown> & SmsChannelConfig>>
+    | undefined = channelCfg.accounts
+    ? Object.fromEntries(
+        Object.entries(channelCfg.accounts).map(([accountKey, account]) => [
+          accountKey,
+          { ...account },
+        ]),
+      )
+    : undefined;
+  const merged = resolveMergedAccountConfig<Record<string, unknown> & SmsChannelConfig>({
+    channelConfig,
+    accounts: accountEntries,
+    accountId: id,
+    omitKeys: ["defaultAccount"],
+  });
+
+  const useEnvFallbacks = id === DEFAULT_ACCOUNT_ID;
+  const envAccountSid = useEnvFallbacks ? process.env.TWILIO_ACCOUNT_SID : undefined;
+  const envAuthToken = useEnvFallbacks ? process.env.TWILIO_AUTH_TOKEN : undefined;
+  const envFromNumber = useEnvFallbacks
+    ? firstNonBlankEnv(process.env.TWILIO_PHONE_NUMBER, process.env.TWILIO_SMS_FROM)
+    : undefined;
+  const envMessagingServiceSid = useEnvFallbacks
+    ? process.env.TWILIO_MESSAGING_SERVICE_SID
+    : undefined;
+  const envWebhookPath = useEnvFallbacks ? process.env.SMS_WEBHOOK_PATH : undefined;
+  const envPublicWebhookUrl = useEnvFallbacks ? process.env.SMS_PUBLIC_WEBHOOK_URL : undefined;
+  const envAllowFrom = useEnvFallbacks ? process.env.SMS_ALLOWED_USERS : undefined;
+  const envTextChunkLimit = useEnvFallbacks ? process.env.SMS_TEXT_CHUNK_LIMIT : undefined;
+  const envDisableSignatureValidation = useEnvFallbacks
+    ? process.env.SMS_DANGEROUSLY_DISABLE_SIGNATURE_VALIDATION
+    : undefined;
+
+  const webhookPath = (merged.webhookPath ?? envWebhookPath ?? DEFAULT_WEBHOOK_PATH).trim();
+  const publicWebhookUrl = (merged.publicWebhookUrl ?? envPublicWebhookUrl ?? "").trim();
+  const authToken =
+    normalizeResolvedSecretInputString({
+      value: merged.authToken ?? envAuthToken,
+      path:
+        id === DEFAULT_ACCOUNT_ID
+          ? "channels.sms.authToken"
+          : `channels.sms.accounts.${id}.authToken`,
+    }) ?? "";
+  return {
+    accountId: id,
+    enabled: channelCfg.enabled !== false && accountConfig?.enabled !== false,
+    accountSid: (merged.accountSid ?? envAccountSid ?? "").trim(),
+    authToken,
+    fromNumber: normalizeSmsPhoneNumber(merged.fromNumber ?? envFromNumber ?? ""),
+    messagingServiceSid: (merged.messagingServiceSid ?? envMessagingServiceSid ?? "").trim(),
+    defaultTo: normalizeSmsPhoneNumber(merged.defaultTo ?? ""),
+    webhookPath: webhookPath || DEFAULT_WEBHOOK_PATH,
+    publicWebhookUrl,
+    dangerouslyDisableSignatureValidation:
+      merged.dangerouslyDisableSignatureValidation === true ||
+      envDisableSignatureValidation === "true",
+    dmPolicy: merged.dmPolicy ?? "pairing",
+    allowFrom: parseList(merged.allowFrom ?? envAllowFrom),
+    textChunkLimit: parseTextChunkLimit(merged.textChunkLimit ?? envTextChunkLimit),
+  };
+}
+
+export function inspectSmsAccount(cfg: RemoteClawConfig, accountId?: string | null) {
+  const account = resolveSmsAccount(cfg, accountId);
+  const configured = isSmsAccountConfigured(account);
+  return {
+    enabled: account.enabled,
+    configured,
+    tokenStatus: account.authToken ? "available" : "missing",
+    webhookPath: account.webhookPath,
+    signatureValidation:
+      account.dangerouslyDisableSignatureValidation || account.publicWebhookUrl
+        ? "configured"
+        : "missing-public-url",
+  };
+}
+
+export function isSmsAccountConfigured(account: ResolvedSmsAccount): boolean {
+  return Boolean(
+    account.accountSid && account.authToken && (account.fromNumber || account.messagingServiceSid),
+  );
+}

--- a/extensions/sms/src/config-schema.ts
+++ b/extensions/sms/src/config-schema.ts
@@ -1,0 +1,61 @@
+import {
+  AllowFromListSchema,
+  buildChannelConfigSchema,
+  DmPolicySchema,
+  requireOpenAllowFrom,
+} from "remoteclaw/plugin-sdk";
+import { z } from "zod";
+import { requireChannelOpenAllowFrom } from "../../shared/config-schema-helpers.js";
+import { buildSecretInputSchema } from "./secret-input.js";
+
+const SecretInputSchema = buildSecretInputSchema();
+
+// Base account shape, kept identical to upstream. The `.strict().superRefine`
+// pair is split into an unrefined base (so it can be `.extend`ed) plus a refined
+// wrapper, mirroring the live peer extensions/mattermost/src/config-schema.ts —
+// the fork's Zod rejects `.extend` on an already-refined schema.
+const SmsAccountConfigSchemaBase = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    accountSid: z.string().optional(),
+    authToken: SecretInputSchema.optional(),
+    fromNumber: z.string().optional(),
+    messagingServiceSid: z.string().optional(),
+    defaultTo: z.string().optional(),
+    webhookPath: z.string().optional(),
+    publicWebhookUrl: z.string().optional(),
+    dangerouslyDisableSignatureValidation: z.boolean().optional(),
+    dmPolicy: DmPolicySchema.optional().default("pairing"),
+    allowFrom: AllowFromListSchema,
+    textChunkLimit: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const SmsAccountConfigSchema = SmsAccountConfigSchemaBase.superRefine((value, ctx) => {
+  requireChannelOpenAllowFrom({
+    channel: "sms",
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    requireOpenAllowFrom,
+  });
+});
+
+export const SmsConfigSchema = SmsAccountConfigSchemaBase.extend({
+  accounts: z.record(z.string(), SmsAccountConfigSchema.optional()).optional(),
+  defaultAccount: z.string().optional(),
+}).superRefine((value, ctx) => {
+  requireChannelOpenAllowFrom({
+    channel: "sms",
+    policy: value.dmPolicy,
+    allowFrom: value.allowFrom,
+    ctx,
+    requireOpenAllowFrom,
+  });
+});
+
+// The fork's `buildChannelConfigSchema` takes only the schema — upstream's second
+// `{ uiHints }` argument (config-editor labels) is not part of the fork's kept
+// primitive (consumer-onboarding UX was gutted), so the uiHints block is dropped.
+export const SmsChannelConfigSchema = buildChannelConfigSchema(SmsConfigSchema);

--- a/extensions/sms/src/secret-input.ts
+++ b/extensions/sms/src/secret-input.ts
@@ -1,0 +1,21 @@
+import {
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+} from "../../../src/plugin-sdk/secret-input-runtime.js";
+import { buildSecretInputSchema } from "../../../src/plugin-sdk/secret-input-schema.js";
+
+// Fork-native secret-input shim for the SMS channel.
+//
+// Peers re-export these symbols from their own `remoteclaw/plugin-sdk/<channel>`
+// barrel (see extensions/mattermost/src/secret-input.ts). SMS has no per-channel
+// barrel, and the underlying `secret-input-schema` / `secret-input-runtime`
+// subpaths are not keys in root package.json "exports" (typecheck-only), so this
+// shim sources them via direct `../../../src/...` relative imports — the fork's
+// convention for un-barreled core internals.
+export {
+  buildSecretInputSchema,
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,8 +437,8 @@ importers:
   extensions/sms:
     dependencies:
       zod:
-        specifier: 4.4.3
-        version: 4.4.3
+        specifier: 4.3.6
+        version: 4.3.6
 
   extensions/synology-chat:
     dependencies:


### PR DESCRIPTION
Second PR of the fork-native Twilio SMS channel adapter (epic #3029), building on PR-1's outbound spine (#3030).

## Included
- **`config-schema.ts`** — zod schema for SMS account config, re-homed onto the fork's kept config primitives (imported from the exported `remoteclaw/plugin-sdk` index barrel). Mirrors `extensions/mattermost`'s split-base refinement pattern; drops upstream's `{ uiHints }` arg (the fork's `buildChannelConfigSchema` takes one argument — the config-editor UX was gutted).
- **`accounts.ts`** — account resolution + env fallbacks, mirroring `extensions/signal` (account machinery via direct `../../../src/...` relative imports). The Twilio `authToken` is resolved through the kept secret-input path — no custom secret logic.
- **`secret-input.ts`** — a local shim re-exporting the fork's secret-input symbols via direct relative imports (the `secret-input` / `secret-input-schema` plugin-sdk subpaths are typecheck-only, not runtime-exported).
- **`accounts.test.ts`** — ported from upstream (11 tests).

## Deferred
- `secret-contract-api.ts` stub + the api barrels (`channel-plugin-api.ts`, `contract-api.ts`) + channel registration → **PR-3**. Upstream's `secret-contract.ts` secret-target-registry logic is intentionally dropped (gutted fork-wide).
- Inbound public webhook → **PR-4** (independent security review before merge).

## Dependency note
`extensions/sms/package.json` pinned zod at the upstream-origin exact `4.4.3`, which skews against the fork standard (zod 4.3.6, used by root + 11 peer extensions) and caused a dual-copy type mismatch against the fork's 4.3.6-compiled config primitives. Pinned to exact `4.3.6` to force dedup. (`extensions/acpx` carries the same upstream-origin `4.4.3` skew — tracked as a separate cleanup.)

## Gates
`pnpm tsgo` green (0 errors) · `accounts.test.ts` 11/11 · no gutted or non-exported plugin-sdk imports · both barrel imports confirmed runtime-exported in `package.json`.

Refs #3029
