### PR TITLE
fix(auto-reply): align typing-indicator TTL with agent runtime timeout

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -98,6 +98,10 @@ export async function getReplyFromConfig(
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     typingIntervalSeconds,
+    // Align the typing-indicator TTL with the agent runtime timeout so long/quiet
+    // runs (long tool calls, thinking) don't stop typing mid-execution; the real
+    // stop is the run's markRunComplete/markDispatchIdle, the TTL is the backstop.
+    typingTtlMs: timeoutMs,
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
   });


### PR DESCRIPTION
## Problem

The typing keepalive had a flat 2-minute TTL, refreshed only by streamed text / tool
results — not by tool starts, thinking, or any other liveness signal. A legitimately
executing but *quiet* run (one long tool call, a long thinking phase) would trip the TTL
and stop the "typing…" indicator mid-execution, and the sealed controller never restarted
it for the rest of the run.

## Fix

Wire `typingTtlMs` to the already-resolved agent runtime timeout (`timeoutMs`, already in
scope at the call site) instead of leaving it on the hardcoded default, so the indicator
stays alive as long as the run may actually execute.

The real stop remains the run's `finally` → `markRunComplete` / `markDispatchIdle`; the TTL
is now a backstop aligned with how long the runtime is allowed to run, rather than an
independent shorter clock that fires first.

```diff
     typingIntervalSeconds,
+    // Align the typing-indicator TTL with the agent runtime timeout so long/quiet
+    // runs (long tool calls, thinking) don't stop typing mid-execution; the real
+    // stop is the run's markRunComplete/markDispatchIdle, the TTL is the backstop.
+    typingTtlMs: timeoutMs,
     silentToken: SILENT_REPLY_TOKEN,
```

+4 lines in `src/auto-reply/reply/get-reply.ts` (1 code + 3 comment).

## Verification

Re-run on the current base after rebase:

| Gate | Result |
|---|---|
| `pnpm tsgo` | exit 0 |
| `reply-utils` + `typing-persistence` + `typing-policy` (auto-reply lane) | 3 files, 42/42 passed |
| `pnpm check` (format, lint, css-drift, lobster-leak, clawd-discord, models-write, .ai TLD) | exit 0 |
| rebrand-gate | no leakage |
| zombie-import-gate | clean |
| stub-debt-gate | exit 0 |
| throwing-stub-callers-gate | 0 violations |
| obsolescence-audit-gate | 47 == baseline |
| attestations | 172 modules, 516 attestations |

`LIVE=1 pnpm test:live` not run — the project's LIVE smoke directive is scoped to
`src/middleware/`, and this change is in `src/auto-reply/`, so it is advisory here.

## Provenance

Originally committed 2026-07-15 on an isolated worktree branch and held unpushed pending a
delivery decision. Rebased from base `ce00e92c65c` onto current `main` — `get-reply.ts` was
byte-identical between the two, so the rebase was conflict-free and the diff is unchanged.