### PR TITLE
feat(matrix): render @mentions as matrix.to pills with m.mentions metadata (#3045)

### DIFF
--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -1,6 +1,13 @@
 // Matrix tests cover format plugin behavior.
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import { describe, expect, it } from "vitest";
-import { markdownToMatrixHtml } from "./format.js";
+import { markdownToMatrixHtml, renderMarkdownToMatrixHtmlWithMentions } from "./format.js";
+
+function createMentionClient(selfUserId = "@bot:example.org") {
+  return {
+    getUserId: async () => selfUserId,
+  } as unknown as MatrixClient;
+}
 
 describe("markdownToMatrixHtml", () => {
   it("renders basic inline formatting", () => {
@@ -43,5 +50,309 @@ describe("markdownToMatrixHtml", () => {
   it("preserves line breaks", () => {
     const html = markdownToMatrixHtml("line1\nline2");
     expect(html).toContain("<br");
+  });
+});
+
+describe("renderMarkdownToMatrixHtmlWithMentions", () => {
+  it("renders qualified Matrix user mentions as matrix.to links and m.mentions metadata", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a></p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@alice:example.org"],
+    });
+  });
+
+  it("url-encodes matrix.to hrefs for valid mxids with path characters", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @foo/bar:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40foo%2Fbar%3Aexample.org">@foo/bar:example.org</a></p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@foo/bar:example.org"],
+    });
+  });
+
+  it("treats mxids that begin with room as user mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @room:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40room%3Aexample.org">@room:example.org</a></p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@room:example.org"],
+    });
+  });
+
+  it("treats hyphenated room-prefixed mxids as user mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @room-admin:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40room-admin%3Aexample.org">@room-admin:example.org</a></p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@room-admin:example.org"],
+    });
+  });
+
+  it("keeps explicit room mentions as room mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @room",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>hello @room</p>");
+    expect(result.mentions).toEqual({
+      room: true,
+    });
+  });
+
+  it("treats sentence-ending room mentions as room mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @room.",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>hello @room.</p>");
+    expect(result.mentions).toEqual({
+      room: true,
+    });
+  });
+
+  it("treats colon-suffixed room mentions as room mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @room:",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>hello @room:</p>");
+    expect(result.mentions).toEqual({
+      room: true,
+    });
+  });
+
+  it("trims punctuation before storing mentioned user ids", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice:example.org.",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a>.</p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@alice:example.org"],
+    });
+  });
+
+  it("does not emit mentions for mxid-like tokens with path suffixes", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice:example.org/path",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>hello @alice:example.org/path</p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("does not emit mentions for filename-embedded mxids with trailing hyphens", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      "<p>read matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt</p>",
+    );
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("accepts bracketed homeservers in matrix mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice:[2001:db8::1]",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40alice%3A%5B2001%3Adb8%3A%3A1%5D">@alice:[2001:db8::1]</a></p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@alice:[2001:db8::1]"],
+    });
+  });
+
+  it("accepts bracketed homeservers with ports in matrix mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice:[2001:db8::1]:8448.",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40alice%3A%5B2001%3Adb8%3A%3A1%5D%3A8448">@alice:[2001:db8::1]:8448</a>.</p>',
+    );
+    expect(result.mentions).toEqual({
+      user_ids: ["@alice:[2001:db8::1]:8448"],
+    });
+  });
+
+  it("leaves bare localpart text unmentioned", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>hello @alice</p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("does not mention the sending account itself", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @bot:example.org",
+      client: createMentionClient("@bot:example.org"),
+    });
+
+    expect(result.html).toBe("<p>hello @bot:example.org</p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("deduplicates repeated mentions of the same user", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "@alice:example.org and @alice:example.org again",
+      client: createMentionClient(),
+    });
+
+    expect(result.mentions).toEqual({
+      user_ids: ["@alice:example.org"],
+    });
+  });
+
+  it("renders mentions inside list items", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "1. hello @alice:example.org\n\n2. bye",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toContain(
+      '<a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a>',
+    );
+    expect(result.mentions).toEqual({ user_ids: ["@alice:example.org"] });
+  });
+
+  it("still escapes raw HTML while resolving mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "<img src=x onerror=alert(1)> @alice:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(result.html).not.toContain("<img");
+    expect(result.mentions).toEqual({ user_ids: ["@alice:example.org"] });
+  });
+
+  it("does not convert escaped qualified mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "\\@alice:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>@alice:example.org</p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("does not convert escaped room mentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "\\@room",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>@room</p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("keeps escaped mentions literal after escaped backticks", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "\\`literal then \\@alice:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p>`literal then @alice:example.org</p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("restores escaped mentions in markdown link labels without linking them", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "[\\@alice:example.org](https://example.com)",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe('<p><a href="https://example.com">@alice:example.org</a></p>');
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("keeps backslashes inside code spans", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "`\\@alice:example.org`",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p><code>\\@alice:example.org</code></p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("does not convert mentions inside code spans", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "`@alice:example.org`",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<p><code>@alice:example.org</code></p>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("keeps backslashes inside tilde fenced code blocks", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "~~~\n\\@alice:example.org\n~~~",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<pre><code>\\@alice:example.org\n</code></pre>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("keeps backslashes inside indented code blocks", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "    \\@alice:example.org",
+      client: createMentionClient(),
+    });
+
+    expect(result.html).toBe("<pre><code>\\@alice:example.org\n</code></pre>");
+    expect(result.mentions).toStrictEqual({});
+  });
+
+  it("does not resolve a self id when the client cannot report one", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "hello @alice:example.org",
+      client: {} as unknown as MatrixClient,
+    });
+
+    expect(result.html).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a></p>',
+    );
+    expect(result.mentions).toEqual({ user_ids: ["@alice:example.org"] });
   });
 });

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -1,5 +1,7 @@
 // Matrix helper module supports format behavior.
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import MarkdownIt from "markdown-it";
+import { normalizeLowercaseStringOrEmpty } from "remoteclaw/plugin-sdk/string-coerce-runtime";
 
 const md = new MarkdownIt({
   html: false,
@@ -11,6 +13,44 @@ const md = new MarkdownIt({
 md.enable("strikethrough");
 
 const { escapeHtml } = md.utils;
+
+export type MatrixMentions = {
+  room?: boolean;
+  user_ids?: string[];
+};
+
+type MarkdownToken = ReturnType<typeof md.parse>[number];
+type MarkdownInlineToken = NonNullable<MarkdownToken["children"]>[number];
+type MatrixMentionCandidate = {
+  raw: string;
+  start: number;
+  end: number;
+  kind: "room" | "user";
+  userId?: string;
+};
+
+/**
+ * Minimal structural view of the one `MatrixClient` member the mention pipeline
+ * needs. Upstream spells this as an inline cast at the point of use
+ * (`(client as { getUserId?: ... }).getUserId`); naming it keeps the cast out of
+ * the function body. `getUserId` stays optional because the guard below still
+ * has to tolerate a client that does not expose it.
+ */
+type MatrixMentionSelfClient = {
+  getUserId?: () => Promise<string> | string;
+};
+
+// Private-use code point (U+E000) used to park `\@` escapes while the mention
+// scanner runs, so escaped mentions are never turned into pills. Written as an
+// escape sequence on purpose: the raw character is invisible in review.
+const ESCAPED_MENTION_SENTINEL = "\uE000";
+const MENTION_PATTERN = /@[A-Za-z0-9._=+\-/:[\]]+/g;
+const MATRIX_MENTION_SERVER_NAME_PATTERN =
+  /(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?))*(?::\d+)?/;
+const MATRIX_MENTION_USER_ID_PATTERN = new RegExp(
+  `^@[A-Za-z0-9._=+\\-/]+:(?:${MATRIX_MENTION_SERVER_NAME_PATTERN.source}|\\[[0-9A-Fa-f:.]+\\](?::\\d+)?)$`,
+);
+const TRIMMABLE_MENTION_SUFFIX = /[),.!?:;\]]/;
 
 /**
  * File extensions that share TLDs and commonly appear in code/documentation.
@@ -87,4 +127,331 @@ md.renderer.rules.link_close = (tokens, idx, options, _env, self) => {
 export function markdownToMatrixHtml(markdown: string): string {
   const rendered = md.render(markdown ?? "");
   return rendered.trimEnd();
+}
+
+/**
+ * Replaces `\@` escapes outside code spans/fences with a sentinel so the mention
+ * scanner cannot see them. Code spans keep their literal backslash — the
+ * sentinel is restored differently for code (`restoreEscapedMentionsInCode`)
+ * than for prose (`restoreEscapedMentions`).
+ */
+function maskEscapedMentions(markdown: string): string {
+  let masked = "";
+  let idx = 0;
+  let codeFenceLength = 0;
+
+  while (idx < markdown.length) {
+    if (markdown[idx] === "`" && !isMarkdownEscaped(markdown, idx)) {
+      let runLength = 1;
+      while (markdown[idx + runLength] === "`") {
+        runLength += 1;
+      }
+      if (codeFenceLength === 0) {
+        codeFenceLength = runLength;
+      } else if (runLength === codeFenceLength) {
+        codeFenceLength = 0;
+      }
+      masked += markdown.slice(idx, idx + runLength);
+      idx += runLength;
+      continue;
+    }
+    if (codeFenceLength === 0 && markdown[idx] === "\\" && markdown[idx + 1] === "@") {
+      masked += ESCAPED_MENTION_SENTINEL;
+      idx += 2;
+      continue;
+    }
+    masked += markdown[idx] ?? "";
+    idx += 1;
+  }
+
+  return masked;
+}
+
+function isMarkdownEscaped(markdown: string, idx: number): boolean {
+  let slashCount = 0;
+  let cursor = idx - 1;
+  while (cursor >= 0 && markdown[cursor] === "\\") {
+    slashCount += 1;
+    cursor -= 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function restoreEscapedMentions(text: string): string {
+  return text.replaceAll(ESCAPED_MENTION_SENTINEL, "@");
+}
+
+function restoreEscapedMentionsInCode(text: string): string {
+  return text.replaceAll(ESCAPED_MENTION_SENTINEL, "\\@");
+}
+
+function restoreEscapedMentionsInBlockTokens(tokens: MarkdownToken[]): void {
+  for (const token of tokens) {
+    if ((token.type === "fence" || token.type === "code_block") && token.content) {
+      token.content = restoreEscapedMentionsInCode(token.content);
+    }
+  }
+}
+
+function isMentionStartBoundary(charBefore: string | undefined): boolean {
+  return !charBefore || !/[A-Za-z0-9_]/.test(charBefore);
+}
+
+function trimMentionSuffix(
+  rawInput: string,
+  endInput: number,
+): { raw: string; end: number } | null {
+  let raw = rawInput;
+  let end = endInput;
+  while (raw.length > 1 && TRIMMABLE_MENTION_SUFFIX.test(raw.at(-1) ?? "")) {
+    if (raw.at(-1) === "]" && /\[[0-9A-Fa-f:.]+\](?::\d+)?$/i.test(raw)) {
+      break;
+    }
+    raw = raw.slice(0, -1);
+    end -= 1;
+  }
+  if (!raw.startsWith("@") || raw === "@") {
+    return null;
+  }
+  return { raw, end };
+}
+
+/**
+ * Fork-local equivalent of upstream's `isMatrixQualifiedUserId` from
+ * `./target-ids.js`, which this fork does not carry. Same predicate, inlined
+ * here the way `isAutoLinkedFileRef` already is in this module.
+ */
+function isMatrixQualifiedUserId(raw: string): boolean {
+  const trimmed = raw.trim();
+  return trimmed.startsWith("@") && trimmed.includes(":");
+}
+
+function isMatrixMentionUserId(raw: string): boolean {
+  return isMatrixQualifiedUserId(raw) && MATRIX_MENTION_USER_ID_PATTERN.test(raw);
+}
+
+function buildMentionCandidate(raw: string, start: number): MatrixMentionCandidate | null {
+  const normalized = trimMentionSuffix(raw, start + raw.length);
+  if (!normalized) {
+    return null;
+  }
+  const kind = normalizeLowercaseStringOrEmpty(normalized.raw) === "@room" ? "room" : "user";
+  const base: MatrixMentionCandidate = {
+    raw: normalized.raw,
+    start,
+    end: normalized.end,
+    kind,
+  };
+  if (kind === "room") {
+    return base;
+  }
+  const userCandidate = isMatrixMentionUserId(normalized.raw)
+    ? { ...base, userId: normalized.raw }
+    : null;
+  if (!userCandidate) {
+    return null;
+  }
+  return userCandidate;
+}
+
+function collectMentionCandidates(text: string): MatrixMentionCandidate[] {
+  const mentions: MatrixMentionCandidate[] = [];
+  for (const match of text.matchAll(MENTION_PATTERN)) {
+    const raw = match[0];
+    const start = match.index ?? -1;
+    if (start < 0 || !raw) {
+      continue;
+    }
+    if (!isMentionStartBoundary(text[start - 1])) {
+      continue;
+    }
+    const candidate = buildMentionCandidate(raw, start);
+    if (!candidate) {
+      continue;
+    }
+    mentions.push(candidate);
+  }
+  return mentions;
+}
+
+function createToken(
+  sample: MarkdownInlineToken,
+  type: string,
+  tag: string,
+  nesting: number,
+): MarkdownInlineToken {
+  const TokenCtor = sample.constructor as new (
+    type: string,
+    tag: string,
+    nesting: number,
+  ) => MarkdownInlineToken;
+  return new TokenCtor(type, tag, nesting);
+}
+
+function createTextToken(sample: MarkdownInlineToken, content: string): MarkdownInlineToken {
+  const token = createToken(sample, "text", "", 0);
+  token.content = content;
+  return token;
+}
+
+function createMentionLinkTokens(params: {
+  sample: MarkdownInlineToken;
+  href: string;
+  label: string;
+}): MarkdownInlineToken[] {
+  const open = createToken(params.sample, "link_open", "a", 1);
+  open.attrSet("href", params.href);
+  const text = createTextToken(params.sample, params.label);
+  const close = createToken(params.sample, "link_close", "a", -1);
+  return [open, text, close];
+}
+
+function resolveMentionUserId(match: MatrixMentionCandidate): string | null {
+  if (match.kind !== "user") {
+    return null;
+  }
+  return match.userId ?? null;
+}
+
+async function resolveMatrixSelfUserId(client: MatrixMentionSelfClient): Promise<string | null> {
+  const getUserId = client.getUserId;
+  if (typeof getUserId !== "function") {
+    return null;
+  }
+  return await Promise.resolve(getUserId.call(client)).catch(() => null);
+}
+
+function mutateInlineTokensWithMentions(params: {
+  children: MarkdownInlineToken[];
+  userIds: string[];
+  seenUserIds: Set<string>;
+  selfUserId: string | null;
+}): { children: MarkdownInlineToken[]; roomMentioned: boolean } {
+  const nextChildren: MarkdownInlineToken[] = [];
+  let roomMentioned = false;
+  let insideLinkDepth = 0;
+  for (const child of params.children) {
+    if (child.type === "link_open") {
+      insideLinkDepth += 1;
+      nextChildren.push(child);
+      continue;
+    }
+    if (child.type === "link_close") {
+      insideLinkDepth = Math.max(0, insideLinkDepth - 1);
+      nextChildren.push(child);
+      continue;
+    }
+    if (child.type !== "text" || !child.content) {
+      nextChildren.push(child);
+      continue;
+    }
+
+    const visibleContent = restoreEscapedMentions(child.content);
+    if (insideLinkDepth > 0) {
+      nextChildren.push(createTextToken(child, visibleContent));
+      continue;
+    }
+    const matches = collectMentionCandidates(child.content);
+    if (matches.length === 0) {
+      nextChildren.push(createTextToken(child, visibleContent));
+      continue;
+    }
+
+    let cursor = 0;
+    for (const match of matches) {
+      if (match.start > cursor) {
+        nextChildren.push(
+          createTextToken(child, restoreEscapedMentions(child.content.slice(cursor, match.start))),
+        );
+      }
+      cursor = match.end;
+      if (match.kind === "room") {
+        roomMentioned = true;
+        nextChildren.push(createTextToken(child, match.raw));
+        continue;
+      }
+
+      const resolvedUserId = resolveMentionUserId(match);
+      if (!resolvedUserId || resolvedUserId === params.selfUserId) {
+        nextChildren.push(createTextToken(child, match.raw));
+        continue;
+      }
+      if (!params.seenUserIds.has(resolvedUserId)) {
+        params.seenUserIds.add(resolvedUserId);
+        params.userIds.push(resolvedUserId);
+      }
+      nextChildren.push(
+        ...createMentionLinkTokens({
+          sample: child,
+          href: `https://matrix.to/#/${encodeURIComponent(resolvedUserId)}`,
+          label: match.raw,
+        }),
+      );
+    }
+    if (cursor < child.content.length) {
+      nextChildren.push(
+        createTextToken(child, restoreEscapedMentions(child.content.slice(cursor))),
+      );
+    }
+  }
+  return { children: nextChildren, roomMentioned };
+}
+
+async function resolveMarkdownMentionState(params: {
+  markdown: string;
+  client: MatrixClient;
+}): Promise<{ tokens: MarkdownToken[]; mentions: MatrixMentions }> {
+  const markdown = maskEscapedMentions(params.markdown ?? "");
+  const tokens = md.parse(markdown, {});
+  restoreEscapedMentionsInBlockTokens(tokens);
+  const selfUserId = await resolveMatrixSelfUserId(params.client);
+  const userIds: string[] = [];
+  const seenUserIds = new Set<string>();
+  let roomMentioned = false;
+
+  for (const token of tokens) {
+    if (!token.children?.length) {
+      continue;
+    }
+    const mutated = mutateInlineTokensWithMentions({
+      children: token.children,
+      userIds,
+      seenUserIds,
+      selfUserId,
+    });
+    token.children = mutated.children;
+    roomMentioned ||= mutated.roomMentioned;
+  }
+
+  const mentions: MatrixMentions = {};
+  if (userIds.length > 0) {
+    mentions.user_ids = userIds;
+  }
+  if (roomMentioned) {
+    mentions.room = true;
+  }
+  return {
+    tokens,
+    mentions,
+  };
+}
+
+export async function resolveMatrixMentionsInMarkdown(params: {
+  markdown: string;
+  client: MatrixClient;
+}): Promise<MatrixMentions> {
+  const state = await resolveMarkdownMentionState(params);
+  return state.mentions;
+}
+
+export async function renderMarkdownToMatrixHtmlWithMentions(params: {
+  markdown: string;
+  client: MatrixClient;
+}): Promise<{ html?: string; mentions: MatrixMentions }> {
+  const state = await resolveMarkdownMentionState(params);
+  const html = md.renderer.render(state.tokens, md.options, {}).trimEnd();
+  return {
+    html: html || undefined,
+    mentions: state.mentions,
+  };
 }

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -66,22 +66,25 @@ const runtimeStub = {
 } as unknown as PluginRuntime;
 
 let sendMessageMatrix: typeof import("./send.js").sendMessageMatrix;
+let sendPollMatrix: typeof import("./send.js").sendPollMatrix;
 let resolveMediaMaxBytes: typeof import("./send/client.js").resolveMediaMaxBytes;
 
 const makeClient = () => {
   const sendMessage = vi.fn().mockResolvedValue("evt1");
   const uploadContent = vi.fn().mockResolvedValue("mxc://example/file");
+  const sendEvent = vi.fn().mockResolvedValue("evt1");
   const client = {
     sendMessage,
     uploadContent,
+    sendEvent,
     getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
   } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
-  return { client, sendMessage, uploadContent };
+  return { client, sendMessage, uploadContent, sendEvent };
 };
 
 beforeAll(async () => {
   setMatrixRuntime(runtimeStub);
-  ({ sendMessageMatrix } = await import("./send.js"));
+  ({ sendMessageMatrix, sendPollMatrix } = await import("./send.js"));
   ({ resolveMediaMaxBytes } = await import("./send/client.js"));
 });
 
@@ -213,6 +216,114 @@ describe("sendMessageMatrix media", () => {
     expect(mediaContent.msgtype).toBe("m.audio");
     expect(mediaContent.body).toBe("voice caption");
     expect(mediaContent["org.matrix.msc3245.voice"]).toBeUndefined();
+  });
+});
+
+// These assertions are the integration guard for the mention wiring in send.ts.
+// Deleting any single `enrichMatrixFormattedContent` / `resolveMatrixMentionsForBody`
+// call site must fail at least one of them (#3045).
+describe("sendMessageMatrix mentions", () => {
+  type MentionedContent = {
+    format?: string;
+    formatted_body?: string;
+    "m.mentions"?: { room?: boolean; user_ids?: string[] };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({});
+    mediaKindFromMimeMock.mockReturnValue("image");
+    isVoiceCompatibleAudioMock.mockReturnValue(false);
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("attaches m.mentions and a matrix.to pill to a plain text message", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "ping @alice:example.org", { client });
+
+    const content = sendMessage.mock.calls[0]?.[1] as MentionedContent;
+    expect(content["m.mentions"]).toEqual({ user_ids: ["@alice:example.org"] });
+    expect(content.format).toBe("org.matrix.custom.html");
+    expect(content.formatted_body).toBe(
+      '<p>ping <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a></p>',
+    );
+  });
+
+  it("does not mention the sending account itself", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "ping @bot:example.org", { client });
+
+    const content = sendMessage.mock.calls[0]?.[1] as MentionedContent;
+    expect(content["m.mentions"]).toStrictEqual({});
+    expect(content.formatted_body).toBe("<p>ping @bot:example.org</p>");
+  });
+
+  it("attaches m.mentions to a media caption", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "look @alice:example.org", {
+      client,
+      mediaUrl: "file:///tmp/photo.png",
+    });
+
+    const content = sendMessage.mock.calls[0]?.[1] as MentionedContent;
+    expect(content["m.mentions"]).toEqual({ user_ids: ["@alice:example.org"] });
+    expect(content.formatted_body).toContain(
+      '<a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a>',
+    );
+  });
+
+  it("attaches m.mentions to a media follow-up chunk", async () => {
+    const { client, sendMessage } = makeClient();
+    mediaKindFromMimeMock.mockReturnValue("audio");
+    isVoiceCompatibleAudioMock.mockReturnValue(true);
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      fileName: "clip.mp3",
+      contentType: "audio/mpeg",
+      kind: "audio",
+    });
+
+    await sendMessageMatrix("room:!room:example", "transcript @alice:example.org", {
+      client,
+      mediaUrl: "file:///tmp/clip.mp3",
+      audioAsVoice: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    const mediaContent = sendMessage.mock.calls[0]?.[1] as MentionedContent;
+    // The voice event body is generic, so it carries no caption and no mentions.
+    expect(mediaContent["m.mentions"]).toStrictEqual({});
+    const followup = sendMessage.mock.calls[1]?.[1] as MentionedContent;
+    expect(followup["m.mentions"]).toEqual({ user_ids: ["@alice:example.org"] });
+    expect(followup.formatted_body).toContain(
+      '<a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a>',
+    );
+  });
+
+  it("attaches m.mentions to a poll payload", async () => {
+    const { client, sendEvent } = makeClient();
+
+    await sendPollMatrix(
+      "room:!room:example",
+      { question: "ping @alice:example.org?", options: ["yes", "no"] },
+      { client },
+    );
+
+    const payload = sendEvent.mock.calls[0]?.[2] as MentionedContent;
+    expect(payload["m.mentions"]).toEqual({ user_ids: ["@alice:example.org"] });
+  });
+
+  it("flags room mentions on a plain text message", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "heads up @room", { client });
+
+    const content = sendMessage.mock.calls[0]?.[1] as MentionedContent;
+    expect(content["m.mentions"]).toEqual({ room: true });
   });
 });
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -8,6 +8,8 @@ import {
   buildReplyRelation,
   buildTextContent,
   buildThreadRelation,
+  enrichMatrixFormattedContent,
+  resolveMatrixMentionsForBody,
   resolveMatrixMsgType,
   resolveMatrixVoiceDecision,
 } from "./send/formatting.js";
@@ -32,6 +34,10 @@ const MATRIX_TEXT_LIMIT = 4000;
 const getCore = () => getMatrixRuntime();
 
 export type { MatrixSendOpts, MatrixSendResult } from "./send/types.js";
+// Re-exported for upstream parity — upstream's monitor handler pulls this off
+// the send module dynamically. This fork's monitor does not, so the only
+// in-tree caller today is `sendPollMatrix` below, via the direct import above.
+export { resolveMatrixMentionsForBody } from "./send/formatting.js";
 export { resolveMatrixRoomId } from "./send/targets.js";
 
 export async function sendMessageMatrix(
@@ -106,7 +112,8 @@ export async function sendMessageMatrix(
           ? await prepareImageInfo({ buffer: media.buffer, client })
           : undefined;
         const [firstChunk, ...rest] = chunks;
-        const body = useVoice ? "Voice message" : (firstChunk ?? media.fileName ?? "(file)");
+        const captionMarkdown = useVoice ? "" : (firstChunk ?? "");
+        const body = useVoice ? "Voice message" : captionMarkdown || media.fileName || "(file)";
         const content = buildMediaContent({
           msgtype,
           body,
@@ -120,6 +127,11 @@ export async function sendMessageMatrix(
           isVoice: useVoice,
           imageInfo,
         });
+        await enrichMatrixFormattedContent({
+          client,
+          content,
+          markdown: captionMarkdown,
+        });
         const eventId = await sendContent(content);
         lastMessageId = eventId ?? lastMessageId;
         const textChunks = useVoice ? chunks : rest;
@@ -130,6 +142,11 @@ export async function sendMessageMatrix(
             continue;
           }
           const followup = buildTextContent(text, followupRelation);
+          await enrichMatrixFormattedContent({
+            client,
+            content: followup,
+            markdown: text,
+          });
           const followupEventId = await sendContent(followup);
           lastMessageId = followupEventId ?? lastMessageId;
         }
@@ -140,6 +157,11 @@ export async function sendMessageMatrix(
             continue;
           }
           const content = buildTextContent(text, relation);
+          await enrichMatrixFormattedContent({
+            client,
+            content,
+            markdown: text,
+          });
           const eventId = await sendContent(content);
           lastMessageId = eventId ?? lastMessageId;
         }
@@ -178,10 +200,17 @@ export async function sendPollMatrix(
   try {
     const roomId = await resolveMatrixRoomId(client, to);
     const pollContent = buildPollStartContent(poll);
+    const fallbackText =
+      pollContent["m.text"] ?? pollContent["org.matrix.msc1767.text"] ?? poll.question ?? "";
+    const mentions = await resolveMatrixMentionsForBody({
+      client,
+      body: fallbackText,
+    });
     const threadId = normalizeThreadId(opts.threadId);
-    const pollPayload = threadId
+    const pollPayload: Record<string, unknown> = threadId
       ? { ...pollContent, "m.relates_to": buildThreadRelation(threadId) }
-      : pollContent;
+      : { ...pollContent };
+    pollPayload["m.mentions"] = mentions;
     // @vector-im/matrix-bot-sdk sendEvent returns eventId string directly
     const eventId = await client.sendEvent(roomId, M_POLL_START, pollPayload);
 

--- a/extensions/matrix/src/matrix/send/formatting.test.ts
+++ b/extensions/matrix/src/matrix/send/formatting.test.ts
@@ -1,0 +1,134 @@
+// Matrix tests cover send formatting mention behavior.
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
+import { describe, expect, it } from "vitest";
+import {
+  buildTextContent,
+  enrichMatrixFormattedContent,
+  extractMatrixMentions,
+  resolveMatrixMentionsForBody,
+} from "./formatting.js";
+import type { MatrixFormattedContent } from "./types.js";
+
+function createMentionClient(selfUserId = "@bot:example.org") {
+  return {
+    getUserId: async () => selfUserId,
+  } as unknown as MatrixClient;
+}
+
+describe("buildTextContent", () => {
+  it("returns a plain text body without formatting", () => {
+    const content = buildTextContent("hello @alice:example.org");
+    expect(content.msgtype).toBe("m.text");
+    expect(content.body).toBe("hello @alice:example.org");
+    expect(content.format).toBeUndefined();
+    expect(content.formatted_body).toBeUndefined();
+  });
+
+  it("attaches a relation when provided", () => {
+    const content = buildTextContent("hi", { "m.in_reply_to": { event_id: "$evt" } });
+    expect(content["m.relates_to"]).toEqual({ "m.in_reply_to": { event_id: "$evt" } });
+  });
+});
+
+describe("enrichMatrixFormattedContent", () => {
+  it("adds formatted_body and m.mentions for a mention", async () => {
+    const content: MatrixFormattedContent = { msgtype: "m.text", body: "hello @alice:example.org" };
+    await enrichMatrixFormattedContent({
+      client: createMentionClient(),
+      content,
+      markdown: "hello @alice:example.org",
+    });
+
+    expect(content.format).toBe("org.matrix.custom.html");
+    expect(content.formatted_body).toBe(
+      '<p>hello <a href="https://matrix.to/#/%40alice%3Aexample.org">@alice:example.org</a></p>',
+    );
+    expect(content["m.mentions"]).toEqual({ user_ids: ["@alice:example.org"] });
+  });
+
+  it("escapes raw HTML in the formatted body", async () => {
+    const content: MatrixFormattedContent = { msgtype: "m.text", body: "<b>x</b>" };
+    await enrichMatrixFormattedContent({
+      client: createMentionClient(),
+      content,
+      markdown: "<b>x</b>",
+    });
+
+    expect(content.formatted_body).toContain("&lt;b&gt;x&lt;/b&gt;");
+    expect(content.formatted_body).not.toContain("<b>x</b>");
+  });
+
+  it("skips mention resolution when includeMentions is false", async () => {
+    const content: MatrixFormattedContent = { msgtype: "m.text", body: "hello @alice:example.org" };
+    await enrichMatrixFormattedContent({
+      client: createMentionClient(),
+      content,
+      markdown: "hello @alice:example.org",
+      includeMentions: false,
+    });
+
+    expect(content.format).toBe("org.matrix.custom.html");
+    expect(content.formatted_body).toBe("<p>hello @alice:example.org</p>");
+    expect(content["m.mentions"]).toBeUndefined();
+  });
+
+  it("clears formatting fields when there is no markdown to render", async () => {
+    const content: MatrixFormattedContent = {
+      msgtype: "m.text",
+      body: "photo.png",
+      format: "org.matrix.custom.html",
+      formatted_body: "<p>stale</p>",
+      "m.mentions": { user_ids: ["@stale:example.org"] },
+    };
+    await enrichMatrixFormattedContent({
+      client: createMentionClient(),
+      content,
+      markdown: "",
+    });
+
+    expect(content.format).toBeUndefined();
+    expect(content.formatted_body).toBeUndefined();
+    expect(content["m.mentions"]).toStrictEqual({});
+  });
+});
+
+describe("resolveMatrixMentionsForBody", () => {
+  it("resolves mentions from a plain body without rendering HTML", async () => {
+    const mentions = await resolveMatrixMentionsForBody({
+      client: createMentionClient(),
+      body: "ping @alice:example.org and @room",
+    });
+
+    expect(mentions).toEqual({ user_ids: ["@alice:example.org"], room: true });
+  });
+
+  it("returns an empty object when there is nothing to mention", async () => {
+    const mentions = await resolveMatrixMentionsForBody({
+      client: createMentionClient(),
+      body: "no mentions here",
+    });
+
+    expect(mentions).toStrictEqual({});
+  });
+});
+
+describe("extractMatrixMentions", () => {
+  it("returns an empty object when m.mentions is missing or not an object", () => {
+    expect(extractMatrixMentions(undefined)).toStrictEqual({});
+    expect(extractMatrixMentions({})).toStrictEqual({});
+    expect(extractMatrixMentions({ "m.mentions": "nope" })).toStrictEqual({});
+  });
+
+  it("keeps only non-empty string user ids", () => {
+    const mentions = extractMatrixMentions({
+      "m.mentions": { user_ids: ["@alice:example.org", "", "   ", 42, null] },
+    });
+
+    expect(mentions).toEqual({ user_ids: ["@alice:example.org"] });
+  });
+
+  it("only treats room as true for a literal true", () => {
+    expect(extractMatrixMentions({ "m.mentions": { room: true } })).toEqual({ room: true });
+    expect(extractMatrixMentions({ "m.mentions": { room: "true" } })).toStrictEqual({});
+  });
+});

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -1,5 +1,11 @@
+import type { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import { getMatrixRuntime } from "../../runtime.js";
-import { markdownToMatrixHtml } from "../format.js";
+import {
+  markdownToMatrixHtml,
+  renderMarkdownToMatrixHtmlWithMentions,
+  resolveMatrixMentionsInMarkdown,
+  type MatrixMentions,
+} from "../format.js";
 import {
   MsgType,
   RelationType,
@@ -13,8 +19,27 @@ import {
 
 const getCore = () => getMatrixRuntime();
 
+export type { MatrixMentions } from "../format.js";
+
+async function renderMatrixFormattedContent(params: {
+  client: MatrixClient;
+  markdown?: string | null;
+  includeMentions?: boolean;
+}): Promise<{ html?: string; mentions?: MatrixMentions }> {
+  const markdown = params.markdown ?? "";
+  if (params.includeMentions === false) {
+    const html = markdownToMatrixHtml(markdown).trimEnd();
+    return { html: html || undefined };
+  }
+  const { html, mentions } = await renderMarkdownToMatrixHtmlWithMentions({
+    markdown,
+    client: params.client,
+  });
+  return { html, mentions };
+}
+
 export function buildTextContent(body: string, relation?: MatrixRelation): MatrixTextContent {
-  const content: MatrixTextContent = relation
+  return relation
     ? {
         msgtype: MsgType.Text,
         body,
@@ -24,17 +49,78 @@ export function buildTextContent(body: string, relation?: MatrixRelation): Matri
         msgtype: MsgType.Text,
         body,
       };
-  applyMatrixFormatting(content, body);
-  return content;
 }
 
-export function applyMatrixFormatting(content: MatrixFormattedContent, body: string): void {
-  const formatted = markdownToMatrixHtml(body ?? "");
-  if (!formatted) {
+/**
+ * Renders `markdown` into the event's `formatted_body` and attaches the
+ * resulting `m.mentions` metadata. Both are derived from the same render pass,
+ * so the HTML pills and the mentions list can never disagree.
+ */
+export async function enrichMatrixFormattedContent(params: {
+  client: MatrixClient;
+  content: MatrixFormattedContent;
+  markdown?: string | null;
+  includeMentions?: boolean;
+}): Promise<void> {
+  const { html, mentions } = await renderMatrixFormattedContent({
+    client: params.client,
+    markdown: params.markdown,
+    includeMentions: params.includeMentions,
+  });
+  if (mentions) {
+    params.content["m.mentions"] = mentions;
+  } else {
+    delete params.content["m.mentions"];
+  }
+  if (!html) {
+    delete params.content.format;
+    delete params.content.formatted_body;
     return;
   }
-  content.format = "org.matrix.custom.html";
-  content.formatted_body = formatted;
+  params.content.format = "org.matrix.custom.html";
+  params.content.formatted_body = html;
+}
+
+export async function resolveMatrixMentionsForBody(params: {
+  client: MatrixClient;
+  body: string;
+}): Promise<MatrixMentions> {
+  return await resolveMatrixMentionsInMarkdown({
+    markdown: params.body ?? "",
+    client: params.client,
+  });
+}
+
+function normalizeMentionUserIds(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : [];
+}
+
+/**
+ * Reads `m.mentions` back off an existing event. Ported for upstream parity but
+ * not yet wired here: upstream only calls it from the message-edit path, which
+ * this fork does not carry (which is also why upstream's companion
+ * `diffMatrixMentions` is absent). Inbound mention detection is a separate
+ * pipeline in `monitor/mentions.ts`.
+ */
+export function extractMatrixMentions(
+  content: Record<string, unknown> | undefined,
+): MatrixMentions {
+  const rawMentions = content?.["m.mentions"];
+  if (!rawMentions || typeof rawMentions !== "object") {
+    return {};
+  }
+  const mentions = rawMentions as { room?: unknown; user_ids?: unknown };
+  const normalized: MatrixMentions = {};
+  const userIds = normalizeMentionUserIds(mentions.user_ids);
+  if (userIds.length > 0) {
+    normalized.user_ids = userIds;
+  }
+  if (mentions.room === true) {
+    normalized.room = true;
+  }
+  return normalized;
 }
 
 export function buildReplyRelation(replyToId?: string): MatrixReplyRelation | undefined {

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -7,7 +7,6 @@ import type {
   VideoFileInfo,
 } from "@vector-im/matrix-bot-sdk";
 import { getMatrixRuntime } from "../../runtime.js";
-import { applyMatrixFormatting } from "./formatting.js";
 import {
   type MatrixMediaContent,
   type MatrixMediaInfo,
@@ -103,7 +102,6 @@ export function buildMediaContent(params: {
   if (params.relation) {
     base["m.relates_to"] = params.relation;
   }
-  applyMatrixFormatting(base, params.body);
   return base;
 }
 

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -7,6 +7,7 @@ import type {
   TimedFileInfo,
   VideoFileInfo,
 } from "@vector-im/matrix-bot-sdk";
+import type { MatrixMentions } from "../format.js";
 
 // Message types
 export const MsgType = {
@@ -107,4 +108,6 @@ export type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 export type MatrixFormattedContent = MessageEventContent & {
   format?: string;
   formatted_body?: string;
+  /** Intentional mentions metadata (MSC3952 / spec `m.mentions`). */
+  "m.mentions"?: MatrixMentions;
 };


### PR DESCRIPTION
Closes #3045.

Ports upstream OpenClaw's Matrix @mention rendering into the fork's kept matrix
adapter. Outgoing messages now convert `@user:server` into matrix.to mention
pills in `formatted_body` and emit matching `m.mentions` metadata, so mentioned
users are actually notified instead of seeing plain text.

## For the security reviewer — this is a user-text → HTML path

**Build reference (the oracle):**
```
git show 'upstream/openclaw-v2026.6.8^{commit}:extensions/matrix/src/matrix/format.ts'
git show 'upstream/openclaw-v2026.6.8^{commit}:extensions/matrix/src/matrix/send/formatting.ts'
```

The mention/escaping helpers are ported **byte-identical** to upstream so they can
be diffed side-by-side. Every deviation is listed under "Fork adaptations" below —
if it is not in that list, it should be character-for-character upstream.

**Escaping posture is unchanged:**
- `markdown-it` is still constructed with `html: false`.
- All pre-existing escaping renderer rules are untouched: `image`, `html_block`,
  `html_inline` → `escapeHtml`; `link_open`/`link_close` → autolink suppression.
- The only new markup is a `link_open` token with
  `href = "https://matrix.to/#/" + encodeURIComponent(userId)`. The link **label**
  goes through a normal text token, so it is escaped by markdown-it's default
  `text` rule (not overridden) — no raw injection path.
- Mentions are not resolved inside code spans, fenced blocks, or indented code,
  and `\@` escapes never become pills (`maskEscapedMentions` parks them on a
  `U+E000` private-use sentinel, restored as `@` in prose and `\@` in code).

An independent adversarial validation pass ran 25 breakout attempts against the
real renderer — `<script>`, `<svg onload>`, `<img onerror>`, quote/angle-bracket
breakout through both the mention label and mxids containing `/`, `"`, `>`,
`javascript:` in markdown-link and autolink form, entity smuggling and
double-encoding, IPv6-bracket mxids with trailing `onload`, and token-index-shift
probes against the `idx - 2` autolink suppression. All produced correctly escaped
output; anchors stayed balanced and every `href` remained `http(s)://`.
No critical or high severity escaping finding.

## What changed

- `format.ts` — mention pipeline: `maskEscapedMentions`, `restoreEscapedMentions{,InCode,InBlockTokens}`,
  `isMentionStartBoundary`, `trimMentionSuffix`, `isMatrixMentionUserId`,
  `buildMentionCandidate`, `collectMentionCandidates`, `createMentionLinkTokens`,
  `resolveMentionUserId`, `mutateInlineTokensWithMentions`, `resolveMarkdownMentionState`,
  `resolveMatrixMentionsInMarkdown`, `renderMarkdownToMatrixHtmlWithMentions`.
- `send/formatting.ts` — `enrichMatrixFormattedContent`, `resolveMatrixMentionsForBody`,
  `extractMatrixMentions` (+ private `normalizeMentionUserIds`).
- `send.ts` — wired at all four call sites that exist in this fork.
- `send/types.ts` — `MatrixFormattedContent` gains `"m.mentions"?: MatrixMentions`
  (explicit rather than riding an index signature, so the wire shape is reviewable).

## Fork adaptations (upstream modules this fork does not carry)

| Upstream | Here | Why |
|---|---|---|
| `./sdk.js` → `MatrixClient` | `@vector-im/matrix-bot-sdk` | no `sdk.ts` in this fork; matches `send.ts`/`handler.ts` |
| `./target-ids.js` → `isMatrixQualifiedUserId` | inlined in `format.ts` | no `target-ids.ts` here; body is verbatim upstream |
| `plugin-sdk/text-autolink-runtime` → `isAutoLinkedFileRef` | fork's existing local impl | the export subpath exists in `package.json` but **no source file** backs it — importing it would typecheck and fail at runtime |
| `plugin-sdk/string-coerce-runtime` | used as-is | resolves; already used by `monitor/mentions.ts` |
| inline `as { getUserId?: … }` cast | named `MatrixMentionSelfClient` param | same property read, same `.call(client)`, same `.catch(() => null)` |

`buildTextContent` and `buildMediaContent` no longer format inline (upstream parity);
formatting + mentions are applied together by `enrichMatrixFormattedContent`, so the
HTML pills and the mentions list are always derived from one render pass and cannot
disagree. `applyMatrixFormatting` is removed — it had exactly one caller.

One behavior change worth calling out: media **without** a caption previously got a
`formatted_body` derived from the filename. Upstream renders only the caption
markdown, so a caption-less media event now sets neither `format` nor
`formatted_body`. This matches the reference.

## Deliberately not ported

- **`compactLooseListTokens`** — a separate upstream feature (loose-list `<p>`
  compaction), not part of mention rendering and not in the issue's helper list.
  Its absence cannot affect escaping or mentions: it only sets `hidden` on
  paragraph tokens. Upstream's 8 list-compaction tests are correspondingly omitted.
- **`diffMatrixMentions`** — upstream calls it only from the message-edit path.
- **`monitor/handler.ts` wiring** — upstream's only mention call sites there
  (`matrixTextWouldActivateMentions`) live inside the draft-stream / `editMessageMatrix`
  subsystem, which this fork does not have. Wiring it here would be dead code.

## Known follow-ups (not regressions from this PR)

- **The fork does have an edit path under a different name**: `actions/messages.ts`
  → `editMatrixMessage()`, reachable from the `edit`/`editMessage` tool actions. It
  builds a plain-text payload and has never carried `formatted_body`, so nothing
  regresses here — but editing a message that contained a mention will drop the pill.
  Wiring it means adding a second user-text → HTML sink, which deserves its own
  change and its own security review rather than riding along late in this one.
- `extractMatrixMentions` ships with no production caller (upstream's consumer is
  that edit path). Included because the issue asks for it; it is unit-tested and
  documented in place. Reasonable to prune if you'd rather wait for the edit path.
- Every outbound text/media event now carries `m.mentions`, including `{}` — this is
  upstream-identical and intended MSC3952 semantics, but note that an event carrying
  `m.mentions` opts out of the legacy `.m.rule.contains_display_name` /
  `.m.rule.roomnotif` push rules. Messages naming a bare display name (`@alice`,
  not a qualified mxid) will no longer notify via those legacy rules. Derived from
  the spec and the code; not verified against a live homeserver.

## Verification

- `pnpm check` → exit 0 (oxfmt, `tsgo`, oxlint type-aware, and every fork-integrity lint).
- Extensions lane → `495 files, 4764 passed, 31 skipped`, exit 0.
- Standalone fork gates all exit 0: zombie-import, stub-debt, throwing-stub-callers,
  attestations, obsolescence-audit, policy-doctor-boundary.
- 21 upstream mention/escaping tests ported byte-identical, plus new coverage for
  self-mention suppression, dedup, mentions in lists, HTML escaping during mention
  resolution, and the missing-`getUserId` fallback.
- **Mutation-verified wiring**: deleting any one of the four `send.ts` call sites
  (media caption, media follow-up, plain text, poll) fails the suite. Before these
  assertions were added, three of the four could be deleted with CI fully green.

No `@ts-expect-error`, no `@ts-nocheck`, no `any` suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
