### PR TITLE
feat(sms): channel definition + registration (3/5, #3029)

### DIFF
--- a/extensions/sms/channel-plugin-api.ts
+++ b/extensions/sms/channel-plugin-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled channel entry imports narrow so bootstrap/discovery paths do
+// not drag the SMS send/status/Twilio surfaces into lightweight plugin loads.
+export { smsPlugin } from "./src/channel.js";

--- a/extensions/sms/index.ts
+++ b/extensions/sms/index.ts
@@ -1,0 +1,17 @@
+import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk/core";
+import { emptyPluginConfigSchema } from "remoteclaw/plugin-sdk/core";
+import { smsPlugin } from "./src/channel.js";
+import { setSmsRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "sms",
+  name: "SMS",
+  description: "Twilio SMS channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: RemoteClawPluginApi) {
+    setSmsRuntime(api.runtime);
+    api.registerChannel({ plugin: smsPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/sms/remoteclaw.plugin.json
+++ b/extensions/sms/remoteclaw.plugin.json
@@ -1,0 +1,18 @@
+{
+  "id": "sms",
+  "channels": ["sms"],
+  "channelEnvVars": {
+    "sms": [
+      "TWILIO_ACCOUNT_SID",
+      "TWILIO_AUTH_TOKEN",
+      "TWILIO_PHONE_NUMBER",
+      "TWILIO_SMS_FROM",
+      "TWILIO_MESSAGING_SERVICE_SID"
+    ]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/sms/secret-contract-api.ts
+++ b/extensions/sms/secret-contract-api.ts
@@ -1,0 +1,4 @@
+// SMS does not expose secret-contract surfaces.
+export const secretTargetRegistryEntries: readonly [] = [];
+
+export function collectRuntimeConfigAssignments(): void {}

--- a/extensions/sms/src/channel.test.ts
+++ b/extensions/sms/src/channel.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { listChannelPluginCatalogEntries } from "../../../src/channels/plugins/catalog.js";
+import { smsPlugin } from "./channel.js";
+
+describe("sms channel plugin", () => {
+  it("loads the channel module and exposes the plugin identity", () => {
+    // The import above is the real gate: a stale/gutted plugin-sdk subpath or a
+    // non-exported specifier fails here with ERR_MODULE_NOT_FOUND, which a
+    // typecheck-only pass (tsconfig `paths`) would not catch.
+    expect(smsPlugin.id).toBe("sms");
+    expect(smsPlugin.meta.id).toBe("sms");
+    expect(smsPlugin.meta.label).toBe("SMS");
+    expect(smsPlugin.meta.selectionLabel).toBe("SMS (Twilio)");
+  });
+
+  it("declares a text-only direct-message channel", () => {
+    expect(smsPlugin.capabilities.chatTypes).toEqual(["direct"]);
+    expect(smsPlugin.capabilities.media).toBe(false);
+  });
+
+  it("wires the config, security, messaging, outbound and status adapters", () => {
+    expect(smsPlugin.configSchema).toBeDefined();
+    expect(smsPlugin.reload?.configPrefixes).toEqual(["channels.sms"]);
+    expect(typeof smsPlugin.config.listAccountIds).toBe("function");
+    expect(typeof smsPlugin.config.resolveAccount).toBe("function");
+    expect(typeof smsPlugin.security?.resolveDmPolicy).toBe("function");
+    expect(typeof smsPlugin.messaging?.targetResolver?.looksLikeId).toBe("function");
+    expect(smsPlugin.outbound?.deliveryMode).toBe("direct");
+    expect(typeof smsPlugin.outbound?.sendText).toBe("function");
+    expect(typeof smsPlugin.status?.probeAccount).toBe("function");
+  });
+
+  it("ships send-only: no gateway block until the inbound webhook lands (PR-4)", () => {
+    expect(smsPlugin.gateway).toBeUndefined();
+    expect(smsPlugin.gatewayMethods).toBeUndefined();
+    // SMS is text-only; MMS/media sending is out of scope for this channel.
+    expect(smsPlugin.outbound?.sendMedia).toBeUndefined();
+  });
+
+  it("normalizes and recognizes E.164 targets", () => {
+    expect(smsPlugin.messaging?.normalizeTarget?.("+1 (555) 123-4567")).toBe("+15551234567");
+    expect(smsPlugin.messaging?.normalizeTarget?.("   ")).toBeUndefined();
+    expect(smsPlugin.messaging?.targetResolver?.looksLikeId?.("+15551234567")).toBe(true);
+    expect(smsPlugin.messaging?.targetResolver?.looksLikeId?.("not-a-number")).toBe(false);
+  });
+
+  it("is discovered by the channel plugin catalog via manifest presence", () => {
+    // Registration is presence-discovery: shipping package.json's
+    // `remoteclaw.channel` block plus index.ts is what registers sms. No shared
+    // production file lists it, so this asserts the discovery path really works.
+    const entries = listChannelPluginCatalogEntries();
+    const sms = entries.find((entry) => entry.id === "sms");
+    expect(sms).toBeDefined();
+    expect(sms?.meta.label).toBe("SMS");
+    expect(sms?.meta.selectionLabel).toBe("SMS (Twilio)");
+    expect(sms?.install.npmSpec).toBe("@remoteclaw/sms");
+    // `pluginId` is resolved by loading this extension's remoteclaw.plugin.json.
+    // It is the discriminating assertion: `id`/`meta` above are derived from
+    // package.json's `remoteclaw.channel` (shipped in PR-2) and would pass
+    // without this PR, whereas `pluginId` is undefined until the manifest lands.
+    expect(sms?.pluginId).toBe("sms");
+  });
+});

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -1,0 +1,250 @@
+import {
+  applyAccountNameToChannelSection,
+  applySetupAccountConfigPatch,
+  buildAccountScopedDmSecurityPolicy,
+  buildBaseAccountStatusSnapshot,
+  buildBaseChannelStatusSummary,
+  collectAllowlistProviderRestrictSendersWarnings,
+  collectStatusIssuesFromLastError,
+  createDefaultChannelRuntimeState,
+  createScopedAccountConfigAccessors,
+  DEFAULT_ACCOUNT_ID,
+  deleteAccountFromConfigSection,
+  migrateBaseNameToDefaultAccount,
+  normalizeAccountId,
+  setAccountEnabledInConfigSection,
+  type ChannelMeta,
+  type ChannelPlugin,
+} from "remoteclaw/plugin-sdk/compat";
+import { chunkTextForOutbound } from "../../../src/plugin-sdk/text-chunking.js";
+import {
+  isSmsAccountConfigured,
+  listSmsAccountIds,
+  resolveDefaultSmsAccountId,
+  resolveSmsAccount,
+} from "./accounts.js";
+import { SmsChannelConfigSchema } from "./config-schema.js";
+import {
+  looksLikeSmsPhoneNumber,
+  normalizeSmsAllowFrom,
+  normalizeSmsPhoneNumber,
+} from "./phone.js";
+import { sendSmsTextChunks } from "./send.js";
+import { probeSmsAccount } from "./status.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+// SMS is a plugin channel, not one of the nine static leaf channels in
+// CHAT_CHANNEL_ORDER, so the shared leaf-meta lookup does not accept "sms" as a
+// ChatChannelId. Meta is declared inline (as mattermost/matrix do) and mirrors
+// the `remoteclaw.channel` block in this package's package.json verbatim.
+const meta: ChannelMeta = {
+  id: "sms",
+  label: "SMS",
+  selectionLabel: "SMS (Twilio)",
+  detailLabel: "Twilio SMS",
+  docsPath: "/channels/sms",
+  docsLabel: "sms",
+  blurb: "Twilio-backed SMS with inbound webhooks and outbound replies.",
+  order: 88,
+  quickstartAllowFrom: true,
+};
+
+const smsConfigAccessors = createScopedAccountConfigAccessors({
+  // PR-2's resolveSmsAccount takes positional args; the accessor factory passes
+  // an object, so adapt rather than assume the peers' object-form signature.
+  resolveAccount: ({ cfg, accountId }) => resolveSmsAccount(cfg, accountId),
+  resolveAllowFrom: (account: ResolvedSmsAccount) => account.allowFrom,
+  formatAllowFrom: (allowFrom) =>
+    allowFrom.map((entry) => normalizeSmsAllowFrom(String(entry))).filter(Boolean),
+  resolveDefaultTo: (account: ResolvedSmsAccount) => account.defaultTo,
+});
+
+export const smsPlugin: ChannelPlugin<ResolvedSmsAccount> = {
+  id: "sms",
+  meta: {
+    ...meta,
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    media: false,
+  },
+  reload: { configPrefixes: ["channels.sms"] },
+  configSchema: SmsChannelConfigSchema,
+  config: {
+    listAccountIds: (cfg) => listSmsAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveSmsAccount(cfg, accountId),
+    defaultAccountId: (cfg) => resolveDefaultSmsAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) =>
+      setAccountEnabledInConfigSection({
+        cfg,
+        sectionKey: "sms",
+        accountId,
+        enabled,
+        allowTopLevel: true,
+      }),
+    deleteAccount: ({ cfg, accountId }) =>
+      deleteAccountFromConfigSection({
+        cfg,
+        sectionKey: "sms",
+        accountId,
+        clearBaseFields: [
+          "accountSid",
+          "authToken",
+          "fromNumber",
+          "messagingServiceSid",
+          "defaultTo",
+          "webhookPath",
+          "publicWebhookUrl",
+          "name",
+        ],
+      }),
+    isConfigured: (account) => isSmsAccountConfigured(account),
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      enabled: account.enabled,
+      configured: isSmsAccountConfigured(account),
+    }),
+    ...smsConfigAccessors,
+  },
+  security: {
+    resolveDmPolicy: ({ cfg, accountId, account }) => {
+      return buildAccountScopedDmSecurityPolicy({
+        cfg,
+        channelKey: "sms",
+        accountId,
+        fallbackAccountId: account.accountId ?? DEFAULT_ACCOUNT_ID,
+        // ResolvedSmsAccount is flat — dmPolicy/allowFrom sit on the account
+        // itself, not under an `account.config` sub-object like signal's.
+        policy: account.dmPolicy,
+        allowFrom: account.allowFrom ?? [],
+        policyPathSuffix: "dmPolicy",
+        normalizeEntry: (raw) => normalizeSmsAllowFrom(raw),
+      });
+    },
+    collectWarnings: ({ cfg }) => {
+      return collectAllowlistProviderRestrictSendersWarnings({
+        cfg,
+        providerConfigPresent: cfg.channels?.sms !== undefined,
+        // SMS is direct-only (no group chat surface), so there is no group
+        // policy to reconcile — only the sender-restriction warning applies.
+        configuredGroupPolicy: undefined,
+        surface: "SMS",
+        openScope: "any sender",
+        groupPolicyPath: "channels.sms.dmPolicy",
+        groupAllowFromPath: "channels.sms.allowFrom",
+        mentionGated: false,
+      });
+    },
+  },
+  messaging: {
+    // The adapter contract is `string | undefined`; PR-2's normalizer returns ""
+    // for unusable input, so collapse that to undefined like the signal peer.
+    normalizeTarget: (raw) => normalizeSmsPhoneNumber(raw) || undefined,
+    targetResolver: {
+      looksLikeId: looksLikeSmsPhoneNumber,
+      hint: "<E.164 phone, e.g. +15551234567>",
+    },
+  },
+  setup: {
+    resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+    applyAccountName: ({ cfg, accountId, name }) =>
+      applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "sms",
+        accountId,
+        name,
+      }),
+    validateInput: ({ accountId, input }) => {
+      if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+        return "SMS env vars can only be used for the default account.";
+      }
+      // ChannelSetupInput has no accountSid/fromNumber/messagingServiceSid
+      // slots, so Twilio identity is supplied via TWILIO_* env vars (--use-env)
+      // or by editing channels.sms directly. --token seeds the auth token only.
+      if (!input.useEnv && !input.token) {
+        return "SMS requires --use-env (TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN/TWILIO_PHONE_NUMBER) or --token.";
+      }
+      return null;
+    },
+    applyAccountConfig: ({ cfg, accountId, input }) => {
+      const namedConfig = applyAccountNameToChannelSection({
+        cfg,
+        channelKey: "sms",
+        accountId,
+        name: input.name,
+      });
+      const next =
+        accountId !== DEFAULT_ACCOUNT_ID
+          ? migrateBaseNameToDefaultAccount({
+              cfg: namedConfig,
+              channelKey: "sms",
+            })
+          : namedConfig;
+      const webhookPath = input.webhookPath?.trim();
+      const publicWebhookUrl = input.webhookUrl?.trim();
+      const patch = input.useEnv
+        ? {}
+        : {
+            ...(input.token ? { authToken: input.token } : {}),
+            ...(webhookPath ? { webhookPath } : {}),
+            ...(publicWebhookUrl ? { publicWebhookUrl } : {}),
+          };
+      return applySetupAccountConfigPatch({
+        cfg: next,
+        channelKey: "sms",
+        accountId,
+        patch,
+      });
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    // Same splitter PR-1's sendSmsTextChunks uses internally, so the core-level
+    // chunk pass and the send-level pass agree and the second is a no-op.
+    chunker: (text, limit) => chunkTextForOutbound(text, limit),
+    chunkerMode: "text",
+    textChunkLimit: 1500,
+    // SMS is text-only: no sendMedia (MMS is out of scope for this channel).
+    sendText: async ({ cfg, to, text, accountId }) => {
+      const account = resolveSmsAccount(cfg, accountId);
+      const results = await sendSmsTextChunks({ account, to, text });
+      // Twilio returns one message per SMS segment; OutboundDeliveryResult is
+      // singular. Report the LAST segment's sid as the canonical messageId (it
+      // is the reply the recipient sees last / replies to) and keep every sid
+      // plus the segment count under `meta` so nothing is lost.
+      const last = results.at(-1);
+      return {
+        channel: "sms",
+        messageId: last?.sid ?? "",
+        meta: {
+          segmentCount: results.length,
+          messageSids: results.map((result) => result.sid),
+          ...(last?.status ? { status: last.status } : {}),
+          ...(last?.from ? { from: last.from } : {}),
+          to,
+        },
+      };
+    },
+  },
+  status: {
+    defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+    collectStatusIssues: (accounts) => collectStatusIssuesFromLastError("sms", accounts),
+    buildChannelSummary: ({ snapshot }) => ({
+      ...buildBaseChannelStatusSummary(snapshot),
+      probe: snapshot.probe,
+    }),
+    probeAccount: async ({ account, timeoutMs }) => await probeSmsAccount({ account, timeoutMs }),
+    buildAccountSnapshot: ({ account, runtime, probe }) =>
+      buildBaseAccountStatusSnapshot({
+        account: {
+          accountId: account.accountId,
+          enabled: account.enabled,
+          configured: isSmsAccountConfigured(account),
+        },
+        runtime,
+        probe,
+      }),
+  },
+  // No `gateway` block: PR-3 ships a send-only channel. The inbound webhook
+  // (and its gateway adapter) lands in PR-4, which is reviewed separately.
+};


### PR DESCRIPTION
Third PR of the Twilio SMS channel adapter. Defines the `ChannelPlugin` and
registers it. Builds on PR-1 (outbound spine) and PR-2 (config + identity).

Refs #3029

## Files included

| File | Purpose |
|------|---------|
| `extensions/sms/src/channel.ts` | `smsPlugin: ChannelPlugin<ResolvedSmsAccount>` — the channel definition |
| `extensions/sms/index.ts` | `register(api)` entry (extension **root**, per PR-2's `remoteclaw.extensions: ["./index.ts"]`) |
| `extensions/sms/remoteclaw.plugin.json` | Plugin manifest (outbound env-var hints only) |
| `extensions/sms/channel-plugin-api.ts` | Narrow parity barrel (mirrors irc/matrix) |
| `extensions/sms/secret-contract-api.ts` | Empty stub (mirrors whatsapp/signal) — the deferred PR-2 stub |
| `extensions/sms/src/channel.test.ts` | Runtime load + catalog-discovery test (6 cases) |

No shared `src/` file is touched — `git diff --name-only c1df89e4037 -- src/` is empty.

## Registration is manifest presence-discovery (no shared-file edit)

There is no shared channel catalog to edit. `listChannelPluginCatalogEntries()`
walks `extensions/`, reads each `package.json` → `remoteclaw.channel`, and loads
each extension's `index.ts` default export. SMS registers purely by shipping its
own files.

Meta is built **inline**. SMS is a plugin channel, not one of the nine static
leaf channels in `CHAT_CHANNEL_ORDER`, so `"sms"` is not a `ChatChannelId` and
the shared leaf-meta lookup does not accept it. This mirrors
`extensions/mattermost/src/channel.ts` and `extensions/matrix/src/channel.ts`.
Values are copied verbatim from PR-2's `package.json` `remoteclaw.channel`.

## `SmsSendResult[]` → `OutboundDeliveryResult` reduction

`sendSmsTextChunks` returns one `SmsSendResult` per SMS segment; the outbound
contract is singular and requires a `messageId`. The reduction:

- **`messageId` = the LAST segment's `sid`** — that is the message the recipient
  sees last and replies to, so it is the correct correlation handle.
- **Nothing is discarded**: `meta` carries `segmentCount`, the full ordered
  `messageSids` array, plus the last segment's `status`/`from` and the `to`.

## Deferred to PR-4 (public inbound webhook, separately security-reviewed)

- The `gateway:` block / `gatewayMethods` — `gateway` is optional on
  `ChannelPlugin`, so PR-3 ships a valid **send-only** channel.
- `webhook.ts`, `inbound.ts`, `gateway.ts`.
- Inbound env-var hints (`SMS_PUBLIC_WEBHOOK_URL`, `SMS_WEBHOOK_PATH`,
  `SMS_ALLOWED_USERS`) — the manifest lists outbound `TWILIO_*` hints only.

`sendMedia` is omitted deliberately and permanently: SMS is text-only (MMS is
out of scope for this channel).

## Judgment calls for review

1. **Import specifiers.** `remoteclaw/plugin-sdk/sms` does not exist (confirmed
   absent from root `package.json` `"exports"`) and is never imported.
   `channel.ts` uses `remoteclaw/plugin-sdk/compat` — the convention in every
   peer `channel.ts` (32 files: signal, mattermost, matrix, irc, discord,
   feishu, googlechat, imessage, bluebubbles…). `index.ts` uses the focused
   `remoteclaw/plugin-sdk/core`, matching `extensions/policy/index.ts`, the
   closest precedent for an extension with no curated per-channel subpath.
   Both are keys in the runtime `"exports"` map.
2. **Dormant gate found (pre-existing, not introduced here).**
   `scripts/check-no-monolithic-plugin-sdk-entry-imports.ts` forbids *both* the
   root barrel *and* `/compat`, but it is **not wired into CI, not in
   `pnpm check`, and currently crashes** — it imports `scripts/check-file-utils`,
   which does not exist in the tree (a fork-sync casualty). No focused subpath
   carries `channel.ts`'s full symbol set, which is exactly why curated
   per-channel barrels exist; SMS has none and creating one would require
   editing shared root `package.json`. Worth tracking separately.
3. **`configSchema` reuses PR-2's pre-built export.** PR-2's `config-schema.ts`
   already exports `SmsChannelConfigSchema = buildChannelConfigSchema(SmsConfigSchema)`,
   so the plugin consumes that rather than rebuilding the schema.
4. **`formatSmsProbeLines` is NOT wired.** `ChannelStatusAdapter` has no slot for
   probe-line formatters and no peer `channel.ts` references one;
   `ChannelCapabilitiesDisplayLine` is a *local* type in PR-2's `status.ts`. It
   stays exported for a later consumer rather than being forced into a field the
   type does not have. `probeSmsAccount` *is* wired (`status.probeAccount`).
5. **Flat account shape.** `ResolvedSmsAccount` is flat — `dmPolicy`/`allowFrom`
   sit on the account, not under `account.config` as in signal/mattermost. The
   `security` block reads the flat fields. Likewise PR-2's
   `resolveSmsAccount(cfg, accountId)` is positional, so
   `createScopedAccountConfigAccessors` gets an adapter rather than the peers'
   object-form signature.
6. **`setup` is constrained by `ChannelSetupInput`.** That shared type has no
   `accountSid`/`fromNumber`/`messagingServiceSid` slots and may not be edited
   here. Following mattermost's `useEnv` pattern, Twilio identity arrives via
   `TWILIO_*` env vars (`--use-env`, already wired in PR-2's `accounts.ts`) or
   direct config edit; `--token` seeds the auth token, `--webhook-path`/
   `--webhook-url` seed the webhook fields.
7. **Chunker.** Uses PR-1's own `chunkTextForOutbound`, so the core-level chunk
   pass and `sendSmsTextChunks`' internal pass use the *same* splitter and the
   second is a no-op (rather than two different splitters disagreeing).

## Verification

- `pnpm tsgo` → exit 0, no errors.
- `pnpm lint` (`oxlint --type-aware`) → 0 warnings, 0 errors across 5397 files.
- `oxfmt --check` → clean.
- `extensions/sms/src/channel.test.ts` → **6/6 pass**, and `vitest list` confirms
  the CI `test-extensions` lane collects all 6 *without* a file argument (so it
  is genuinely gated, not only runnable when force-run). SMS is not quarantined.
- The catalog-discovery assertion was falsification-tested: with
  `remoteclaw.plugin.json` removed, `pluginId` disappears while `id`/`meta`
  (derived from PR-2's `package.json`) remain — so `pluginId` is the assertion
  that actually discriminates this PR's contribution, and it is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
