### PR TITLE
fix(sms): MessageSid replay-dedup for the inbound webhook (#3035)

### DIFF
--- a/extensions/sms/src/inbound.test.ts
+++ b/extensions/sms/src/inbound.test.ts
@@ -446,6 +446,9 @@ describe("sms inbound webhook — authorization is default-deny", () => {
       runtime: allowed,
       account: baseAccount({ dmPolicy: "pairing", allowFrom: [] }),
       signature: "valid",
+      // Distinct MessageSid: this is a SECOND inbound message, not a redelivery
+      // of the one above, so it must not be swallowed by the replay dedup.
+      form: formBody({ MessageSid: "SM00000000000000000000000000000002" }),
     });
     expect(allowedResult.status).toBe(200);
     expect(allowed.dispatchReply).toHaveBeenCalledTimes(1);
@@ -566,6 +569,54 @@ describe("sms inbound webhook — delivery seam", () => {
     expect(logged).not.toContain(SENTINEL_TOKEN);
     // And nothing is echoed to the caller either.
     expect(result.body).not.toContain(SENTINEL_TOKEN);
+  });
+});
+
+describe("sms inbound webhook — MessageSid replay dedup", () => {
+  it("delivers a MessageSid ONCE: the replayed POST is ACKed but never re-delivered", async () => {
+    // Twilio signatures carry no timestamp or nonce, so this second request is
+    // byte-identical to the first and just as signature-valid (#3035).
+    const spies = createRuntime();
+    const form = formBody({ MessageSid: "SM000000000000000000000000000000aa" });
+
+    const first = await post({ runtime: spies, signature: "valid", form });
+    const replay = await post({ runtime: spies, signature: "valid", form });
+
+    expect(first.status).toBe(200);
+    // The replay is ACKed exactly like the original — it learns nothing from
+    // the response, and a legitimate Twilio retry is satisfied.
+    expect(replay.status).toBe(200);
+    expect(replay.body).toBe("<Response></Response>");
+
+    // The real delivery seam ran exactly once: the replay never reached the
+    // runtime, the session store, or the outbound SMS path.
+    expect(spies.dispatchReply).toHaveBeenCalledTimes(1);
+    expect(spies.finalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(spies.recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(sendSmsTextChunks).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers BOTH when two POSTs carry different MessageSids", async () => {
+    // Identical body, different sid: the dedup must key on the sid alone and
+    // must not coalesce two genuinely distinct inbound messages.
+    const spies = createRuntime();
+
+    const first = await post({
+      runtime: spies,
+      signature: "valid",
+      form: formBody({ MessageSid: "SM000000000000000000000000000000ab" }),
+    });
+    const second = await post({
+      runtime: spies,
+      signature: "valid",
+      form: formBody({ MessageSid: "SM000000000000000000000000000000ac" }),
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(spies.dispatchReply).toHaveBeenCalledTimes(2);
+    expect(spies.finalizeInboundContext).toHaveBeenCalledTimes(2);
+    expect(sendSmsTextChunks).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/extensions/sms/src/inbound.ts
+++ b/extensions/sms/src/inbound.ts
@@ -39,8 +39,41 @@ const smsWebhookRateLimiter = createFixedWindowRateLimiter({
   maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
 });
 
+/**
+ * Bounded replay/retry dedup for the public SMS webhook, keyed by `MessageSid`.
+ *
+ * Twilio's `X-Twilio-Signature` carries no timestamp and no nonce, so a
+ * captured, signature-valid POST stays valid indefinitely and can be replayed
+ * to re-inject the same inbound message into the agent (#3035). A fixed-window
+ * limiter with `maxRequests: 1` IS a bounded dedup: the first request carrying
+ * a given sid passes, any repeat inside the window is a replay. Reuses the same
+ * kept primitive as `smsWebhookRateLimiter` above, so memory stays bounded —
+ * `maxTrackedKeys` LRU-evicts the least-recently-seen sids.
+ *
+ * The window also makes legitimate Twilio retries idempotent: a redelivered
+ * webhook is ACKed without re-running the agent.
+ *
+ * Two bounds are deliberately accepted for this LOW-severity hardening:
+ *  - Per-process and in-memory, exactly like the rate limiter above: a restart
+ *    or a second gateway instance starts with an empty window.
+ *  - Fixed window rather than a sliding TTL: a replay that arrives after the
+ *    window has elapsed is allowed through again.
+ * Both are acceptable because Twilio retries and duplicates land within
+ * minutes, and presenting a sid at all still requires a signature-valid request
+ * (i.e. the account auth token) — this guard sits AFTER signature validation.
+ */
+const SMS_REPLAY_WINDOW_MS = 5 * 60_000;
+const SMS_REPLAY_MAX_TRACKED_SIDS = 2_048;
+
+const smsReplayGuard = createFixedWindowRateLimiter({
+  windowMs: SMS_REPLAY_WINDOW_MS,
+  maxRequests: 1,
+  maxTrackedKeys: SMS_REPLAY_MAX_TRACKED_SIDS,
+});
+
 export function clearSmsWebhookRateLimitStateForTest(): void {
   smsWebhookRateLimiter.clear();
+  smsReplayGuard.clear();
 }
 
 export type SmsWebhookLog = {
@@ -89,8 +122,10 @@ function isSmsSenderAllowed(senderId: string, allowFrom: string[]): boolean {
  *  2. `X-Twilio-Signature` is verified fail-closed against the account auth
  *     token before ANY message reaches the runtime. Missing/invalid/unsigned
  *     ⇒ 403 and no delivery.
- *  3. Allowlist authorization is default-deny via the shared command-auth path.
- *  4. Every response body is empty TwiML: no secret, token, or signature is
+ *  3. A signature-valid POST is deduped by `MessageSid` before delivery, so a
+ *     captured request cannot be replayed into repeated agent runs (#3035).
+ *  4. Allowlist authorization is default-deny via the shared command-auth path.
+ *  5. Every response body is empty TwiML: no secret, token, or signature is
  *     echoed back to the caller.
  */
 export function createSmsWebhookHandler(
@@ -175,6 +210,26 @@ export function createSmsWebhookHandler(
           `[sms] dropped malformed inbound webhook payload for account ${account.accountId}`,
         );
         respondTwiml(res, 400);
+        return true;
+      }
+
+      // Replay dedup (#3035), after signature validation and before any
+      // delivery: a signature-valid POST is only acted on once per `MessageSid`
+      // inside the window. `buildTwilioInboundMessage` already rejects a blank
+      // sid with 400 above, so this is unreachable with an empty key; the
+      // explicit check keeps a future relaxation of that guard from coalescing
+      // distinct messages under one blank key.
+      if (
+        inbound.messageSid &&
+        smsReplayGuard.isRateLimited(`${account.accountId}:${inbound.messageSid}`)
+      ) {
+        log?.info?.(
+          `[sms] ignored duplicate inbound webhook for account ${account.accountId} ` +
+            `(MessageSid ${inbound.messageSid} already handled)`,
+        );
+        // Same empty-TwiML ACK as the success path: a replay learns nothing
+        // from the response, and a legitimate Twilio retry is satisfied.
+        respondTwiml(res, 200);
         return true;
       }
 


### PR DESCRIPTION
## The threat

`extensions/sms/src/inbound.ts` validates every inbound request's `X-Twilio-Signature` fail-closed, but Twilio's signature scheme carries **no timestamp and no nonce**. A captured, signature-valid POST therefore stays valid indefinitely and **replays forever** — each replay re-injected the same inbound message into the AgentRuntime, so an agent performing a non-idempotent action per inbound SMS re-ran it once per replay. Signature validation alone does not stop replay.

Rated LOW (from the #3034 security review) because the exploit precondition is real: this guard sits **after** signature validation, so presenting a `MessageSid` at all requires a signature-valid request — an attacker cannot spoof arbitrary sids without the account auth token. That bounds the threat; the fix is cheap regardless.

## The fix

Dedup by `MessageSid`, placed between `buildTwilioInboundMessage(form)` and `deliverSmsInbound(...)`: a repeat sid is ACKed with the same empty TwiML as the success path and never reaches delivery.

It reuses the **kept bounded-memory primitive this handler already imports** — `createFixedWindowRateLimiter` from `src/plugin-sdk/webhook-memory-guards.js`, the same one backing `smsWebhookRateLimiter`. A fixed-window limiter with `maxRequests: 1` *is* a bounded replay dedup: the first request carrying a given sid passes, any repeat inside the window is a replay. `maxTrackedKeys` LRU-evicts the least-recently-seen sids (`touch()` re-inserts, `pruneMapToMaxSize` evicts from the Map front), so memory stays bounded.

**Zero shared `src/` edit** — the whole point of reusing the kept primitive. Only two files change, both under `extensions/sms/`:

```
extensions/sms/src/inbound.ts
extensions/sms/src/inbound.test.ts
```

The key is namespaced `${account.accountId}:${messageSid}`, mirroring the existing rate-limit key, so one account's sid cannot suppress another's. The existing test-reset hook (`clearSmsWebhookRateLimitStateForTest`) now clears both guards.

## Chosen values

| Value | Setting | Rationale |
|---|---|---|
| `windowMs` | `5 * 60_000` (5 min) | On the order of Twilio's retry/duplicate-delivery window, which lands within minutes. |
| `maxTrackedKeys` | `2_048` | ~6.8 msg/s sustained before LRU eviction — far above any plausible inbound SMS rate for this middleware. Hard-bounded state: ~150 B/entry (key + window state + Map overhead) puts the cap in the low hundreds of KB. |

## Retry-idempotency win

Beyond replay, this makes **legitimate Twilio retries idempotent**: a redelivered webhook is ACKed without re-running the agent. That is a functional improvement, not just a hardening.

## Bounds deliberately accepted (LOW severity)

- **Per-process, in-memory** — exactly like the existing `smsWebhookRateLimiter`. A restart, or a second gateway instance, starts with an empty window.
- **Fixed window, not a sliding TTL** — a replay arriving after the window elapses is allowed through again. Twilio retries land well inside 5 minutes.
- **LRU eviction** under sid pressure degrades gracefully to the pre-fix behaviour for the evicted sid. Note that flooding distinct sids to force eviction already requires the auth token, i.e. the ability to inject arbitrary messages outright — strictly worse than replay, so no new vector is introduced.

## Blank `MessageSid`

A blank key cannot coalesce distinct messages: `buildTwilioInboundMessage` returns `null` when `MessageSid`/`SmsSid`/`SmsMessageSid` are all blank, so a blank sid is already rejected with 400 **before** the dedup point. The explicit `inbound.messageSid &&` short-circuit is defence-in-depth against a future relaxation of that guard.

## Tests

Two new tests in `extensions/sms/src/inbound.test.ts`, asserting on the **real delivery seam** spies (`dispatchReplyWithBufferedBlockDispatcher`, `finalizeInboundContext`, `recordInboundSession`, `sendSmsTextChunks`) — no mocked dedup:

- *delivers a MessageSid ONCE: the replayed POST is ACKed but never re-delivered* — two byte-identical signature-valid POSTs ⇒ delivery invoked exactly once, the second returns 200 `<Response></Response>`.
- *delivers BOTH when two POSTs carry different MessageSids* — identical body, different sid ⇒ delivery invoked twice, so the dedup cannot over-match distinct messages.

Verified non-tautological: short-circuiting the guard turns the first test red (`expected "vi.fn()" to be called 1 times, but got 2 times`).

One pre-existing test needed a fixture adjustment: *"honors a sender paired via the allow-from store under the pairing policy"* POSTs twice within one test and reused the default `MessageSid`. Its second POST is a genuinely distinct inbound message, so it now carries a distinct sid. No assertion was weakened.

## Gates

- `pnpm tsgo` — green.
- `pnpm check` (format + typecheck + lint + fork-integrity gates) — green.
- `pnpm vitest run extensions/sms/` — **72 passed** (the pre-existing 70 + 2 new).

Closes #3035
