### PR TITLE
fix(outbound): stop replaying deliveries whose send outcome is unknown (#2934)

### DIFF
--- a/src/infra/backup-volatile-filter.test.ts
+++ b/src/infra/backup-volatile-filter.test.ts
@@ -1,6 +1,7 @@
 // Tests volatile path filtering for backup operations.
 import { describe, expect, it } from "vitest";
 import { isVolatileBackupPath } from "./backup-volatile-filter.js";
+import { resolveNeedsReviewDir } from "./outbound/delivery-queue.js";
 
 const stateDir = "/opt/remoteclaw/state";
 const plan = { stateDirs: [stateDir] };
@@ -84,6 +85,22 @@ describe("isVolatileBackupPath", () => {
 
   it("does not treat non-json delivery-queue files as volatile", () => {
     expect(isVolatileBackupPath(`${stateDir}/delivery-queue/README.md`, plan)).toBe(false);
+  });
+
+  it("keeps delivery-queue needs-review entries out of the volatile set", () => {
+    // Quarantined deliveries are terminal and unique: they are the only record
+    // that a message's delivery outcome is undetermined, so losing them on a
+    // restore loses the operator's reconciliation queue with no trace.
+    //
+    // Path comes from resolveNeedsReviewDir rather than a literal so that
+    // renaming the quarantine directory fails this test instead of silently
+    // dropping the exemption and making quarantined entries volatile again.
+    expect(
+      isVolatileBackupPath(
+        `${resolveNeedsReviewDir(stateDir)}/3fac5e46-42dc-4230-a725-51c203830b4f.json`,
+        plan,
+      ),
+    ).toBe(false);
   });
 
   it("does not treat delivery-queue json outside stateDir as volatile", () => {

--- a/src/infra/backup-volatile-filter.ts
+++ b/src/infra/backup-volatile-filter.ts
@@ -74,7 +74,8 @@ export type VolatileFilterPlan = {
  *   - `{stateDir}/agents/<agentId>/sessions/**`/`*.{jsonl,log}`
  *   - `{stateDir}/cron/runs/**`/`*.{jsonl,log}`
  *   - `{stateDir}/logs/**`/`*.{jsonl,log}`
- *   - `{stateDir}/{delivery-queue,session-delivery-queue}/**`/`*.{json,delivered,tmp}`
+ *   - `{stateDir}/{delivery-queue,session-delivery-queue}/**`/`*.{json,delivered,tmp}`,
+ *     EXCEPT `delivery-queue/needs-review/**` — see below
  *   - `{stateDir}/**`/`*.{sock,pid,tmp}`
  */
 export function isVolatileBackupPath(absolutePath: string, plan: VolatileFilterPlan): boolean {
@@ -112,13 +113,24 @@ export function isVolatileBackupPath(absolutePath: string, plan: VolatileFilterP
         return true;
       }
 
-      for (const queueDir of ["delivery-queue", "session-delivery-queue"]) {
-        const queueRoot = path.posix.join(stateDirPosix, queueDir);
-        if (
-          isUnder(filePosix, queueRoot) &&
-          hasExtension(filePosix, [".json", ".delivered", ".tmp"])
-        ) {
-          return true;
+      // Deliveries awaiting manual reconciliation are the one part of the queue
+      // that is NOT volatile: they are terminal, unique, and the only record
+      // that a message's delivery outcome is undetermined. Losing them on a
+      // restore loses the operator's to-do list with no trace it existed.
+      // ("awaiting review", not "pending" — in the queue's own vocabulary a
+      // pending entry is one still queued to send, the opposite of this.)
+      const needsReviewRoot = path.posix.join(stateDirPosix, "delivery-queue", "needs-review");
+      const isAwaitingReview = isUnder(filePosix, needsReviewRoot);
+
+      if (!isAwaitingReview) {
+        for (const queueDir of ["delivery-queue", "session-delivery-queue"]) {
+          const queueRoot = path.posix.join(stateDirPosix, queueDir);
+          if (
+            isUnder(filePosix, queueRoot) &&
+            hasExtension(filePosix, [".json", ".delivered", ".tmp"])
+          ) {
+            return true;
+          }
         }
       }
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -12,6 +12,7 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { createIMessageTestPlugin } from "../../test-utils/imessage-test-plugin.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import { resolvePreferredRemoteClawTmpDir } from "../tmp-remoteclaw-dir.js";
+import { readDeliveredBeforeFailure } from "./delivered-before-failure.js";
 
 const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
@@ -30,6 +31,8 @@ const queueMocks = vi.hoisted(() => ({
   enqueueDelivery: vi.fn(async () => "mock-queue-id"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
+  failPartialDelivery: vi.fn(async () => {}),
+  markDeliveryAttemptStarted: vi.fn(async () => {}),
   withActiveDeliveryClaim: vi.fn<
     (
       entryId: string,
@@ -61,6 +64,8 @@ vi.mock("./delivery-queue.js", () => ({
   enqueueDelivery: queueMocks.enqueueDelivery,
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
+  failPartialDelivery: queueMocks.failPartialDelivery,
+  markDeliveryAttemptStarted: queueMocks.markDeliveryAttemptStarted,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
 }));
 vi.mock("../../logging/subsystem.js", () => ({
@@ -85,6 +90,17 @@ const telegramChunkConfig: RemoteClawConfig = {
 const whatsappChunkConfig: RemoteClawConfig = {
   channels: { whatsapp: { textChunkLimit: 4000 } },
 };
+
+/**
+ * A 4-character text payload under this config splits into exactly two platform
+ * sends, so the first can land and the second fail. That is the mechanism the
+ * partial-delivery queue tests depend on — spelled out here once instead of
+ * being re-derived from `textChunkLimit: 2` at every use.
+ */
+const whatsappSplitsIntoTwoChunksConfig: RemoteClawConfig = {
+  channels: { whatsapp: { textChunkLimit: 2 } },
+};
+const TWO_CHUNK_TEXT = "abcd";
 
 type DeliverOutboundArgs = Parameters<typeof deliverOutboundPayloads>[0];
 type DeliverOutboundPayload = DeliverOutboundArgs["payloads"][number];
@@ -209,6 +225,10 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.ackDelivery.mockResolvedValue(undefined);
     queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
+    queueMocks.failPartialDelivery.mockClear();
+    queueMocks.failPartialDelivery.mockResolvedValue(undefined);
+    queueMocks.markDeliveryAttemptStarted.mockClear();
+    queueMocks.markDeliveryAttemptStarted.mockResolvedValue(undefined);
     queueMocks.withActiveDeliveryClaim.mockClear();
     queueMocks.withActiveDeliveryClaim.mockImplementation(async (_entryId, fn) => ({
       status: "claimed",
@@ -800,17 +820,176 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("calls failDelivery instead of ackDelivery on bestEffort partial failure", async () => {
+  it("records a bestEffort partial failure as an unknown outcome, not a plain failure", async () => {
     const { onError } = await runBestEffortPartialFailureDelivery();
 
     // onError was called for the first payload's failure.
     expect(onError).toHaveBeenCalledTimes(1);
 
-    // Queue entry should NOT be acked — failDelivery should be called instead.
+    // Some payloads landed, so the entry must be neither acked nor marked
+    // plainly-failed: a plain failure is replayed whole, re-sending what
+    // already arrived. failPartialDelivery keeps it for reconciliation.
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    // The landed count is passed through: it is the only record of how far the
+    // send got, and the operator opening the quarantined entry has no other way
+    // to tell which part arrived. The cause travels with it — "partial delivery
+    // failure" alone says nothing about why.
+    expect(queueMocks.failPartialDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("partial delivery failure (bestEffort):"),
+      undefined,
+      1,
+    );
+  });
+
+  it("records a bestEffort failure where NOTHING landed as a plain, replayable failure", async () => {
+    // "onError fired" is not "something landed". Quarantining a send that never
+    // reached the recipient turns a routine transient failure into a permanent
+    // manual-reconciliation item that is never delivered.
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("network blip"));
+    const onError = vi.fn();
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+      onError,
+    });
+
+    expect(results).toEqual([]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failPartialDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+  });
+
+  it("records a bestEffort failure even when the caller supplies no onError", async () => {
+    // Whether a send failed is a property of the send, not of the caller's
+    // callback wiring. Gating partial-failure detection on `params.onError`
+    // acked an entry whose payloads all failed, silently dropping the message —
+    // and several bestEffort callers pass no onError at all
+    // (server-node-events, server-restart-sentinel, the message command).
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("network blip"));
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+    });
+
+    expect(results).toEqual([]);
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+  });
+
+  it("still forwards to a caller-supplied onError while tracking the failure itself", async () => {
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("network blip"));
+    const onError = vi.fn();
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), expect.anything());
+  });
+
+  it("annotates the rethrown error with how many payloads landed", async () => {
+    // Crash recovery calls this function with skipQueue set, so it does its own
+    // queue bookkeeping and the error is its only channel for "how far did the
+    // send get" — the difference between replaying whole and quarantining.
+    const sendWhatsApp = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "w1", toJid: "jid" })
+      .mockRejectedValueOnce(new Error("rate limited"));
+
+    const err = await deliverOutboundPayloads({
+      cfg: whatsappSplitsIntoTwoChunksConfig,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: TWO_CHUNK_TEXT }],
+      deps: { sendWhatsApp },
+      skipQueue: true,
+    }).catch((e: unknown) => e);
+
+    expect(readDeliveredBeforeFailure(err)).toBe(1);
+  });
+
+  it("annotates a total failure with a landed count of zero", async () => {
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("rate limited"));
+
+    const err = await deliverOutboundPayloads({
+      cfg: whatsappSplitsIntoTwoChunksConfig,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: TWO_CHUNK_TEXT }],
+      deps: { sendWhatsApp },
+      skipQueue: true,
+    }).catch((e: unknown) => e);
+
+    expect(readDeliveredBeforeFailure(err)).toBe(0);
+  });
+
+  it("records a mid-chunk failure as an unknown outcome — earlier chunks already landed", async () => {
+    // The default (non-bestEffort) path: chunk 1 reaches the wire, chunk 2
+    // throws. Replaying the whole entry re-sends chunk 1 to the recipient.
+    const sendWhatsApp = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "w1", toJid: "jid" })
+      .mockRejectedValueOnce(new Error("rate limited"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: whatsappSplitsIntoTwoChunksConfig,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: TWO_CHUNK_TEXT }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("rate limited");
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(2);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failPartialDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("rate limited"),
+      undefined,
+      1,
+    );
+  });
+
+  it("records a first-chunk failure as a plain, replayable failure", async () => {
+    // Nothing landed, so the entry must stay on the normal retry path rather
+    // than being quarantined for a human.
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("rate limited"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: whatsappSplitsIntoTwoChunksConfig,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: TWO_CHUNK_TEXT }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("rate limited");
+
+    expect(queueMocks.failPartialDelivery).not.toHaveBeenCalled();
     expect(queueMocks.failDelivery).toHaveBeenCalledWith(
       "mock-queue-id",
-      "partial delivery failure (bestEffort)",
+      expect.stringContaining("rate limited"),
     );
   });
 
@@ -834,6 +1013,134 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
     expect(sendWhatsApp).not.toHaveBeenCalled();
+  });
+
+  it("does NOT ack an abort that landed part of the message", async () => {
+    // Acking discards the entry outright — no retry, no failed/, no
+    // needs-review. A cancellation that already put chunk 1 on the recipient's
+    // device is not a clean discard: erasing it loses the only record that a
+    // partial message went out.
+    const abortController = new AbortController();
+    const sendWhatsApp = vi.fn(async () => {
+      abortController.abort();
+      return { messageId: "w1", toJid: "jid" };
+    });
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: whatsappSplitsIntoTwoChunksConfig,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: TWO_CHUNK_TEXT }],
+        deps: { sendWhatsApp },
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toThrow("Operation aborted");
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failPartialDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.any(String),
+      undefined,
+      1,
+    );
+  });
+
+  it("does NOT ack a transport error that merely calls itself AbortError", async () => {
+    // `isAbortError` is name-based. A client-side request timeout that aborts
+    // its own controller surfaces a DOMException named "AbortError" without the
+    // CALLER ever cancelling — BlueBubbles' fetch timeout does exactly this.
+    // That is an unknown send outcome (the server may have delivered it), not a
+    // cancellation, and acking it would silently drop the message.
+    const sendWhatsApp = vi
+      .fn()
+      .mockRejectedValue(new DOMException("This operation was aborted", "AbortError"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: "a" }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("aborted");
+
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+  });
+
+  it("marks the queue entry as send-in-flight before the platform send", async () => {
+    const order: string[] = [];
+    queueMocks.markDeliveryAttemptStarted.mockImplementation(async () => {
+      order.push("mark");
+    });
+    const sendWhatsApp = vi.fn(async () => {
+      order.push("send");
+      return { messageId: "w1", toJid: "jid" };
+    });
+
+    await deliverWhatsAppPayload({ sendWhatsApp, payload: { text: "hi" } });
+
+    // Ordering is the whole point: a marker written after the send would leave
+    // the crash window open for a duplicate replay.
+    expect(order).toEqual(["mark", "send"]);
+    expect(queueMocks.markDeliveryAttemptStarted).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.withActiveDeliveryClaim).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.any(Function),
+    );
+  });
+
+  it("delivers anyway when the send-in-flight marker cannot be written, but warns", async () => {
+    queueMocks.markDeliveryAttemptStarted.mockRejectedValue(new Error("disk full"));
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    const results = await deliverWhatsAppPayload({ sendWhatsApp, payload: { text: "hi" } });
+
+    expect(results).toHaveLength(1);
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    // Silently disarming duplicate suppression is worse than the duplicate:
+    // the operator has to be able to see that the guard is off.
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      expect.stringContaining("could not record the send-in-flight marker"),
+      expect.objectContaining({ channel: "whatsapp", queueId: "mock-queue-id" }),
+    );
+  });
+
+  it("fails loudly rather than reporting success when the entry is claimed elsewhere", async () => {
+    queueMocks.withActiveDeliveryClaim.mockResolvedValue({ status: "claimed-by-other-owner" });
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    // Returning [] here would read as a successful send to the several call sites
+    // that ignore the result array.
+    await expect(deliverWhatsAppPayload({ sendWhatsApp, payload: { text: "hi" } })).rejects.toThrow(
+      "already owned by another delivery worker",
+    );
+
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue, claim, or mark when skipQueue is set (recovery replay)", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    const results = await deliverOutboundPayloads({
+      cfg: whatsappChunkConfig,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hi" }],
+      deps: { sendWhatsApp },
+      skipQueue: true,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(queueMocks.enqueueDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.withActiveDeliveryClaim).not.toHaveBeenCalled();
+    expect(queueMocks.markDeliveryAttemptStarted).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
   it("passes normalized payload to onError", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -39,7 +39,15 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
-import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
+import { annotateDeliveredBeforeFailure } from "./delivered-before-failure.js";
+import {
+  ackDelivery,
+  enqueueDelivery,
+  failDelivery,
+  failPartialDelivery,
+  markDeliveryAttemptStarted,
+  withActiveDeliveryClaim,
+} from "./delivery-queue.js";
 import { describeDeliveryError } from "./describe-delivery-error.js";
 import type { OutboundIdentity } from "./identity.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
@@ -492,46 +500,135 @@ export async function deliverOutboundPayloads(
         mirror: params.mirror,
       }).catch(() => null); // Best-effort — don't block delivery if queue write fails.
 
-  // Wrap onError to detect partial failures under bestEffort mode.
+  // Wrap onError to detect per-payload failures under bestEffort mode.
   // When bestEffort is true, per-payload errors are caught and passed to onError
   // without throwing — so the outer try/catch never fires. We track whether any
-  // payload failed so we can call failDelivery instead of ackDelivery.
-  let hadPartialFailure = false;
-  const wrappedParams = params.onError
-    ? {
-        ...params,
-        onError: (err: unknown, payload: NormalizedOutboundPayload) => {
-          hadPartialFailure = true;
-          params.onError!(err, payload);
-        },
-      }
-    : params;
+  // payload failed so we can record a failure instead of acking.
+  //
+  // Wrapped unconditionally, not only when the caller passed an onError: whether
+  // a send failed is a property of the send, not of the caller's callback wiring.
+  // Gating on `params.onError` made a bestEffort caller that supplies no callback
+  // (server-node-events, server-restart-sentinel, the message command) ack an
+  // entry whose payloads all failed — silently dropping the message.
+  let hadPayloadFailure = false;
+  let firstPayloadError: string | undefined;
+  const wrappedParams = {
+    ...params,
+    onError: (err: unknown, payload: NormalizedOutboundPayload) => {
+      hadPayloadFailure = true;
+      // Keep the cause: "partial delivery failure (bestEffort)" alone tells an
+      // operator triaging the entry nothing about why it failed.
+      firstPayloadError ??= describeDeliveryError(err);
+      params.onError?.(err, payload);
+    },
+  };
 
-  try {
-    const results = await deliverOutboundPayloadsCore(wrappedParams);
-    if (queueId) {
-      if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
-      } else {
-        await ackDelivery(queueId).catch(() => {}); // Best-effort cleanup.
-      }
+  // The core fills this as each payload lands, so the queue bookkeeping below
+  // can tell "nothing reached the recipient" (safe to replay whole) from "some
+  // of it did" (replaying duplicates what already arrived) — including when the
+  // core throws part-way and never returns its results. Chunked text makes this
+  // ordinary, not exotic: chunk 1 can land and chunk 2 throw.
+  const landed: OutboundDeliveryResult[] = [];
+
+  const recordQueueFailure = async (error: string): Promise<void> => {
+    if (!queueId) {
+      return;
     }
-    return results;
-  } catch (err) {
-    if (queueId) {
-      if (isAbortError(err)) {
-        await ackDelivery(queueId).catch(() => {});
-      } else {
-        await failDelivery(queueId, describeDeliveryError(err)).catch(() => {});
-      }
+    if (landed.length > 0) {
+      // Pass the count: it is the only record of how far the send got, and the
+      // operator who opens the quarantined entry otherwise sees the full payload
+      // list with no way to tell which part arrived.
+      await failPartialDelivery(queueId, error, undefined, landed.length).catch(() => {});
+    } else {
+      await failDelivery(queueId, error).catch(() => {});
     }
-    throw err;
+  };
+
+  const runDelivery = async (): Promise<OutboundDeliveryResult[]> => {
+    try {
+      const results = await deliverOutboundPayloadsCore(wrappedParams, landed);
+      if (queueId) {
+        if (hadPayloadFailure) {
+          await recordQueueFailure(
+            `partial delivery failure (bestEffort): ${firstPayloadError ?? "unknown error"}`,
+          );
+        } else {
+          await ackDelivery(queueId).catch(() => {}); // Best-effort cleanup.
+        }
+      }
+      return results;
+    } catch (err) {
+      if (queueId) {
+        // Acking discards the entry outright — no retry, no failed/, no
+        // needs-review — so it is only correct when the CALLER cancelled and
+        // nothing reached the recipient. `isAbortError` is name-based, and a
+        // transport timeout that aborts its own AbortController surfaces a
+        // DOMException named "AbortError" (BlueBubbles does exactly this): that
+        // is an unknown send outcome, not a cancellation, and acking it would
+        // silently drop the message. A caller-cancelled send that already
+        // landed part of its payloads is likewise not a clean discard.
+        const cancelledByCaller = isAbortError(err) && params.abortSignal?.aborted === true;
+        if (cancelledByCaller && landed.length === 0) {
+          await ackDelivery(queueId).catch(() => {});
+        } else {
+          await recordQueueFailure(describeDeliveryError(err));
+        }
+      }
+      // Tell whoever catches this how far the send got. Crash recovery calls
+      // this function with skipQueue set, so it owns its own queue bookkeeping
+      // and has no other way to tell a total failure (safe to replay whole)
+      // from a partial one (replaying duplicates what already arrived).
+      throw annotateDeliveredBeforeFailure(err, landed.length);
+    }
+  };
+
+  if (!queueId) {
+    return await runDelivery();
   }
+
+  // Hold a single-owner claim for the whole send, so a crash-recovery pass
+  // running concurrently cannot drive the same queue entry, and stamp the entry
+  // as "send in flight" so an interrupted send is quarantined rather than
+  // blind-replayed on the next startup (#2934).
+  const claim = await withActiveDeliveryClaim(queueId, async () => {
+    try {
+      await markDeliveryAttemptStarted(queueId);
+    } catch (err) {
+      // Degrade to the pre-marker replay behaviour rather than block the send —
+      // but say so, or an operator cannot tell that duplicate suppression is
+      // disarmed for this message.
+      log.warn(
+        "deliverOutboundPayloads: could not record the send-in-flight marker; if this process dies mid-send the message may be delivered twice",
+        { channel, to, queueId, error: describeDeliveryError(err) },
+      );
+    }
+    return await runDelivery();
+  });
+  if (claim.status === "claimed") {
+    return claim.value;
+  }
+  // Unreachable today, and the reason is narrow: there is no `await` between
+  // enqueueDelivery resolving above and the claim being taken, so no recovery
+  // pass can interleave and grab this freshly-minted id. Do not insert one.
+  // Throwing rather than returning [] keeps this loud if that ever changes —
+  // most callers ignore the result array, so an empty return would read as a
+  // successful send of a message that was never sent.
+  throw new Error(
+    `Delivery queue entry ${queueId} is already owned by another delivery worker — refusing to send it twice`,
+  );
 }
 
-/** Core delivery logic (extracted for queue wrapper). */
+/**
+ * Core delivery logic (extracted for queue wrapper).
+ *
+ * `results` is accepted from the caller — required, not defaulted — rather than
+ * created here, so the queue wrapper still sees which payloads landed when this
+ * function throws part-way. A default would silently let a future caller drop
+ * that wiring and lose the partial-send signal.
+ */
 async function deliverOutboundPayloadsCore(
   params: DeliverOutboundPayloadsCoreParams,
+  results: OutboundDeliveryResult[],
 ): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const accountId = params.accountId;
@@ -542,7 +639,6 @@ async function deliverOutboundPayloadsCore(
     cfg,
     params.session?.agentId ?? params.mirror?.agentId,
   );
-  const results: OutboundDeliveryResult[] = [];
   const handler = await createChannelHandler({
     cfg,
     channel,

--- a/src/infra/outbound/delivered-before-failure.ts
+++ b/src/infra/outbound/delivered-before-failure.ts
@@ -1,0 +1,51 @@
+/**
+ * How far a failed send got, carried on the error itself.
+ *
+ * A caller that only sees a rejected promise cannot tell a total failure (safe
+ * to replay whole) from a partial one (replaying re-sends what already arrived).
+ * The sender knows, so it annotates the error on the way out and the queue's
+ * recovery pass reads it back.
+ *
+ * Its own module rather than part of `delivery-queue.ts` so `deliver.ts` can use
+ * it without importing the queue: `deliver.test.ts` mocks the queue module
+ * wholesale, and a mocked annotation would make a broken one untestable.
+ */
+
+const DELIVERED_BEFORE_FAILURE_KEY = "remoteClawDeliveredBeforeFailure";
+
+/**
+ * Record how many payloads reached the platform before the send failed.
+ *
+ * Non-enumerable so it does not leak into `JSON.stringify` of the error, and
+ * returns the same error so it can be used inline at a `throw`.
+ */
+export function annotateDeliveredBeforeFailure<T>(err: T, deliveredCount: number): T {
+  if (err && typeof err === "object") {
+    try {
+      Object.defineProperty(err, DELIVERED_BEFORE_FAILURE_KEY, {
+        value: deliveredCount,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+    } catch {
+      // Frozen or non-extensible error. Losing the annotation costs precision;
+      // throwing here would replace the real delivery failure with a TypeError.
+    }
+  }
+  return err;
+}
+
+/**
+ * Read the annotation left by {@link annotateDeliveredBeforeFailure}.
+ *
+ * `undefined` means the sender did not report one — not that nothing landed.
+ * Callers must decide what an unreported outcome means for them.
+ */
+export function readDeliveredBeforeFailure(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const value = (err as Record<string, unknown>)[DELIVERED_BEFORE_FAILURE_KEY];
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -1,0 +1,647 @@
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteClawConfig } from "../../config/config.js";
+import { annotateDeliveredBeforeFailure } from "./delivered-before-failure.js";
+import {
+  ackDelivery,
+  clearDeliveryAttemptMarker,
+  type DeliverFn,
+  enqueueDelivery,
+  failDelivery,
+  failPartialDelivery,
+  hasUnknownSendOutcome,
+  loadPendingDeliveries,
+  markDeliveryAttemptStarted,
+  type QueuedDelivery,
+  quarantineUnknownSend,
+  recoverPendingDeliveries,
+  type RecoverySummary,
+  resolveNeedsReviewDir,
+  withActiveDeliveryClaim,
+} from "./delivery-queue.js";
+
+const cfg: RemoteClawConfig = {};
+
+function createLog() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+let stateDir: string;
+
+beforeEach(async () => {
+  // realpath: macOS tmpdir is a symlink, and the queue compares resolved paths.
+  stateDir = await fs.promises.realpath(
+    await fs.promises.mkdtemp(path.join(tmpdir(), "remoteclaw-delivery-queue-")),
+  );
+});
+
+async function enqueueTestDelivery(): Promise<string> {
+  return await enqueueDelivery(
+    { channel: "whatsapp", to: "+1555", payloads: [{ text: "hello" }] },
+    stateDir,
+  );
+}
+
+/**
+ * Enqueue with an explicit `enqueuedAt` and recipient. Recovery processes
+ * oldest-first, and two entries enqueued in the same millisecond would sort
+ * by readdir order — stamping the timestamp makes multi-entry tests
+ * deterministic rather than filesystem-dependent.
+ */
+async function enqueueTestDeliveryAt(enqueuedAt: number, to: string): Promise<string> {
+  const id = await enqueueDelivery(
+    { channel: "whatsapp", to, payloads: [{ text: "hello" }] },
+    stateDir,
+  );
+  const filePath = path.join(stateDir, "delivery-queue", `${id}.json`);
+  const entry = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
+  entry.enqueuedAt = enqueuedAt;
+  await fs.promises.writeFile(filePath, JSON.stringify(entry, null, 2));
+  return id;
+}
+
+/**
+ * Drive one recovery pass. Defaults to a no-op deliverer and a fresh log so a
+ * test that only cares about the queue's own bookkeeping states just that.
+ */
+async function runRecovery(
+  deliver: DeliverFn = vi.fn<DeliverFn>(async () => undefined),
+  log = createLog(),
+): Promise<{ summary: RecoverySummary; deliver: DeliverFn; log: ReturnType<typeof createLog> }> {
+  const summary = await recoverPendingDeliveries({ deliver, log, cfg, stateDir });
+  return { summary, deliver, log };
+}
+
+async function readEntry(id: string, dir?: string): Promise<QueuedDelivery> {
+  const filePath = path.join(dir ?? path.join(stateDir, "delivery-queue"), `${id}.json`);
+  return JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
+}
+
+describe("send-in-flight marker", () => {
+  it("stamps recoveryState and platformSendStartedAt on the pending entry", async () => {
+    const id = await enqueueTestDelivery();
+    expect((await readEntry(id)).recoveryState).toBeUndefined();
+
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("send_attempt_started");
+    expect(entry.platformSendStartedAt).toBeGreaterThan(0);
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+  });
+
+  it("is cleared by failDelivery, because an observed failure is a known outcome", async () => {
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    await failDelivery(id, "boom", stateDir);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(entry.platformSendStartedAt).toBeUndefined();
+    expect(entry.retryCount).toBe(1);
+    expect(entry.lastError).toBe("boom");
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  it("does not quarantine a marked entry that then acks successfully", async () => {
+    // The marker is set on EVERY send, so the common case is a marked entry that
+    // completes normally. Acking must clear it outright — not leave it pending,
+    // and not route it to needs-review, which would make routine traffic land in
+    // the operator's reconciliation queue.
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    await ackDelivery(id, stateDir);
+
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+    expect(fs.existsSync(path.join(resolveNeedsReviewDir(stateDir), `${id}.json`))).toBe(false);
+
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+    const { summary } = await runRecovery(deliver);
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(0);
+    expect(summary.awaitingReviewAtStart).toBe(0);
+  });
+
+  it("is KEPT by failPartialDelivery, because some payloads already landed", async () => {
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    await failPartialDelivery(id, "partial delivery failure (bestEffort)", stateDir);
+
+    const entry = await readEntry(id);
+    // Replaying the whole entry would re-send the payloads that arrived.
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+    expect(entry.retryCount).toBe(1);
+  });
+
+  it("quarantines a partially-delivered entry instead of replaying it", async () => {
+    const id = await enqueueTestDelivery();
+    await failPartialDelivery(id, "partial delivery failure (bestEffort)", stateDir);
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+    expect(fs.existsSync(path.join(resolveNeedsReviewDir(stateDir), `${id}.json`))).toBe(true);
+  });
+
+  it("is cleared by clearDeliveryAttemptMarker", async () => {
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    await clearDeliveryAttemptMarker(id, stateDir);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(entry.platformSendStartedAt).toBeUndefined();
+  });
+});
+
+describe("quarantineUnknownSend", () => {
+  it("moves the entry to needs-review/ stamped unknown_after_send", async () => {
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    await quarantineUnknownSend(id, stateDir);
+
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+    const quarantined = await readEntry(id, resolveNeedsReviewDir(stateDir));
+    expect(quarantined.recoveryState).toBe("unknown_after_send");
+    expect(quarantined.payloads).toEqual([{ text: "hello" }]);
+  });
+});
+
+describe("withActiveDeliveryClaim", () => {
+  it("returns the wrapped value to the owner", async () => {
+    const result = await withActiveDeliveryClaim("entry-1", async () => "done");
+    expect(result).toEqual({ status: "claimed", value: "done" });
+  });
+
+  it("denies a second concurrent claim on the same entry", async () => {
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const first = withActiveDeliveryClaim("entry-1", async () => {
+      await held;
+      return "first";
+    });
+    const second = await withActiveDeliveryClaim("entry-1", async () => "second");
+
+    expect(second).toEqual({ status: "claimed-by-other-owner" });
+    release?.();
+    expect(await first).toEqual({ status: "claimed", value: "first" });
+  });
+
+  it("does not block a concurrent claim on a different entry", async () => {
+    let release: (() => void) | undefined;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = withActiveDeliveryClaim("entry-1", async () => {
+      await held;
+      return "first";
+    });
+
+    expect(await withActiveDeliveryClaim("entry-2", async () => "second")).toEqual({
+      status: "claimed",
+      value: "second",
+    });
+
+    release?.();
+    await first;
+  });
+
+  it("releases the claim after the callback throws", async () => {
+    await expect(
+      withActiveDeliveryClaim("entry-1", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(await withActiveDeliveryClaim("entry-1", async () => "reclaimed")).toEqual({
+      status: "claimed",
+      value: "reclaimed",
+    });
+  });
+});
+
+describe("recoverPendingDeliveries", () => {
+  it("refuses to replay an entry whose send outcome is unknown", async () => {
+    // The crash window: the process died between the platform send and the ack.
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+    const log = createLog();
+
+    const { summary } = await runRecovery(deliver, log);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+    expect(summary.recovered).toBe(0);
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+    expect((await readEntry(id, resolveNeedsReviewDir(stateDir))).recoveryState).toBe(
+      "unknown_after_send",
+    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("outcome unknown"));
+    // The operator log must name where the entry went and when the send began.
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(resolveNeedsReviewDir(stateDir)));
+  });
+
+  it("refuses replay even when the unknown entry is otherwise retry-eligible", async () => {
+    // retryCount 0 + no lastAttemptAt is the "first replay after crash" fast path
+    // that bypasses backoff — duplicate suppression must still win.
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+    expect((await readEntry(id)).retryCount).toBe(0);
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+  });
+
+  it("still replays a clean pending entry and acks it", async () => {
+    const id = await enqueueTestDelivery();
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver.mock.calls[0]?.[0]).toMatchObject({
+      channel: "whatsapp",
+      to: "+1555",
+      skipQueue: true,
+    });
+    expect(summary).toMatchObject({ recovered: 1, needsReview: 0, failed: 0 });
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+    expect(fs.existsSync(path.join(resolveNeedsReviewDir(stateDir), `${id}.json`))).toBe(false);
+  });
+
+  it("replays a mid-retry entry written before the marker existed", async () => {
+    // Backward compatibility on the shape that actually differs: a pre-upgrade
+    // gateway that had already retried. A clean pre-upgrade entry is
+    // byte-identical to a clean current one (the new fields are optional), so
+    // only a mid-retry entry distinguishes this from the clean-replay case.
+    const id = "11111111-2222-3333-4444-555555555555";
+    const queueDir = path.join(stateDir, "delivery-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true, mode: 0o700 });
+    await fs.promises.writeFile(
+      path.join(queueDir, `${id}.json`),
+      JSON.stringify(
+        {
+          id,
+          enqueuedAt: Date.now() - 3_600_000,
+          channel: "whatsapp",
+          to: "+1555",
+          payloads: [{ text: "legacy" }],
+          retryCount: 3,
+          lastAttemptAt: Date.now() - 600_000, // past the 2m backoff for retry 3
+          lastError: "boom",
+        },
+        null,
+        2,
+      ),
+    );
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const { summary } = await runRecovery(deliver);
+
+    // Replayed as before, not swept into needs-review on first upgrade.
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(summary.recovered).toBe(1);
+    expect(summary.needsReview).toBe(0);
+  });
+
+  it("skips an entry another owner removed after the scan", async () => {
+    // Guards the vanished-entry path specifically: the file is gone by the time
+    // the claim is granted, so there is nothing left to send.
+    await enqueueTestDeliveryAt(1_000, "+FIRST");
+    const gone = await enqueueTestDeliveryAt(2_000, "+GONE");
+    const deliver = vi.fn<DeliverFn>(async () => {
+      // A concurrent owner completes `gone` while recovery is busy with FIRST.
+      await ackDelivery(gone, stateDir);
+      return undefined;
+    });
+
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver.mock.calls[0]?.[0]).toMatchObject({ to: "+FIRST" });
+    expect(summary.recovered).toBe(1);
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+  });
+
+  it("honours a retry/backoff state another owner wrote after the scan", async () => {
+    // The entry still EXISTS, so no vanished-entry guard can save this one —
+    // only re-reading it under the claim does. The stale snapshot says
+    // "retryCount 0, never attempted" (immediately eligible); disk says
+    // "attempted just now" (25s of backoff left).
+    await enqueueTestDeliveryAt(1_000, "+FIRST");
+    const retried = await enqueueTestDeliveryAt(2_000, "+RETRIED");
+    const deliver = vi.fn<DeliverFn>(async () => {
+      await failDelivery(retried, "network blip", stateDir);
+      return undefined;
+    });
+
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver.mock.calls[0]?.[0]).toMatchObject({ to: "+FIRST" });
+    expect(summary.recovered).toBe(1);
+    expect(summary.deferredBackoff).toBe(1);
+  });
+
+  it("re-reads the entry under the claim so a marker set after the scan still wins", async () => {
+    // The marker can land between the scan and the claim (another owner entered
+    // its send path). The stale snapshot says "clean"; disk says "in flight".
+    await enqueueTestDeliveryAt(1_000, "+FIRST");
+    const marked = await enqueueTestDeliveryAt(2_000, "+MARKED");
+    const deliver = vi.fn<DeliverFn>(async () => {
+      await markDeliveryAttemptStarted(marked, stateDir);
+      return undefined;
+    });
+
+    const { summary } = await runRecovery(deliver);
+
+    // FIRST was delivered; MARKED was quarantined off disk state, not replayed.
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver.mock.calls[0]?.[0]).toMatchObject({ to: "+FIRST" });
+    expect(summary.recovered).toBe(1);
+    expect(summary.needsReview).toBe(1);
+    expect((await readEntry(marked, resolveNeedsReviewDir(stateDir))).recoveryState).toBe(
+      "unknown_after_send",
+    );
+  });
+
+  it("counts a failed quarantine separately and leaves the entry unsent", async () => {
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+    // Block the move by occupying the target path with a non-directory.
+    await fs.promises.writeFile(resolveNeedsReviewDir(stateDir), "not a directory");
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+    const log = createLog();
+
+    const { summary } = await runRecovery(deliver, log);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.quarantineFailed).toBe(1);
+    // Not counted as handled — the entry is still pending and still unsent.
+    expect(summary.needsReview).toBe(0);
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("will NOT be replayed"));
+    expect(await loadPendingDeliveries(stateDir)).toHaveLength(1);
+  });
+
+  it("marks its own replay in flight before delivering", async () => {
+    // Recovery re-opens the same crash window it exists to close; without this
+    // marker a crash mid-recovery would blind-replay on the next restart.
+    const id = await enqueueTestDelivery();
+    let stateDuringSend: string | undefined;
+    const deliver = vi.fn<DeliverFn>(async () => {
+      stateDuringSend = (await readEntry(id)).recoveryState;
+      return undefined;
+    });
+
+    await runRecovery(deliver);
+
+    expect(stateDuringSend).toBe("send_attempt_started");
+  });
+
+  it("clears the marker on an observed failure so the entry stays replayable", async () => {
+    const id = await enqueueTestDelivery();
+    const failing = vi.fn<DeliverFn>(async () => {
+      throw new Error("network blip");
+    });
+
+    const { summary } = await runRecovery(failing);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(entry.retryCount).toBe(1);
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  it("does not double-deliver when two recovery passes race the same entry", async () => {
+    await enqueueTestDelivery();
+    let release: (() => void) | undefined;
+    const inSend = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let held: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      held = resolve;
+    });
+    const slowDeliver = vi.fn<DeliverFn>(async () => {
+      release?.();
+      await blocked;
+      return undefined;
+    });
+    // Separate mock so a broken claim guard fails this assertion instead of
+    // deadlocking on the first pass's still-open send.
+    const racingDeliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const first = runRecovery(slowDeliver);
+    await inSend;
+    const { summary: secondSummary } = await runRecovery(racingDeliver);
+
+    // The claim, not the marker, is what tells recovery this entry is live:
+    // without it the racing pass would quarantine a send still in flight.
+    expect(racingDeliver).not.toHaveBeenCalled();
+    expect(secondSummary.skippedClaimed).toBe(1);
+    expect(secondSummary.needsReview).toBe(0);
+
+    held?.();
+    expect((await first).summary.recovered).toBe(1);
+    expect(slowDeliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clear the marker when its own retry failed after some payloads landed", async () => {
+    // Recovery's retry has the same partial-send window as the live path. If it
+    // clears the marker regardless, the next restart replays the whole entry and
+    // re-sends whatever already arrived — the duplicate, one restart later.
+    const id = await enqueueTestDelivery();
+    const partiallyFailing = vi.fn<DeliverFn>(async () => {
+      throw annotateDeliveredBeforeFailure(new Error("chunk 2 exploded"), 1);
+    });
+
+    const { summary } = await runRecovery(partiallyFailing);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(entry.deliveredBeforeFailure).toBe(1);
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+  });
+
+  it("quarantines rather than replays an entry its own retry partly delivered", async () => {
+    const id = await enqueueTestDelivery();
+    const partiallyFailing = vi.fn<DeliverFn>(async () => {
+      throw annotateDeliveredBeforeFailure(new Error("chunk 2 exploded"), 1);
+    });
+    await runRecovery(partiallyFailing);
+
+    const replay = vi.fn<DeliverFn>(async () => undefined);
+    const { summary } = await runRecovery(replay);
+
+    expect(replay).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+    expect((await readEntry(id, resolveNeedsReviewDir(stateDir))).deliveredBeforeFailure).toBe(1);
+  });
+
+  it("still replays whole when the retry failed with nothing landed", async () => {
+    // The mirror of the case above — an unreported or zero landed count must not
+    // over-quarantine, or every transient failure becomes manual work.
+    const id = await enqueueTestDelivery();
+    const totallyFailing = vi.fn<DeliverFn>(async () => {
+      throw annotateDeliveredBeforeFailure(new Error("connection refused"), 0);
+    });
+
+    await runRecovery(totallyFailing);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  it("does not ack a bestEffort retry whose payloads all failed", async () => {
+    // bestEffort swallows per-payload errors and resolves, so "did not throw" is
+    // not "arrived". Acking here silently drops the message.
+    const id = await enqueueTestDelivery();
+    const swallowing = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(new Error("rate limited"), params.payloads[0]);
+      return [];
+    });
+
+    const { summary } = await runRecovery(swallowing);
+
+    expect(summary.recovered).toBe(0);
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.retryCount).toBe(1);
+    expect(entry.lastError).toContain("rate limited");
+    // Nothing landed, so it stays replayable rather than becoming manual work.
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  it("quarantines a bestEffort retry where some payloads landed and others failed", async () => {
+    const id = await enqueueTestDelivery();
+    const partial = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(new Error("rate limited"), params.payloads[0]);
+      return [{ messageId: "m1" }];
+    });
+
+    const { summary } = await runRecovery(partial);
+
+    expect(summary.recovered).toBe(0);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(entry.deliveredBeforeFailure).toBe(1);
+  });
+
+  it("quarantines a partly-delivered entry even when the error is permanent", async () => {
+    // "Permanent" answers whether retrying can work, not whether part of the
+    // message is already on the recipient's device. Filing it under failed/
+    // would tell the operator it never arrived.
+    const id = await enqueueTestDelivery();
+    const permanentMidSend = vi.fn<DeliverFn>(async () => {
+      throw annotateDeliveredBeforeFailure(new Error("chat not found"), 1);
+    });
+
+    const { summary } = await runRecovery(permanentMidSend);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", "failed", `${id}.json`))).toBe(
+      false,
+    );
+  });
+
+  it("reports quarantined mail on every later startup, not just the one that quarantined it", async () => {
+    // Quarantining moves the entry out of the pending scan, so without a
+    // standing count the only startup that ever mentions it is the one that
+    // created it. After a log rotation the operator has no way to discover that
+    // mail is waiting for them.
+    const id = await enqueueTestDelivery();
+    await failPartialDelivery(id, "boom", stateDir, 1);
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+    await runRecovery(deliver);
+
+    // Second startup: nothing pending at all, one entry still awaiting review.
+    const log = createLog();
+    const { summary } = await runRecovery(deliver, log);
+
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+    expect(summary.needsReview).toBe(0);
+    expect(summary.awaitingReviewAtStart).toBe(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("awaiting manual reconciliation"),
+    );
+  });
+
+  it("counts message parts without a payload-count denominator", async () => {
+    // `deliveredBeforeFailure` counts PLATFORM SENDS (one text payload chunks
+    // into several), so rendering it as a fraction of payloads.length produced
+    // impossible operator lines like "2 of 1 payload(s)".
+    const id = await enqueueTestDelivery();
+    await failPartialDelivery(id, "boom", stateDir, 2);
+    const log = createLog();
+
+    await runRecovery(
+      vi.fn<DeliverFn>(async () => undefined),
+      log,
+    );
+
+    // The incident record, not the remediation one that follows it.
+    const incident = log.warn.mock.calls
+      .map(String)
+      .find((line) => line.includes(id) && line.includes("interrupted mid-send"));
+    expect(incident).toContain("2 message part(s) confirmed sent");
+    expect(incident).not.toContain("of 1");
+  });
+
+  it("tells the operator to reset retryCount when un-quarantining a maxed-out entry", async () => {
+    // failPartialDelivery increments retryCount, so an entry that accumulated
+    // transient failures and then partly landed is quarantined AT the cap.
+    // Following instructions that omit the reset files it to failed/ unsent.
+    const id = await enqueueTestDelivery();
+    for (let i = 0; i < 5; i += 1) {
+      await failDelivery(id, "transient", stateDir);
+    }
+    await failPartialDelivery(id, "boom", stateDir, 1);
+    const log = createLog();
+
+    await runRecovery(
+      vi.fn<DeliverFn>(async () => undefined),
+      log,
+    );
+
+    const remediation = log.warn.mock.calls
+      .map(String)
+      .find((line) => line.includes(id) && line.includes("To reconcile"));
+    expect(remediation).toContain('"retryCount" to 0');
+    expect(remediation).toContain(`"retryCount" at 6 (max 5)`);
+  });
+
+  it("still routes a permanent error with nothing landed to failed/", async () => {
+    const id = await enqueueTestDelivery();
+    const permanent = vi.fn<DeliverFn>(async () => {
+      throw new Error("chat not found");
+    });
+
+    const { summary } = await runRecovery(permanent);
+
+    expect(summary.failed).toBe(1);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", "failed", `${id}.json`))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", `${id}.json`))).toBe(false);
+  });
+});

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -4,11 +4,16 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { generateSecureUuid } from "../secure-random.js";
+import {
+  annotateDeliveredBeforeFailure,
+  readDeliveredBeforeFailure,
+} from "./delivered-before-failure.js";
 import { describeDeliveryError } from "./describe-delivery-error.js";
 import type { OutboundChannel } from "./targets.js";
 
 const QUEUE_DIRNAME = "delivery-queue";
 const FAILED_DIRNAME = "failed";
+const NEEDS_REVIEW_DIRNAME = "needs-review";
 const MAX_RETRIES = 5;
 
 /** Backoff delays in milliseconds indexed by retry count (1-based). */
@@ -44,12 +49,39 @@ type QueuedDeliveryPayload = {
   mirror?: DeliveryMirrorPayload;
 };
 
+/**
+ * Where an entry sits relative to the platform send, so recovery can tell
+ * "never sent" apart from "maybe sent, outcome unknown".
+ *
+ * - `send_attempt_started` — written immediately before the platform send. If a
+ *   crash leaves this on disk, the send may or may not have landed on the wire.
+ * - `unknown_after_send` — the verdict for a send that may already have landed:
+ *   written by recovery when it quarantines an interrupted attempt, and by
+ *   {@link failPartialDelivery} when a send delivered part of its payloads and
+ *   then failed — which is an ordinary live send, not only a crash. Either way
+ *   the entry is quarantined instead of replayed.
+ *
+ * Absent (`undefined`) means no send has been attempted since the entry was
+ * enqueued or since its last observed failure — the entry is safe to replay.
+ * Entries written before this field existed have no marker and keep the
+ * historical replay behaviour.
+ */
+export type DeliveryRecoveryState = "send_attempt_started" | "unknown_after_send";
+
 export interface QueuedDelivery extends QueuedDeliveryPayload {
   id: string;
   enqueuedAt: number;
   retryCount: number;
   lastAttemptAt?: number;
   lastError?: string;
+  recoveryState?: DeliveryRecoveryState;
+  /** Wall-clock ms when the platform send that set {@link recoveryState} began. */
+  platformSendStartedAt?: number;
+  /**
+   * How many payloads reached the platform before the send failed. Recorded on
+   * a partial send so whoever reconciles the entry knows which part arrived.
+   */
+  deliveredBeforeFailure?: number;
 }
 
 export type RecoverySummary = {
@@ -57,6 +89,20 @@ export type RecoverySummary = {
   failed: number;
   skippedMaxRetries: number;
   deferredBackoff: number;
+  /** Entries with an unknown send outcome, quarantined instead of replayed. */
+  needsReview: number;
+  /** Entries with an unknown send outcome that could NOT be quarantined. */
+  quarantineFailed: number;
+  /** Entries skipped because another in-process worker held the claim. */
+  skippedClaimed: number;
+  /**
+   * Entries already sitting in `needs-review/` when this pass STARTED, i.e.
+   * quarantined by earlier passes. Unlike the counters above this is a standing
+   * backlog, not an outcome of this run — it is what makes quarantined mail
+   * visible on every startup rather than only the one that quarantined it.
+   * The current total is `awaitingReviewAtStart + needsReview`.
+   */
+  awaitingReviewAtStart: number;
 };
 
 function resolveQueueDir(stateDir?: string): string {
@@ -66,6 +112,11 @@ function resolveQueueDir(stateDir?: string): string {
 
 function resolveFailedDir(stateDir?: string): string {
   return path.join(resolveQueueDir(stateDir), FAILED_DIRNAME);
+}
+
+/** Quarantine directory for entries whose send outcome could not be determined. */
+export function resolveNeedsReviewDir(stateDir?: string): string {
+  return path.join(resolveQueueDir(stateDir), NEEDS_REVIEW_DIRNAME);
 }
 
 function resolveQueueEntryPaths(
@@ -94,6 +145,28 @@ async function unlinkBestEffort(filePath: string): Promise<void> {
   } catch {
     // Best-effort cleanup.
   }
+}
+
+/** Atomically rewrite a queue entry in place (write tmp, then rename over). */
+async function writeQueueEntryAtomic(filePath: string, entry: QueuedDelivery): Promise<void> {
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  await fs.promises.rename(tmp, filePath);
+}
+
+/** Read-modify-write a pending queue entry. Throws ENOENT if it is already gone. */
+async function updateQueueEntry(
+  id: string,
+  stateDir: string | undefined,
+  mutate: (entry: QueuedDelivery) => QueuedDelivery,
+): Promise<void> {
+  const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
+  const raw = await fs.promises.readFile(filePath, "utf-8");
+  const entry: QueuedDelivery = JSON.parse(raw);
+  await writeQueueEntryAtomic(filePath, mutate(entry));
 }
 
 /** Ensure the queue directory (and failed/ subdirectory) exist. */
@@ -128,12 +201,101 @@ export async function enqueueDelivery(
     mirror: params.mirror,
     retryCount: 0,
   };
-  const filePath = path.join(queueDir, `${id}.json`);
-  const tmp = `${filePath}.${process.pid}.tmp`;
-  const json = JSON.stringify(entry, null, 2);
-  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
-  await fs.promises.rename(tmp, filePath);
+  await writeQueueEntryAtomic(path.join(queueDir, `${id}.json`), entry);
   return id;
+}
+
+/**
+ * Record that delivery for `id` has entered the send path.
+ *
+ * This is the write that closes the duplicate-delivery window: if the process
+ * dies anywhere between here and the matching ack/fail, the entry is left on
+ * disk carrying `send_attempt_started`, and {@link recoverPendingDeliveries}
+ * quarantines it instead of re-sending a message that may already have landed.
+ *
+ * The marked window is deliberately wider than the wire call — it opens before
+ * payload normalization and the `message_sending` hook, so a crash before
+ * anything reached the network still quarantines. Over-quarantining costs an
+ * operator a look; under-marking costs a user a duplicate.
+ *
+ * Callers treat this as best-effort — a queue-write failure must not block the
+ * delivery itself. The cost of a missed marker is the pre-existing replay
+ * behaviour, not a new failure mode, but callers should say so in the log.
+ */
+export async function markDeliveryAttemptStarted(id: string, stateDir?: string): Promise<void> {
+  await updateQueueEntry(id, stateDir, (entry) => ({
+    ...entry,
+    recoveryState: "send_attempt_started",
+    platformSendStartedAt: Date.now(),
+  }));
+}
+
+/** Drop the in-flight marker once the send outcome is definitively known. */
+export async function clearDeliveryAttemptMarker(id: string, stateDir?: string): Promise<void> {
+  await updateQueueEntry(id, stateDir, (entry) => ({
+    ...entry,
+    recoveryState: undefined,
+    platformSendStartedAt: undefined,
+  }));
+}
+
+/** True when the entry's send may have landed but was never acknowledged. */
+export function hasUnknownSendOutcome(entry: QueuedDelivery): boolean {
+  return (
+    entry.recoveryState === "send_attempt_started" || entry.recoveryState === "unknown_after_send"
+  );
+}
+
+/**
+ * Quarantine an entry whose send outcome cannot be determined: stamp the
+ * verdict onto the entry, then move it out of the pending scan into
+ * `needs-review/` for an operator to reconcile by hand.
+ *
+ * Deliberately conservative — for a messaging product a message that silently
+ * needs a human is strictly better than a message the recipient receives twice.
+ */
+export async function quarantineUnknownSend(id: string, stateDir?: string): Promise<void> {
+  const queueDir = resolveQueueDir(stateDir);
+  const needsReviewDir = resolveNeedsReviewDir(stateDir);
+  await updateQueueEntry(id, stateDir, (entry) => ({
+    ...entry,
+    recoveryState: "unknown_after_send",
+  }));
+  await fs.promises.mkdir(needsReviewDir, { recursive: true, mode: 0o700 });
+  await fs.promises.rename(
+    path.join(queueDir, `${id}.json`),
+    path.join(needsReviewDir, `${id}.json`),
+  );
+}
+
+export type ActiveDeliveryClaimResult<T> =
+  | { status: "claimed"; value: T }
+  | { status: "claimed-by-other-owner" };
+
+/**
+ * In-process single-owner claim over one queue entry.
+ *
+ * Scope is deliberately in-process: it stops a recovery pass from draining an
+ * entry that a live send (or a concurrent recovery pass) is already working on
+ * within this gateway process. It is NOT a cross-process lock — the queue is
+ * owned by one gateway per state directory, which is the same boundary the
+ * session delivery queue's `entriesInProgress` guard assumes.
+ */
+const activeDeliveryClaims = new Set<string>();
+
+export async function withActiveDeliveryClaim<T>(
+  entryId: string,
+  fn: () => Promise<T>,
+): Promise<ActiveDeliveryClaimResult<T>> {
+  if (activeDeliveryClaims.has(entryId)) {
+    return { status: "claimed-by-other-owner" };
+  }
+  activeDeliveryClaims.add(entryId);
+  try {
+    return { status: "claimed", value: await fn() };
+  } finally {
+    activeDeliveryClaims.delete(entryId);
+  }
 }
 
 /** Remove a successfully delivered entry from the queue.
@@ -164,20 +326,84 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
   await unlinkBestEffort(deliveredPath);
 }
 
-/** Update a queue entry after a failed delivery attempt. */
+/**
+ * Update a queue entry after a delivery attempt where no payload was observed
+ * to reach the recipient, clearing the in-flight marker so the entry replays.
+ *
+ * The caller must establish that nothing landed — this function cannot tell.
+ * A send that delivered some payloads and then failed is a different outcome
+ * ({@link failPartialDelivery}); recording it here re-arms a replay that
+ * re-sends whatever already arrived. Chunked text makes that ordinary: one
+ * chunk lands, the next throws.
+ *
+ * Known residual: "no payload observed to land" is not the same as "nothing
+ * reached the platform". A request that times out or resets *after* hitting the
+ * wire produces no result object, so it is recorded here and replayed — the
+ * queue's long-standing at-least-once behaviour for ambiguous transport errors.
+ * Closing that needs transport-level error classification and is out of scope
+ * for the crash-window fix (#2934).
+ */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
-  const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
-  const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
-  entry.retryCount += 1;
-  entry.lastAttemptAt = Date.now();
-  entry.lastError = error;
-  const tmp = `${filePath}.${process.pid}.tmp`;
-  await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
-    encoding: "utf-8",
-    mode: 0o600,
-  });
-  await fs.promises.rename(tmp, filePath);
+  await updateQueueEntry(id, stateDir, (entry) => ({
+    ...entry,
+    retryCount: entry.retryCount + 1,
+    lastAttemptAt: Date.now(),
+    lastError: error,
+    recoveryState: undefined,
+    platformSendStartedAt: undefined,
+  }));
+}
+
+/**
+ * Update a queue entry after a send where some payloads landed and others did
+ * not — a failed chunk mid-sequence, or a per-payload error under best-effort.
+ *
+ * Replaying such an entry re-sends the payloads that already arrived, which is
+ * the same duplicate this queue's recovery path exists to prevent. So the entry
+ * keeps an unknown-outcome marker and recovery quarantines it for a human
+ * rather than retrying it whole.
+ */
+export async function failPartialDelivery(
+  id: string,
+  error: string,
+  stateDir?: string,
+  deliveredCount?: number,
+): Promise<void> {
+  await updateQueueEntry(id, stateDir, (entry) => ({
+    ...entry,
+    retryCount: entry.retryCount + 1,
+    lastAttemptAt: Date.now(),
+    lastError: error,
+    recoveryState: "unknown_after_send",
+    // Persist how far the send got: without it, whoever opens the quarantined
+    // entry sees the full payload list and no way to tell which part arrived.
+    deliveredBeforeFailure: deliveredCount,
+  }));
+}
+
+/**
+ * Load a single pending entry by id, or null if it is no longer pending.
+ *
+ * Recovery re-reads through this inside its claim: the scan snapshot is a
+ * hypothesis about an entry, and by the time the claim is granted another owner
+ * may have acked it, failed it, or stamped it in-flight.
+ */
+async function loadPendingDelivery(id: string, stateDir?: string): Promise<QueuedDelivery | null> {
+  const { jsonPath } = resolveQueueEntryPaths(id, stateDir);
+  try {
+    const stat = await fs.promises.stat(jsonPath);
+    if (!stat.isFile()) {
+      return null;
+    }
+    const raw = await fs.promises.readFile(jsonPath, "utf-8");
+    // Normalize in memory only — the scan already persisted any migration.
+    return normalizeLegacyQueuedDeliveryEntry(JSON.parse(raw) as QueuedDelivery).entry;
+  } catch (err) {
+    if (getErrnoCode(err) === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
 }
 
 /** Load all pending delivery entries from the queue directory. */
@@ -217,12 +443,7 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
       const parsed = JSON.parse(raw) as QueuedDelivery;
       const { entry, migrated } = normalizeLegacyQueuedDeliveryEntry(parsed);
       if (migrated) {
-        const tmp = `${filePath}.${process.pid}.tmp`;
-        await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
-          encoding: "utf-8",
-          mode: 0o600,
-        });
-        await fs.promises.rename(tmp, filePath);
+        await writeQueueEntryAtomic(filePath, entry);
       }
       entries.push(entry);
     } catch {
@@ -308,6 +529,12 @@ export type DeliverFn = (
     cfg: RemoteClawConfig;
   } & QueuedDeliveryParams & {
       skipQueue?: boolean;
+      /**
+       * Called once per payload that failed under `bestEffort`, where the send
+       * resolves instead of throwing. Recovery needs it: without it a retry in
+       * which every payload failed looks identical to a clean success.
+       */
+      onError?: (err: unknown, payload: unknown) => void;
     },
 ) => Promise<unknown>;
 
@@ -317,9 +544,77 @@ export interface RecoveryLogger {
   error(msg: string): void;
 }
 
+function createEmptyRecoverySummary(): RecoverySummary {
+  return {
+    recovered: 0,
+    failed: 0,
+    skippedMaxRetries: 0,
+    deferredBackoff: 0,
+    needsReview: 0,
+    quarantineFailed: 0,
+    skippedClaimed: 0,
+    awaitingReviewAtStart: 0,
+  };
+}
+
+/**
+ * Count entries awaiting manual reconciliation. Never throws — an unreadable
+ * quarantine directory must not stop recovery of the pending queue.
+ */
+async function countNeedsReviewEntries(stateDir?: string): Promise<number> {
+  try {
+    const files = await fs.promises.readdir(resolveNeedsReviewDir(stateDir));
+    return files.filter((file) => file.endsWith(".json")).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Whether the entry might still be pending. Deliberately conservative: an
+ * unreadable entry answers `true`, so a caller using this to decide "was that
+ * ENOENT because the entry is gone?" never mistakes an IO fault for a removal.
+ */
+async function pendingEntryMayStillExist(id: string, stateDir?: string): Promise<boolean> {
+  try {
+    return (await loadPendingDelivery(id, stateDir)) !== null;
+  } catch {
+    return true;
+  }
+}
+
+function formatSendStartedAt(entry: QueuedDelivery): string {
+  const startedAt = entry.platformSendStartedAt;
+  return typeof startedAt === "number" && startedAt > 0
+    ? new Date(startedAt).toISOString()
+    : "an unrecorded time";
+}
+
+/**
+ * Narrow the operator's reconciliation window when the sender reported how far
+ * it got. Without it the log says "some or all of this may have arrived"; with
+ * it, the first N parts are known-sent and only the rest are in question.
+ *
+ * Counts PLATFORM SENDS, not `payloads[]` entries: one payload of long text
+ * becomes several chunked sends, and a media payload one send per URL. Rendering
+ * it as a fraction of `payloads.length` produced impossible lines like
+ * "2 of 1 payload(s)", so there is deliberately no denominator here.
+ */
+function describeDeliveredBeforeFailure(entry: QueuedDelivery): string {
+  const landed = entry.deliveredBeforeFailure;
+  if (typeof landed !== "number" || landed <= 0) {
+    return "";
+  }
+  return ` (${landed} message part(s) confirmed sent before the failure)`;
+}
+
 /**
  * On gateway startup, scan the delivery queue and retry any pending entries.
  * Uses exponential backoff and moves entries that exceed MAX_RETRIES to failed/.
+ *
+ * Entries whose send outcome is unknown (the process died mid-send) are never
+ * replayed — they are quarantined to `needs-review/` so a crash cannot turn
+ * into a duplicate message on the recipient's device.
  */
 export async function recoverPendingDeliveries(opts: {
   deliver: DeliverFn;
@@ -329,9 +624,22 @@ export async function recoverPendingDeliveries(opts: {
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next restart. Default: 60 000. */
   maxRecoveryMs?: number;
 }): Promise<RecoverySummary> {
+  // Report the standing backlog before anything else. Quarantining moves an
+  // entry out of the pending scan, so without this the only startup that ever
+  // mentions a quarantined message is the one that quarantined it — after a log
+  // rotation an operator has no way to discover that mail is awaiting them.
+  // Deliberately before the early return: a state dir with nothing pending and
+  // ten quarantined entries is exactly when this matters most.
+  const awaitingReviewAtStart = await countNeedsReviewEntries(opts.stateDir);
+  if (awaitingReviewAtStart > 0) {
+    opts.log.warn(
+      `${awaitingReviewAtStart} delivery entr${awaitingReviewAtStart === 1 ? "y is" : "ies are"} awaiting manual reconciliation in ${resolveNeedsReviewDir(opts.stateDir)} — their send outcome is unknown and they will NOT be retried automatically`,
+    );
+  }
+
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
-    return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
+    return { ...createEmptyRecoverySummary(), awaitingReviewAtStart };
   }
 
   // Process oldest first.
@@ -341,84 +649,222 @@ export async function recoverPendingDeliveries(opts: {
 
   const deadline = Date.now() + (opts.maxRecoveryMs ?? 60_000);
 
-  let recovered = 0;
-  let failed = 0;
-  let skippedMaxRetries = 0;
-  let deferredBackoff = 0;
+  const summary = { ...createEmptyRecoverySummary(), awaitingReviewAtStart };
 
-  for (const entry of pending) {
+  for (const [index, entry] of pending.entries()) {
     const now = Date.now();
     if (now >= deadline) {
-      const deferred = pending.length - recovered - failed - skippedMaxRetries - deferredBackoff;
+      // Everything from this entry onward is untouched — counting by position
+      // rather than by summary totals stays correct no matter how many of the
+      // per-entry outcomes are counted.
+      const deferred = pending.length - index;
       opts.log.warn(`Recovery time budget exceeded — ${deferred} entries deferred to next restart`);
       break;
     }
-    if (entry.retryCount >= MAX_RETRIES) {
-      opts.log.warn(
-        `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${MAX_RETRIES}) — moving to failed/`,
-      );
+
+    // The claim wraps the whole per-entry decision, not just the send. It is
+    // what separates "another worker is on this right now" from "orphaned by a
+    // crash" — deciding without it would quarantine entries that a live send is
+    // still working, and re-drive entries another recovery pass already holds.
+    const claim = await withActiveDeliveryClaim(entry.id, async () => {
+      // Re-read under the claim. `entry` came from a scan taken before the claim
+      // was granted, so it is only a hypothesis: another owner may have acked,
+      // failed, or stamped the entry in-flight since. Deciding from the snapshot
+      // is how a "never replay unknown outcomes" guarantee still ships a
+      // duplicate. Same discipline as the session queue's per-entry re-read.
+      let current: QueuedDelivery | null;
       try {
-        await moveToFailed(entry.id, opts.stateDir);
+        current = await loadPendingDelivery(entry.id, opts.stateDir);
       } catch (err) {
-        opts.log.error(`Failed to move entry ${entry.id} to failed/: ${String(err)}`);
+        // Keep one unreadable entry from aborting the whole pass: the scan
+        // already tolerates malformed entries per file, and recovery should too.
+        opts.log.error(`Could not re-read delivery ${entry.id} — skipping it: ${String(err)}`);
+        return;
       }
-      skippedMaxRetries += 1;
-      continue;
-    }
+      if (!current) {
+        // Acked or moved by whoever owned it — there is nothing left to recover.
+        return;
+      }
 
-    const retryEligibility = isEntryEligibleForRecoveryRetry(entry, now);
-    if (!retryEligibility.eligible) {
-      deferredBackoff += 1;
-      opts.log.info(
-        `Delivery ${entry.id} not ready for retry yet — backoff ${retryEligibility.remainingBackoffMs}ms remaining`,
-      );
-      continue;
-    }
-
-    try {
-      await opts.deliver({
-        cfg: opts.cfg,
-        channel: entry.channel,
-        to: entry.to,
-        accountId: entry.accountId,
-        payloads: entry.payloads,
-        threadId: entry.threadId,
-        replyToId: entry.replyToId,
-        bestEffort: entry.bestEffort,
-        gifPlayback: entry.gifPlayback,
-        silent: entry.silent,
-        mirror: entry.mirror,
-        skipQueue: true, // Prevent re-enqueueing during recovery
-      });
-      await ackDelivery(entry.id, opts.stateDir);
-      recovered += 1;
-      opts.log.info(`Recovered delivery ${entry.id} to ${entry.channel}:${entry.to}`);
-    } catch (err) {
-      const errMsg = describeDeliveryError(err);
-      if (isPermanentDeliveryError(errMsg)) {
-        opts.log.warn(`Delivery ${entry.id} hit permanent error — moving to failed/: ${errMsg}`);
+      // Duplicate suppression comes first: an entry whose send may already have
+      // landed must never reach the retry path, whatever its retry/backoff state.
+      if (hasUnknownSendOutcome(current)) {
         try {
-          await moveToFailed(entry.id, opts.stateDir);
-        } catch (moveErr) {
-          opts.log.error(`Failed to move entry ${entry.id} to failed/: ${String(moveErr)}`);
+          await quarantineUnknownSend(current.id, opts.stateDir);
+        } catch (err) {
+          // An ENOENT only means "already handled" if the entry is genuinely
+          // gone. ENOENT from the mkdir (state dir pulled out from under a
+          // running gateway) leaves it pending and must not pass silently.
+          if (
+            getErrnoCode(err) === "ENOENT" &&
+            !(await pendingEntryMayStillExist(current.id, opts.stateDir))
+          ) {
+            return;
+          }
+          opts.log.error(
+            `Delivery ${current.id} has an unknown send outcome but could not be moved to ${resolveNeedsReviewDir(opts.stateDir)} — it stays pending and will NOT be replayed: ${String(err)}`,
+          );
+          summary.quarantineFailed += 1;
+          return;
         }
-        failed += 1;
-        continue;
+        // Two records on purpose: what happened, then what to do about it. One
+        // combined line buries the incident under a four-step runbook.
+        opts.log.warn(
+          `Delivery ${current.id} to ${current.channel}:${current.to} was interrupted mid-send at ${formatSendStartedAt(current)}${describeDeliveredBeforeFailure(current)} — outcome unknown, refusing to replay. Moved to ${path.join(resolveNeedsReviewDir(opts.stateDir), `${current.id}.json`)}`,
+        );
+        opts.log.warn(
+          `To reconcile delivery ${current.id}: check the recipient's message history around that time, then delete the file if it arrived. To send it after all, move the file back into ${resolveQueueDir(opts.stateDir)}, set its "recoveryState" to null and its "retryCount" to 0, then restart the gateway — recovery only runs at startup, leaving "recoveryState" set only re-quarantines it, and leaving "retryCount" at ${current.retryCount} (max ${MAX_RETRIES}) files it under failed/ without sending.`,
+        );
+        summary.needsReview += 1;
+        return;
       }
+
+      if (current.retryCount >= MAX_RETRIES) {
+        opts.log.warn(
+          `Delivery ${current.id} exceeded max retries (${current.retryCount}/${MAX_RETRIES}) — moving to failed/`,
+        );
+        try {
+          await moveToFailed(current.id, opts.stateDir);
+        } catch (err) {
+          opts.log.error(`Failed to move entry ${current.id} to failed/: ${String(err)}`);
+        }
+        summary.skippedMaxRetries += 1;
+        return;
+      }
+
+      const retryEligibility = isEntryEligibleForRecoveryRetry(current, Date.now());
+      if (!retryEligibility.eligible) {
+        summary.deferredBackoff += 1;
+        opts.log.info(
+          `Delivery ${current.id} not ready for retry yet — backoff ${retryEligibility.remainingBackoffMs}ms remaining`,
+        );
+        return;
+      }
+
+      // Recovery's own re-delivery opens the same crash window as the live send
+      // path, so it takes the same marker: without this, a crash during recovery
+      // would blind-replay on the next restart.
       try {
-        await failDelivery(entry.id, errMsg, opts.stateDir);
-      } catch {
-        // Best-effort update.
+        await markDeliveryAttemptStarted(current.id, opts.stateDir);
+      } catch (err) {
+        if (getErrnoCode(err) === "ENOENT") {
+          // The entry vanished after the re-read above. In-process that window
+          // is closed (no await between the two), so this covers removal from
+          // outside this process — a second gateway on the same state dir, or
+          // an operator clearing the queue. Either way it is gone: sending now
+          // is the duplicate.
+          return;
+        }
+        // Any other write failure degrades to the pre-marker replay behaviour.
+        // Say so: an operator cannot otherwise tell that duplicate suppression
+        // is disarmed for this entry.
+        opts.log.warn(
+          `Could not record the send-in-flight marker for delivery ${current.id} — if this process dies mid-send the entry may be delivered twice: ${String(err)}`,
+        );
       }
-      failed += 1;
-      opts.log.warn(`Retry failed for delivery ${entry.id}: ${errMsg}`);
+
+      // A `bestEffort` retry swallows per-payload errors and resolves, so
+      // "did not throw" is not "arrived". Without this the recovery pass acks
+      // an entry whose payloads all failed and the message is silently dropped.
+      let sawPayloadFailure = false;
+      let firstPayloadError: string | undefined;
+      try {
+        const sent = await opts.deliver({
+          cfg: opts.cfg,
+          channel: current.channel,
+          to: current.to,
+          accountId: current.accountId,
+          payloads: current.payloads,
+          threadId: current.threadId,
+          replyToId: current.replyToId,
+          bestEffort: current.bestEffort,
+          gifPlayback: current.gifPlayback,
+          silent: current.silent,
+          mirror: current.mirror,
+          skipQueue: true, // Prevent re-enqueueing during recovery
+          onError: (err) => {
+            sawPayloadFailure = true;
+            firstPayloadError ??= describeDeliveryError(err);
+          },
+        });
+        if (sawPayloadFailure) {
+          // Route it exactly as a thrown failure would be: what already landed
+          // decides between "retry it whole" and "a human has to reconcile it".
+          const landed = Array.isArray(sent) ? sent.length : 0;
+          throw annotateDeliveredBeforeFailure(
+            new Error(
+              `bestEffort delivery reported a per-payload failure: ${firstPayloadError ?? "unknown error"}`,
+            ),
+            landed,
+          );
+        }
+        await ackDelivery(current.id, opts.stateDir);
+        summary.recovered += 1;
+        opts.log.info(`Recovered delivery ${current.id} to ${current.channel}:${current.to}`);
+      } catch (err) {
+        const errMsg = describeDeliveryError(err);
+        // Recovery's own retry can land some payloads and then fail, exactly as
+        // the live send path can. Clearing the marker here regardless would
+        // re-arm a replay of the payloads that already arrived — the same
+        // duplicate this function exists to prevent, one restart later.
+        // An unreported count means the DeliverFn is not the outbound sender
+        // and cannot tell us; treat that as the historical "replay whole".
+        const landedBeforeFailure = readDeliveredBeforeFailure(err) ?? 0;
+
+        // Checked BEFORE the permanent-error branch on purpose. "Permanent"
+        // answers whether retrying can ever work; it does not answer whether
+        // part of this message is already on the recipient's device. A chunked
+        // send whose later chunk hits `chat not found` has both properties, and
+        // filing it under failed/ ("never arrived") would be a lie.
+        if (landedBeforeFailure > 0) {
+          try {
+            await failPartialDelivery(current.id, errMsg, opts.stateDir, landedBeforeFailure);
+          } catch {
+            // Best-effort update.
+          }
+          summary.failed += 1;
+          opts.log.warn(
+            `Retry for delivery ${current.id} failed after ${landedBeforeFailure} payload(s) had already been sent — it will be quarantined rather than replayed: ${errMsg}`,
+          );
+          return;
+        }
+
+        if (isPermanentDeliveryError(errMsg)) {
+          opts.log.warn(
+            `Delivery ${current.id} hit permanent error — moving to failed/: ${errMsg}`,
+          );
+          try {
+            // Clear the in-flight marker first: a permanent error means the send
+            // definitively did not land, and an operator triaging failed/ should
+            // not read a stale "send may have landed" stamp.
+            await clearDeliveryAttemptMarker(current.id, opts.stateDir).catch(() => {});
+            await moveToFailed(current.id, opts.stateDir);
+          } catch (moveErr) {
+            opts.log.error(`Failed to move entry ${current.id} to failed/: ${String(moveErr)}`);
+          }
+          summary.failed += 1;
+          return;
+        }
+
+        try {
+          await failDelivery(current.id, errMsg, opts.stateDir);
+        } catch {
+          // Best-effort update.
+        }
+        summary.failed += 1;
+        opts.log.warn(`Retry failed for delivery ${current.id}: ${errMsg}`);
+      }
+    });
+    if (claim.status === "claimed-by-other-owner") {
+      summary.skippedClaimed += 1;
+      opts.log.info(`Delivery ${entry.id} is already being delivered by another worker — skipping`);
     }
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.deferredBackoff} deferred (backoff), ${summary.needsReview} quarantined (unknown send outcome), ${summary.quarantineFailed} stuck (quarantine failed), ${summary.skippedClaimed} skipped (claimed), ${summary.awaitingReviewAtStart + summary.needsReview} awaiting manual reconciliation`,
   );
-  return { recovered, failed, skippedMaxRetries, deferredBackoff };
+  return summary;
 }
 
 export { MAX_RETRIES };


### PR DESCRIPTION
Closes #2934.

## The bug

The write-ahead delivery queue persists an entry before sending and removes it after the ack. A crash **between the platform send and the ack** left the entry pending, and `recoverPendingDeliveries` blind-replayed it on the next startup — the recipient got the message twice.

## The fix

Ported into the fork's monolithic `delivery-queue.ts` per the issue's "Porting guidance (fork-specific)". Upstream's `delivery-queue-storage.ts` / `delivery-queue-recovery.ts` split is **not** adopted — it pulls an `fs-safe/store` module this fork does not have.

Three pieces:

1. **A persisted pre-send marker.** `markDeliveryAttemptStarted` stamps `recoveryState: "send_attempt_started"` + `platformSendStartedAt` on the entry *before* the platform send. A send that lands part of its payloads and then fails converts it to `unknown_after_send`.
2. **Recovery refuses to replay an unknown outcome.** An entry carrying either marker is never re-sent; it is quarantined to `delivery-queue/needs-review/` with an actionable operator log. For a messaging product, a message that silently needs a human beats a message the recipient receives twice.
3. **A single-owner claim guard.** `withActiveDeliveryClaim` wraps the *whole* per-entry decision — modelled on the fork's own `session-delivery-queue-recovery.ts` `entriesInProgress` set. It is what separates "a live worker is sending this right now" from "orphaned by a crash": without it, recovery would quarantine sends still in flight. Recovery also **re-reads the entry under the claim** — the pre-claim scan snapshot is a hypothesis, disk is the evidence.

Both the live path and recovery's own retry route on **how many payloads landed**: nothing landed → retry whole; something landed → quarantine. The count travels on the error itself (`delivered-before-failure.ts`) so recovery — which sends with `skipQueue` and owns its own bookkeeping — can read it back.

### Also fixed, same failure class

Surfaced by adversarial review of the applied diff:

- A `bestEffort` send whose payloads **all** failed was acked when the caller passed no `onError`, silently dropping the message. Whether a send failed is a property of the send, not of the caller's callback wiring. Affects `server-node-events.ts`, `server-restart-sentinel.ts`, `commands/message.ts`.
- A transport error merely **named** `AbortError` was acked and erased — no retry, no `failed/`, no `needs-review/`. `blueBubblesFetchWithTimeout` raises exactly this on a client-side timeout, which is an unknown send outcome, not a cancellation. Only a genuinely caller-cancelled send with nothing landed is a clean discard now.
- A partly-delivered entry hitting a *permanent* error was filed under `failed/` ("never arrived"). "Permanent" answers whether retrying can work, not whether part of the message is already on the recipient's device — landed-count now outranks that branch.
- Quarantined mail was invisible after the one startup that created it. Every pass now reports the standing `needs-review/` backlog (`awaitingReviewAtStart`).
- `needs-review/` is exempted from the backup volatile filter: quarantined entries are terminal, unique, and the only record that a message's outcome is undetermined — losing them on a restore loses the operator's to-do list with no trace it existed.

### Partial-sync residue

`deliver.test.ts` mocked `withActiveDeliveryClaim`, a symbol **no fork source defined**. Reconciled by implementing the guard it was mocking, and the mock factory now supplies exactly the symbols `deliver.ts` imports.

## Verification

| Gate | Result |
|---|---|
| `pnpm check` (format + tsgo + lint + fork lints) | EXIT=0 |
| unit lane | 1038 files, **10024 passed** / 42 skipped |
| gateway lane | 185 files, **1960 passed** / 3 skipped |
| auto-reply lane | 57 files, **652 passed** |
| fork-integrity gates (zombie-import, stub-debt, throwing-stub-callers, attestations, obsolescence, policy-doctor) | all EXIT=0 |

**Adversarial validation**: four independent fresh-context review rounds against the applied diff. Rounds 1–3 each found a real blocking defect (recovery deciding from a stale scan snapshot; the live path clearing the marker after a partially-landed chunked send; recovery's own retry doing the same). Round 4 found **no blocking defect**; its should-fix findings are the "also fixed" list above. A fresh-context polish pass followed.

**Mutation-tested**: 11 targeted mutants covering every new guard — in both the over-quarantine and under-quarantine directions — **all killed, no survivors**.

## Deferred

Full per-adapter `reconcileUnknownSend` parity remains a stretch goal per the issue, to be filed as a follow-up.

Two items intentionally left for a follow-up rather than done here:

- Extracting recovery's ~52-line catch block into a `recordRetryFailure` helper (polish review's largest suggestion). It is a pure code move through the exact branch logic that was just adversarially validated — cheap to do separately, not worth disturbing at PR time.
- `failDelivery`'s documented residual: a request that times out *after* hitting the wire produces no result object, so it is recorded as "nothing landed" and replayed. Closing that needs transport-level error classification and is explicitly out of scope for #2934. Documented in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
