### PR TITLE
feat(clickclack): adopt self-hosted-chat channel adapter (#2861)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -248,6 +248,7 @@ export default defineConfig({
                 { slug: "channels/feishu" },
                 { slug: "channels/googlechat" },
                 { slug: "channels/mattermost" },
+                { slug: "channels/clickclack" },
                 { slug: "channels/signal" },
                 { slug: "channels/imessage" },
                 { slug: "channels/bluebubbles" },

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -1,0 +1,170 @@
+---
+summary: "ClickClack bot-token channel setup and target syntax"
+read_when:
+  - Connecting RemoteClaw to a ClickClack workspace
+  - Testing ClickClack bot identities
+title: "ClickClack"
+sidebarTitle: "ClickClack"
+---
+
+ClickClack connects RemoteClaw to a self-hosted ClickClack workspace through first-class ClickClack bot tokens.
+
+Use this when you want a RemoteClaw agent to appear as a ClickClack bot user. ClickClack supports independent service bots and user-owned bots; user-owned bots keep an `owner_user_id` and receive only the token scopes you grant.
+
+## Quick setup
+
+Create a bot token in ClickClack:
+
+```bash
+clickclack admin bot create \
+  --workspace <workspace_id_or_slug> \
+  --name "RemoteClaw" \
+  --handle remoteclaw \
+  --scopes bot:write \
+  --plain
+```
+
+For a user-owned bot, add `--owner <user_id>`.
+
+Configure RemoteClaw:
+
+```json5
+{
+  channels: {
+    clickclack: {
+      enabled: true,
+      baseUrl: "https://app.clickclack.example",
+      token: { source: "env", provider: "default", id: "CLICKCLACK_BOT_TOKEN" },
+      workspace: "default",
+      defaultTo: "channel:general",
+      allowFrom: ["usr_your_user_id"],
+      agentId: "clickclack-bot",
+    },
+  },
+}
+```
+
+Then run:
+
+```bash
+export CLICKCLACK_BOT_TOKEN="ccb_..."
+remoteclaw gateway
+```
+
+If `plugins.allow` is a non-empty restrictive list, explicitly selecting
+ClickClack in channel setup or running `remoteclaw plugins enable clickclack`
+appends `clickclack` to that list. Onboarding installation uses the same
+explicit-selection behavior. These paths do not override `plugins.deny` or a
+global `plugins.enabled: false` setting. Direct `remoteclaw plugins install
+clickclack` follows the normal plugin-install policy and also records ClickClack
+in an existing allowlist.
+
+## Access control
+
+ClickClack admission is **allowlist-only**, in direct conversations and in
+channels alike. `allowFrom` is the allowlist; a sender that does not match it is
+dropped before the message reaches the agent pipeline. There is no open-policy
+mode for this channel — the adapter pins its DM and group policies rather than
+reading them from config.
+
+Allowlist entries may be written as a bare user id or with a provider/DM prefix;
+all four forms below resolve to the same user:
+
+```json5
+allowFrom: ["usr_123", "clickclack:usr_123", "cc:usr_123", "dm:usr_123"]
+```
+
+Use `["*"]` to admit every workspace member. Command authorization is evaluated
+only for senders that were already admitted — it never widens admission.
+
+## Multiple bots
+
+Each account opens its own ClickClack realtime connection and uses its own bot token.
+
+```json5
+{
+  channels: {
+    clickclack: {
+      enabled: true,
+      baseUrl: "https://app.clickclack.example",
+      defaultAccount: "service",
+      accounts: {
+        service: {
+          token: { source: "env", provider: "default", id: "CLICKCLACK_SERVICE_BOT_TOKEN" },
+          workspace: "default",
+          defaultTo: "channel:general",
+          allowFrom: ["usr_your_user_id"],
+          agentId: "service-bot",
+        },
+        support: {
+          token: { source: "env", provider: "default", id: "CLICKCLACK_SUPPORT_BOT_TOKEN" },
+          workspace: "default",
+          defaultTo: "dm:usr_...",
+          allowFrom: ["usr_your_user_id"],
+          agentId: "support-bot",
+        },
+      },
+    },
+  },
+}
+```
+
+## Reply timeout
+
+`timeoutSeconds` bounds how long a single agent turn may run before the reply is
+given up on. It is optional; omit it to use the global reply timeout.
+
+```json5
+{
+  channels: {
+    clickclack: {
+      timeoutSeconds: 180,
+    },
+  },
+}
+```
+
+Every reply routes through the standard RemoteClaw agent pipeline. Upstream
+OpenClaw additionally offered a `replyMode: "model"` shortcut that ran short
+completions in-process; RemoteClaw does not ship an in-process model surface
+(CLI runtimes own model execution), so that mode and its `model` /
+`systemPrompt` settings are not part of this channel.
+
+## Targets
+
+- `channel:<name-or-id>` sends to a workspace channel. Bare targets default to `channel:`.
+- `dm:<user_id>` creates or reuses a direct conversation with that user.
+- `thread:<message_id>` replies in an existing thread.
+
+Examples:
+
+```bash
+remoteclaw message send --channel clickclack --target channel:general --message "hello"
+remoteclaw message send --channel clickclack --target dm:usr_123 --message "hello"
+remoteclaw message send --channel clickclack --target thread:msg_123 --message "following up"
+```
+
+## Permissions
+
+ClickClack token scopes are enforced by the ClickClack API.
+
+- `bot:read`: read workspace/channel/message/thread/DM/realtime/profile data.
+- `bot:write`: `bot:read` plus channel messages, thread replies, DMs, and uploads.
+- `bot:admin`: `bot:write` plus channel creation.
+
+RemoteClaw only needs `bot:write` for normal agent chat.
+
+## Network posture
+
+The ClickClack client talks directly to the configured `baseUrl` over HTTP and a
+realtime WebSocket. `baseUrl` is operator-supplied local configuration, never a
+value taken from inbound traffic, so requests are not routed through
+RemoteClaw's SSRF dispatcher. Point `baseUrl` only at a ClickClack deployment
+you control.
+
+## Troubleshooting
+
+- `ClickClack is not configured`: set `channels.clickclack.token` or `CLICKCLACK_BOT_TOKEN`.
+- `workspace not found`: set `workspace` to the workspace id or slug returned by ClickClack.
+- No inbound replies: confirm the sender is in `allowFrom`, the token has realtime read access, and the bot is not replying to its own messages.
+- Channel sends fail: verify the bot is a member of the workspace and has `bot:write`.

--- a/docs/plugins/reference/clickclack.md
+++ b/docs/plugins/reference/clickclack.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds the ClickClack channel surface for sending and receiving RemoteClaw messages."
+read_when:
+  - You are installing, configuring, or auditing the clickclack plugin
+title: "ClickClack plugin"
+---
+
+# ClickClack plugin
+
+Adds the ClickClack channel surface for sending and receiving RemoteClaw messages.
+
+## Distribution
+
+- Package: `@remoteclaw/clickclack`
+- Install route: included in RemoteClaw
+
+## Surface
+
+channels: clickclack
+
+## Related docs
+
+- [clickclack](/channels/clickclack)

--- a/extensions/clickclack/api.ts
+++ b/extensions/clickclack/api.ts
@@ -1,0 +1,24 @@
+/**
+ * Public ClickClack runtime API barrel used by plugin tests, docs, and
+ * integration code that should not reach into src internals.
+ */
+export {
+  DEFAULT_ACCOUNT_ID,
+  listClickClackAccountIds,
+  listEnabledClickClackAccounts,
+  resolveClickClackAccount,
+  resolveDefaultClickClackAccountId,
+} from "./src/accounts.js";
+export { clickClackPlugin } from "./src/channel.js";
+export { clickClackConfigSchema } from "./src/config-schema.js";
+export { createClickClackClient } from "./src/http-client.js";
+export { getClickClackRuntime, setClickClackRuntime } from "./src/runtime.js";
+export { buildClickClackTarget, parseClickClackTarget } from "./src/target.js";
+export type {
+  ClickClackAccountConfig,
+  ClickClackEvent,
+  ClickClackMessage,
+  ClickClackTarget,
+  CoreConfig,
+  ResolvedClickClackAccount,
+} from "./src/types.js";

--- a/extensions/clickclack/channel-plugin-api.ts
+++ b/extensions/clickclack/channel-plugin-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled channel entry imports narrow so bootstrap/discovery paths do not
+// drag ClickClack runtime/send/gateway surfaces into lightweight plugin loads.
+export { clickClackPlugin } from "./src/channel.js";

--- a/extensions/clickclack/index.ts
+++ b/extensions/clickclack/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Bundled channel entry for the ClickClack plugin.
+ *
+ * The fork registers bundled channel plugins through the plugin API's
+ * `registerChannel` hook (see extensions/mattermost, extensions/matrix) rather
+ * than upstream's `defineBundledChannelEntry` contract, which this repo's
+ * plugin-sdk does not ship.
+ */
+import type { RemoteClawPluginApi } from "remoteclaw/plugin-sdk/clickclack";
+import { emptyPluginConfigSchema } from "remoteclaw/plugin-sdk/clickclack";
+import { clickClackPlugin } from "./src/channel.js";
+import { setClickClackRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "clickclack",
+  name: "ClickClack",
+  description: "ClickClack channel plugin",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: RemoteClawPluginApi) {
+    setClickClackRuntime(api.runtime);
+    api.registerChannel({ plugin: clickClackPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@remoteclaw/clickclack",
+  "version": "0.8.0",
+  "description": "RemoteClaw ClickClack channel plugin",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts",
+    "./api.js": "./api.ts",
+    "./runtime-api.js": "./runtime-api.ts"
+  },
+  "dependencies": {
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
+  },
+  "remoteclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "clickclack",
+      "label": "ClickClack",
+      "selectionLabel": "ClickClack (plugin)",
+      "detailLabel": "ClickClack Bot",
+      "docsPath": "/channels/clickclack",
+      "docsLabel": "clickclack",
+      "blurb": "self-hosted chat via first-class ClickClack bot tokens.",
+      "systemImage": "bubble.left.and.bubble.right",
+      "markdownCapable": true,
+      "preferSessionLookupForAnnounceTarget": true,
+      "order": 85
+    },
+    "install": {
+      "npmSpec": "@remoteclaw/clickclack",
+      "localPath": "extensions/clickclack",
+      "defaultChoice": "npm"
+    }
+  }
+}

--- a/extensions/clickclack/remoteclaw.plugin.json
+++ b/extensions/clickclack/remoteclaw.plugin.json
@@ -1,0 +1,15 @@
+{
+  "id": "clickclack",
+  "activation": {
+    "onStartup": false
+  },
+  "channels": ["clickclack"],
+  "channelEnvVars": {
+    "clickclack": ["CLICKCLACK_BOT_TOKEN"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/clickclack/runtime-api.ts
+++ b/extensions/clickclack/runtime-api.ts
@@ -1,0 +1,4 @@
+// Keep the bundled runtime entry narrow so generic runtime activation does not
+// import the broad ClickClack API barrel (and transitively `ws`) just to install
+// runtime state.
+export { setClickClackRuntime } from "./src/runtime.js";

--- a/extensions/clickclack/src/access.test.ts
+++ b/extensions/clickclack/src/access.test.ts
@@ -1,0 +1,317 @@
+// Clickclack tests cover the ingress admission contract this adapter must keep.
+//
+// These are the two conformance points #2861 calls out for the channel-ingress
+// surface, asserted against the REAL `resolveStableChannelMessageIngress` gate
+// (nothing in the message-access path is mocked here):
+//
+//  1. The DM/group admission policies are hardcoded to `"allowlist"`. An
+//     unlisted sender is refused in direct conversations AND in channels, and
+//     open-policy config on the channel section must not widen that.
+//  2. `shouldDispatch` derives from `ingress.admission === "dispatch"`, and
+//     admission is decided ahead of command authorization — a refused sender
+//     never becomes dispatchable by virtue of the command gate.
+import {
+  type PluginRuntime,
+  resolveStableChannelMessageIngress,
+} from "remoteclaw/plugin-sdk/clickclack";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../test-utils/plugin-runtime-mock.js";
+import { resolveClickClackInboundAccess } from "./access.js";
+import { setClickClackRuntime } from "./runtime.js";
+import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+// Spy on the ingress gate WITHOUT replacing it: every test in this file still
+// exercises the real `resolveStableChannelMessageIngress`. The spy exists so the
+// policy literals the adapter passes can be asserted at the seam, not only
+// through their outcome — see the "pins the policy literals" test below for why
+// outcome-only assertions are not enough for the DM half.
+vi.mock("remoteclaw/plugin-sdk/clickclack", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("remoteclaw/plugin-sdk/clickclack")>();
+  return {
+    ...actual,
+    resolveStableChannelMessageIngress: vi.fn(actual.resolveStableChannelMessageIngress),
+  };
+});
+
+function createRuntime(params: { commandRequested: boolean }): PluginRuntime {
+  const runtime = createPluginRuntimeMock() as PluginRuntime;
+  vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(
+    params.commandRequested,
+  );
+  return runtime;
+}
+
+function createAccount(
+  overrides: Partial<ResolvedClickClackAccount> = {},
+): ResolvedClickClackAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    baseUrl: "http://127.0.0.1:8080",
+    token: "ccb_default",
+    workspace: "wsp_1",
+    defaultTo: "channel:general",
+    allowFrom: ["usr_owner"],
+    reconnectMs: 1_500,
+    config: { allowFrom: ["usr_owner"] },
+    ...overrides,
+  };
+}
+
+function groupMessage(authorId: string): ClickClackMessage {
+  return {
+    id: "msg_1",
+    workspace_id: "wsp_1",
+    channel_id: "chn_1",
+    author_id: authorId,
+    thread_root_id: "msg_1",
+    body: "/fast on",
+    body_format: "markdown",
+    created_at: "2026-05-09T12:00:00.000Z",
+  };
+}
+
+function directMessage(authorId: string): ClickClackMessage {
+  return {
+    id: "msg_2",
+    workspace_id: "wsp_1",
+    direct_conversation_id: "dcn_1",
+    author_id: authorId,
+    thread_root_id: "msg_2",
+    body: "/fast on",
+    body_format: "markdown",
+    created_at: "2026-05-09T12:00:00.000Z",
+  };
+}
+
+const bareConfig = {} satisfies CoreConfig;
+
+describe("ClickClack ingress admission (hardcoded allowlist policy)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("admits an allowlisted sender in a channel", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+
+    const access = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_owner"),
+    });
+
+    expect(access.shouldDispatch).toBe(true);
+  });
+
+  it("admits an allowlisted sender in a direct conversation", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+
+    const access = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: directMessage("usr_owner"),
+    });
+
+    expect(access.shouldDispatch).toBe(true);
+  });
+
+  it("refuses an unlisted sender in a channel (groupPolicy stays allowlist)", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+
+    const access = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_attacker"),
+    });
+
+    expect(access.shouldDispatch).toBe(false);
+  });
+
+  it("refuses an unlisted sender in a direct conversation (dmPolicy stays allowlist)", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+
+    const access = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: directMessage("usr_attacker"),
+    });
+
+    expect(access.shouldDispatch).toBe(false);
+  });
+
+  it("does not let open dm/group policy config widen the hardcoded allowlist", async () => {
+    // The adapter passes literal `dmPolicy: "allowlist"` / `groupPolicy: "allowlist"`
+    // rather than reading them from config, so an operator (or a config-write
+    // path) cannot flip this channel to an open admission policy.
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+    const openConfig = {
+      channels: {
+        clickclack: {
+          dmPolicy: "open",
+          groupPolicy: "open",
+        },
+      },
+    } as unknown as CoreConfig;
+
+    const direct = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: openConfig,
+      message: directMessage("usr_attacker"),
+    });
+    const group = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: openConfig,
+      message: groupMessage("usr_attacker"),
+    });
+
+    expect(direct.shouldDispatch).toBe(false);
+    expect(group.shouldDispatch).toBe(false);
+  });
+
+  it("pins the policy literals handed to the ingress gate, not just their outcome", async () => {
+    // Outcome-only assertions do NOT discriminate the DM half of conformance
+    // point 1: absent a pairing store, `dmPolicy: "open"` and `"pairing"` both
+    // produce the same allow/refuse results as `"allowlist"` for these inputs,
+    // so a widening mutation would slip through green. Assert the literals the
+    // adapter actually hands the gate instead — that fails on any widening.
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+    const spy = vi.mocked(resolveStableChannelMessageIngress);
+
+    await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: directMessage("usr_owner"),
+    });
+    await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_owner"),
+    });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    for (const [params] of spy.mock.calls) {
+      expect(params.dmPolicy).toBe("allowlist");
+      expect(params.groupPolicy).toBe("allowlist");
+    }
+  });
+
+  it("records the allowlist policy on the resolved sender gate for both kinds", async () => {
+    // Second, independent read of the same invariant: the gate graph the engine
+    // produced must report `sender.policy === "allowlist"`. This catches a
+    // widening that happened INSIDE the gate rather than at the call site.
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+    const spy = vi.mocked(resolveStableChannelMessageIngress);
+
+    for (const message of [directMessage("usr_owner"), groupMessage("usr_owner")]) {
+      await resolveClickClackInboundAccess({
+        account: createAccount(),
+        config: bareConfig,
+        message,
+      });
+      const resolved = await spy.mock.results.at(-1)?.value;
+      const senderGates = resolved.ingress.graph.gates.filter(
+        (gate: { sender?: { policy?: string } }) => gate.sender,
+      );
+      expect(senderGates.length).toBeGreaterThan(0);
+      for (const gate of senderGates) {
+        expect(gate.sender.policy).toBe("allowlist");
+      }
+    }
+  });
+
+  it("keeps a wildcard allowFrom entry working for both conversation kinds", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+    const account = createAccount({ allowFrom: ["*"], config: { allowFrom: ["*"] } });
+
+    const direct = await resolveClickClackInboundAccess({
+      account,
+      config: bareConfig,
+      message: directMessage("usr_anyone"),
+    });
+    const group = await resolveClickClackInboundAccess({
+      account,
+      config: bareConfig,
+      message: groupMessage("usr_anyone"),
+    });
+
+    expect(direct.shouldDispatch).toBe(true);
+    expect(group.shouldDispatch).toBe(true);
+  });
+});
+
+describe("ClickClack ingress admission ordering vs command authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuses dispatch for an unlisted sender even when a command gate is requested", async () => {
+    // Admission is resolved from `ingress.admission`, independently of the
+    // command gate: requesting command authorization must not become a second
+    // path into the pipeline for a sender the allowlist already refused.
+    setClickClackRuntime(createRuntime({ commandRequested: true }));
+
+    const access = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_attacker"),
+    });
+
+    expect(access.shouldDispatch).toBe(false);
+    expect(access.commandAuthorized).toBe(false);
+  });
+
+  it("authorizes commands for an allowlisted sender once admitted", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: true }));
+
+    const access = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_owner"),
+    });
+
+    expect(access.shouldDispatch).toBe(true);
+    expect(access.commandAuthorized).toBe(true);
+  });
+
+  it("falls back to sender access for commandAuthorized when no command gate is requested", async () => {
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+
+    const allowed = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_owner"),
+    });
+    const refused = await resolveClickClackInboundAccess({
+      account: createAccount(),
+      config: bareConfig,
+      message: groupMessage("usr_attacker"),
+    });
+
+    expect(allowed.commandAuthorized).toBe(true);
+    expect(refused.commandAuthorized).toBe(false);
+  });
+
+  it("normalizes provider-prefixed and dm-prefixed allowlist entries to the same user id", async () => {
+    // The identity normalizer strips `clickclack:` / `cc:` / `dm:` prefixes.
+    // A loose normalizer here would be an allowlist bypass vector, so pin the
+    // accepted spellings and confirm a near-miss is still refused.
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+
+    for (const entry of ["usr_owner", "clickclack:usr_owner", "cc:usr_owner", "dm:usr_owner"]) {
+      const access = await resolveClickClackInboundAccess({
+        account: createAccount({ allowFrom: [entry], config: { allowFrom: [entry] } }),
+        config: bareConfig,
+        message: directMessage("usr_owner"),
+      });
+      expect(access.shouldDispatch, `entry ${entry} should admit usr_owner`).toBe(true);
+    }
+
+    const nearMiss = await resolveClickClackInboundAccess({
+      account: createAccount({ allowFrom: ["usr_owner2"], config: { allowFrom: ["usr_owner2"] } }),
+      config: bareConfig,
+      message: directMessage("usr_owner"),
+    });
+    expect(nearMiss.shouldDispatch).toBe(false);
+  });
+});

--- a/extensions/clickclack/src/access.ts
+++ b/extensions/clickclack/src/access.ts
@@ -1,0 +1,94 @@
+/**
+ * Maps ClickClack senders and conversations onto the shared channel ingress
+ * allowlist/command authorization contract.
+ */
+import {
+  resolveStableChannelMessageIngress,
+  type RemoteClawConfig,
+  type StableChannelIngressIdentityParams,
+} from "remoteclaw/plugin-sdk/clickclack";
+import { getClickClackRuntime } from "./runtime.js";
+import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const CHANNEL_ID = "clickclack" as const;
+
+function normalizeClickClackUserId(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withoutProvider = trimmed.replace(/^(clickclack|cc):/i, "").trim();
+  const directTarget = withoutProvider.match(/^dm:(.+)$/i);
+  return directTarget?.[1]?.trim() || withoutProvider || null;
+}
+
+const clickClackIngressIdentity = {
+  key: "user-id",
+  normalizeEntry: normalizeClickClackUserId,
+  normalizeSubject: normalizeClickClackUserId,
+  isWildcardEntry: (entry) => normalizeClickClackUserId(entry) === "*",
+  entryIdPrefix: "clickclack-user",
+} satisfies StableChannelIngressIdentityParams;
+
+/**
+ * Dispatch and command authorization decision for one inbound ClickClack
+ * message.
+ */
+export type ClickClackInboundAccess = {
+  shouldDispatch: boolean;
+  commandAuthorized: boolean;
+};
+
+/**
+ * Resolves whether a ClickClack message should enter the agent pipeline and
+ * whether its command-style body may run tools.
+ *
+ * Both `dmPolicy` and `groupPolicy` are hardcoded to `"allowlist"`: this
+ * adapter never widens admission to an open policy, so an unlisted sender is
+ * refused in DMs and in channels alike. Callers must honor `shouldDispatch`
+ * (derived from `ingress.admission === "dispatch"`) BEFORE acting on
+ * `commandAuthorized` — admission gates the pipeline, command authorization
+ * only gates tool use within an already-admitted turn.
+ */
+export async function resolveClickClackInboundAccess(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  message: ClickClackMessage;
+}): Promise<ClickClackInboundAccess> {
+  const runtime = getClickClackRuntime();
+  const isDirect = Boolean(params.message.direct_conversation_id);
+  const cfg = params.config as RemoteClawConfig;
+  const shouldCheckCommand = runtime.channel.commands.shouldComputeCommandAuthorized(
+    params.message.body,
+    cfg,
+  );
+  const resolved = await resolveStableChannelMessageIngress({
+    channelId: CHANNEL_ID,
+    accountId: params.account.accountId,
+    identity: clickClackIngressIdentity,
+    cfg,
+    subject: { stableId: params.message.author_id },
+    conversation: {
+      kind: isDirect ? "direct" : "group",
+      id: isDirect
+        ? (params.message.direct_conversation_id ?? params.message.author_id)
+        : (params.message.channel_id ?? params.message.thread_root_id),
+    },
+    allowFrom: params.account.allowFrom,
+    dmPolicy: "allowlist",
+    groupPolicy: "allowlist",
+    command: shouldCheckCommand
+      ? {
+          cfg,
+          modeWhenAccessGroupsOff: "configured",
+        }
+      : false,
+  });
+
+  return {
+    shouldDispatch: resolved.ingress.admission === "dispatch",
+    commandAuthorized: resolved.commandAccess.requested
+      ? resolved.commandAccess.authorized
+      : resolved.senderAccess.allowed,
+  };
+}

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -1,0 +1,180 @@
+// Clickclack tests cover accounts plugin behavior.
+import { describe, expect, it } from "vitest";
+import {
+  listClickClackAccountIds,
+  resolveClickClackAccount,
+  resolveDefaultClickClackAccountId,
+} from "./accounts.js";
+import type { CoreConfig } from "./types.js";
+
+describe("ClickClack account resolution", () => {
+  it("preserves top-level default account when named accounts are configured", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          token: "ccb_default",
+          accounts: {
+            work: { enabled: false },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(listClickClackAccountIds(cfg)).toEqual(["default", "work"]);
+    expect(resolveDefaultClickClackAccountId(cfg)).toBe("default");
+    expect(resolveClickClackAccount({ cfg }).token).toBe("ccb_default");
+  });
+
+  it("does not synthesize a partial top-level default account from inherited credentials", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          token: "ccb_shared",
+          accounts: {
+            work: {
+              baseUrl: "https://app.clickclack.chat",
+              workspace: "wsp_1",
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(listClickClackAccountIds(cfg)).toEqual(["work"]);
+    expect(resolveDefaultClickClackAccountId(cfg)).toBe("work");
+  });
+
+  it("does not synthesize a default account from blank top-level credentials", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_default",
+          token: "   ",
+          accounts: {
+            work: {
+              baseUrl: "https://app.clickclack.chat",
+              workspace: "wsp_1",
+              token: "ccb_work",
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(listClickClackAccountIds(cfg)).toEqual(["work"]);
+    expect(resolveDefaultClickClackAccountId(cfg)).toBe("work");
+  });
+
+  it("resolves env SecretRefs at runtime", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          accounts: {
+            service: {
+              token: { source: "env", provider: "default", id: "CLICKCLACK_SERVICE_TOKEN" },
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(
+      resolveClickClackAccount({
+        cfg,
+        accountId: "service",
+        env: { CLICKCLACK_SERVICE_TOKEN: "  ccb_live  " },
+      }),
+    ).toEqual({
+      allowFrom: ["*"],
+      accountId: "service",
+      baseUrl: "https://app.clickclack.chat",
+      config: {
+        allowFrom: ["*"],
+        baseUrl: "https://app.clickclack.chat",
+        enabled: true,
+        token: { source: "env", provider: "default", id: "CLICKCLACK_SERVICE_TOKEN" },
+        workspace: "wsp_1",
+      },
+      configured: true,
+      defaultTo: "channel:general",
+      enabled: true,
+      reconnectMs: 1_500,
+      token: "ccb_live",
+      workspace: "wsp_1",
+    });
+  });
+
+  it("resolves per-account agent routing overrides", () => {
+    // Upstream's equivalent case also carried `replyMode: "model"` / `model` /
+    // `toolsAllow`. This fork drops in-process model replies and per-account
+    // tool narrowing (no `runtime.llm` and no dispatch-level tools allowlist),
+    // so the surviving per-account policy is agent routing plus timeouts.
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          accounts: {
+            peter: {
+              token: "ccb_peter",
+              agentId: "peter-bot",
+              timeoutSeconds: 120,
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(resolveClickClackAccount({ cfg, accountId: "peter" })).toEqual({
+      allowFrom: ["*"],
+      accountId: "peter",
+      agentId: "peter-bot",
+      baseUrl: "https://app.clickclack.chat",
+      config: {
+        agentId: "peter-bot",
+        allowFrom: ["*"],
+        baseUrl: "https://app.clickclack.chat",
+        enabled: true,
+        timeoutSeconds: 120,
+        token: "ccb_peter",
+        workspace: "wsp_1",
+      },
+      configured: true,
+      defaultTo: "channel:general",
+      enabled: true,
+      reconnectMs: 1_500,
+      timeoutSeconds: 120,
+      token: "ccb_peter",
+      workspace: "wsp_1",
+    });
+  });
+
+  it("normalizes reconnect intervals to the public config bounds", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          token: "ccb_global",
+          workspace: "wsp_1",
+          reconnectMs: 1,
+          accounts: {
+            slow: {
+              reconnectMs: 1_000_000,
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(resolveClickClackAccount({ cfg }).reconnectMs).toBe(100);
+    expect(resolveClickClackAccount({ cfg, accountId: "slow" }).reconnectMs).toBe(60_000);
+  });
+});

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -1,0 +1,176 @@
+/**
+ * Resolves ClickClack account configuration from root channel config, named
+ * account overrides, and secret-provider references.
+ */
+import {
+  createAccountListHelpers,
+  DEFAULT_ACCOUNT_ID,
+  hasConfiguredAccountValue,
+  normalizeAccountId,
+  normalizeOptionalString,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+  resolveDefaultSecretProviderAlias,
+  resolveIntegerOption,
+  resolveMergedAccountConfig,
+  resolveSecretInputString,
+} from "remoteclaw/plugin-sdk/clickclack";
+import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const DEFAULT_RECONNECT_MS = 1_500;
+const MIN_RECONNECT_MS = 100;
+const MAX_RECONNECT_MS = 60_000;
+
+/**
+ * Narrow read of one `secrets.providers.*` entry. The fork's config types the
+ * provider map as `Record<string, unknown>`, so callers must project the two
+ * fields they actually gate on instead of reaching through `any`.
+ */
+type SecretProviderConfigShape = { source?: string; allowlist?: readonly string[] };
+
+function readSecretProviderConfig(
+  cfg: CoreConfig,
+  provider: string,
+): SecretProviderConfigShape | undefined {
+  const entry = cfg.secrets?.providers?.[provider];
+  return entry && typeof entry === "object" ? (entry as SecretProviderConfigShape) : undefined;
+}
+
+const {
+  listAccountIds: listClickClackAccountIds,
+  resolveDefaultAccountId: resolveDefaultClickClackAccountId,
+} = createAccountListHelpers("clickclack", {
+  normalizeAccountId,
+  hasImplicitDefaultAccount: (cfg) => {
+    const channel = (cfg as CoreConfig).channels?.clickclack;
+    return Boolean(
+      channel?.baseUrl?.trim() &&
+      hasConfiguredAccountValue(channel.token) &&
+      channel.workspace?.trim(),
+    );
+  },
+});
+
+export { DEFAULT_ACCOUNT_ID, listClickClackAccountIds, resolveDefaultClickClackAccountId };
+
+function resolveMergedClickClackAccountConfig(
+  cfg: CoreConfig,
+  accountId: string,
+): ClickClackAccountConfig {
+  return resolveMergedAccountConfig<ClickClackAccountConfig & Record<string, unknown>>({
+    channelConfig: cfg.channels?.clickclack as ClickClackAccountConfig | undefined,
+    accounts: cfg.channels?.clickclack?.accounts,
+    accountId,
+    omitKeys: ["defaultAccount"],
+    normalizeAccountId,
+  });
+}
+
+function resolveClickClackToken(params: {
+  cfg: CoreConfig;
+  value: unknown;
+  accountId: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const resolved = resolveSecretInputString({
+    value: params.value,
+    path:
+      params.accountId === DEFAULT_ACCOUNT_ID
+        ? "channels.clickclack.token"
+        : `channels.clickclack.accounts.${params.accountId}.token`,
+    defaults: params.cfg.secrets?.defaults,
+    mode: "inspect",
+  });
+  if (resolved.status !== "available") {
+    if (resolved.status === "configured_unavailable" && resolved.ref.source === "env") {
+      const providerConfig = readSecretProviderConfig(params.cfg, resolved.ref.provider);
+      if (providerConfig) {
+        if (providerConfig.source !== "env") {
+          throw new Error(
+            `Secret provider "${resolved.ref.provider}" has source "${providerConfig.source}" but ref requests "env".`,
+          );
+        }
+        if (providerConfig.allowlist && !providerConfig.allowlist.includes(resolved.ref.id)) {
+          throw new Error(
+            `Environment variable "${resolved.ref.id}" is not allowlisted in secrets.providers.${resolved.ref.provider}.allowlist.`,
+          );
+        }
+      } else if (
+        resolved.ref.provider !==
+        // Only `secrets.defaults` is consulted here (the provider map is used
+        // solely by the `preferFirstProviderForSource` option, which is off).
+        resolveDefaultSecretProviderAlias(
+          { secrets: { defaults: params.cfg.secrets?.defaults } },
+          "env",
+        )
+      ) {
+        throw new Error(
+          `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
+        );
+      }
+      return normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "";
+    }
+    return "";
+  }
+  return (
+    normalizeResolvedSecretInputString({
+      value: resolved.value,
+      path: "channels.clickclack.token",
+    }) ?? ""
+  );
+}
+
+/**
+ * Builds the normalized account snapshot used by gateway, outbound delivery,
+ * status reporting, and channel routing.
+ */
+export function resolveClickClackAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+  env?: NodeJS.ProcessEnv;
+}): ResolvedClickClackAccount {
+  const accountId = normalizeAccountId(params.accountId);
+  const merged = resolveMergedClickClackAccountConfig(params.cfg, accountId);
+  const baseEnabled = params.cfg.channels?.clickclack?.enabled !== false;
+  const enabled = baseEnabled && merged.enabled !== false;
+  const baseUrl = merged.baseUrl?.trim().replace(/\/$/, "") ?? "";
+  const token = resolveClickClackToken({
+    cfg: params.cfg,
+    value: merged.token,
+    accountId,
+    env: params.env,
+  });
+  const workspace = merged.workspace?.trim() ?? "";
+  return {
+    accountId,
+    enabled,
+    configured: Boolean(baseUrl && token && workspace),
+    name: normalizeOptionalString(merged.name),
+    baseUrl,
+    token,
+    workspace,
+    botUserId: normalizeOptionalString(merged.botUserId),
+    agentId: normalizeOptionalString(merged.agentId),
+    timeoutSeconds: merged.timeoutSeconds,
+    defaultTo: merged.defaultTo?.trim() || "channel:general",
+    allowFrom: merged.allowFrom ?? ["*"],
+    reconnectMs: resolveIntegerOption(merged.reconnectMs, DEFAULT_RECONNECT_MS, {
+      min: MIN_RECONNECT_MS,
+      max: MAX_RECONNECT_MS,
+    }),
+    config: {
+      ...merged,
+      allowFrom: merged.allowFrom ?? ["*"],
+    },
+  };
+}
+
+/**
+ * Returns all enabled accounts, including the implicit default account when
+ * legacy top-level ClickClack config is present.
+ */
+export function listEnabledClickClackAccounts(cfg: CoreConfig): ResolvedClickClackAccount[] {
+  return listClickClackAccountIds(cfg)
+    .map((accountId) => resolveClickClackAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}

--- a/extensions/clickclack/src/channel.ts
+++ b/extensions/clickclack/src/channel.ts
@@ -1,0 +1,156 @@
+/**
+ * ClickClack channel plugin definition: target parsing, account config, status,
+ * gateway startup, and outbound delivery wiring.
+ */
+import {
+  buildChannelOutboundSessionRoute,
+  buildComputedAccountStatusSnapshot,
+  buildThreadAwareOutboundSessionRoute,
+  createChatChannelPlugin,
+  createDefaultChannelRuntimeState,
+  DEFAULT_ACCOUNT_ID,
+  type ChannelPlugin,
+} from "remoteclaw/plugin-sdk/clickclack";
+import {
+  listClickClackAccountIds,
+  resolveClickClackAccount,
+  resolveDefaultClickClackAccountId,
+} from "./accounts.js";
+import { clickClackConfigSchema } from "./config-schema.js";
+import { startClickClackGatewayAccount } from "./gateway.js";
+import { sendClickClackText } from "./outbound.js";
+import {
+  buildClickClackTarget,
+  looksLikeClickClackTarget,
+  normalizeClickClackTarget,
+  parseClickClackTarget,
+} from "./target.js";
+import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const CHANNEL_ID = "clickclack" as const;
+
+// Plugin-provided channels declare their own metadata inline (see
+// extensions/mattermost, extensions/matrix). The fork's `getChatChannelMeta`
+// is typed to the core `ChatChannelId` union, which covers only built-in
+// channels — widening it for a plugin channel is not the fork's convention.
+const meta = {
+  id: CHANNEL_ID,
+  label: "ClickClack",
+  selectionLabel: "ClickClack (plugin)",
+  detailLabel: "ClickClack Bot",
+  docsPath: "/channels/clickclack",
+  docsLabel: "clickclack",
+  blurb: "self-hosted chat via first-class ClickClack bot tokens.",
+  systemImage: "bubble.left.and.bubble.right",
+  order: 85,
+  quickstartAllowFrom: true,
+};
+
+/**
+ * Channel plugin instance registered by the bundled ClickClack entry.
+ */
+export const clickClackPlugin: ChannelPlugin<ResolvedClickClackAccount> = createChatChannelPlugin({
+  base: {
+    id: CHANNEL_ID,
+    meta,
+    capabilities: {
+      chatTypes: ["direct", "group"],
+      threads: true,
+      blockStreaming: true,
+    },
+    reload: { configPrefixes: ["channels.clickclack"] },
+    configSchema: clickClackConfigSchema,
+    config: {
+      listAccountIds: (cfg) => listClickClackAccountIds(cfg as CoreConfig),
+      resolveAccount: (cfg, accountId) =>
+        resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }),
+      defaultAccountId: (cfg) => resolveDefaultClickClackAccountId(cfg as CoreConfig),
+      isConfigured: (account) => account.configured,
+      resolveAllowFrom: ({ cfg, accountId }) =>
+        resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }).allowFrom,
+      resolveDefaultTo: ({ cfg, accountId }) =>
+        resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }).defaultTo,
+    },
+    // Upstream additionally declared `targetPrefixes`, `inferTargetChatType`,
+    // and `resolveSessionConversation` here. The fork's `ChannelMessagingAdapter`
+    // carries none of them and nothing in this repo reads them, so they are
+    // dropped rather than reintroduced as unconsumed surface — the same posture
+    // `plugin-sdk/channel-core.ts` documents for the factory carve.
+    messaging: {
+      normalizeTarget: normalizeClickClackTarget,
+      targetResolver: {
+        looksLikeId: looksLikeClickClackTarget,
+        hint: "<channel:name|dm:usr_id|thread:msg_id>",
+      },
+      resolveOutboundSessionRoute: ({
+        cfg,
+        agentId,
+        accountId,
+        target,
+        replyToId,
+        threadId,
+        currentSessionKey,
+      }) => {
+        const parsed = parseClickClackTarget(target);
+        const baseRoute = buildChannelOutboundSessionRoute({
+          cfg,
+          agentId,
+          channel: CHANNEL_ID,
+          accountId,
+          peer: {
+            kind: parsed.chatType === "direct" ? "direct" : "channel",
+            id: buildClickClackTarget(parsed),
+          },
+          chatType: parsed.chatType,
+          from: `clickclack:${accountId ?? DEFAULT_ACCOUNT_ID}`,
+          to: buildClickClackTarget(parsed),
+        });
+        return buildThreadAwareOutboundSessionRoute({
+          route: baseRoute,
+          replyToId,
+          threadId: threadId ?? (parsed.kind === "thread" ? parsed.id : undefined),
+          currentSessionKey,
+          canRecoverCurrentThread: () => true,
+        });
+      },
+    },
+    status: {
+      defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+      buildChannelSummary: ({ snapshot }) => ({
+        ok: Boolean(snapshot.configured),
+        label: snapshot.configured ? "configured" : "missing config",
+        detail: snapshot.baseUrl ?? "",
+      }),
+      buildAccountSnapshot: ({ account, runtime }) => ({
+        ...buildComputedAccountStatusSnapshot({
+          accountId: account.accountId,
+          name: account.name,
+          enabled: account.enabled,
+          configured: account.configured,
+          runtime,
+        }),
+        baseUrl: account.baseUrl,
+      }),
+    },
+    gateway: {
+      startAccount: startClickClackGatewayAccount,
+    },
+  },
+  outbound: {
+    base: {
+      deliveryMode: "direct",
+    },
+    attachedResults: {
+      channel: CHANNEL_ID,
+      sendText: async ({ cfg, to, text, accountId, threadId, replyToId }) =>
+        await sendClickClackText({
+          cfg: cfg as CoreConfig,
+          accountId,
+          to,
+          text,
+          threadId,
+          replyToId,
+        }),
+    },
+  },
+});

--- a/extensions/clickclack/src/config-schema.ts
+++ b/extensions/clickclack/src/config-schema.ts
@@ -1,0 +1,32 @@
+/**
+ * Zod-backed config schema for ClickClack channel accounts.
+ */
+import { buildChannelConfigSchema, buildSecretInputSchema } from "remoteclaw/plugin-sdk/clickclack";
+import { z } from "zod";
+
+const ClickClackAccountConfigSchema = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    baseUrl: z.string().url().optional(),
+    token: buildSecretInputSchema().optional(),
+    workspace: z.string().optional(),
+    botUserId: z.string().optional(),
+    agentId: z.string().optional(),
+    timeoutSeconds: z.number().int().min(1).max(3_600).optional(),
+    defaultTo: z.string().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    reconnectMs: z.number().int().min(100).max(60_000).optional(),
+  })
+  .strict();
+
+const ClickClackConfigSchema = ClickClackAccountConfigSchema.extend({
+  accounts: z.record(z.string(), ClickClackAccountConfigSchema.partial()).optional(),
+  defaultAccount: z.string().optional(),
+}).strict();
+
+/**
+ * Config schema exported to core so `remoteclaw doctor` and config validation
+ * understand both default and named ClickClack accounts.
+ */
+export const clickClackConfigSchema = buildChannelConfigSchema(ClickClackConfigSchema);

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -1,0 +1,231 @@
+// Clickclack tests cover gateway plugin behavior.
+import { EventEmitter } from "node:events";
+import type { ChannelGatewayContext } from "remoteclaw/plugin-sdk/clickclack";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedClickClackAccount } from "./types.js";
+
+class FakeSocket extends EventEmitter {
+  close = vi.fn(() => {
+    this.emit("close");
+  });
+}
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    me: vi.fn(),
+    events: vi.fn(),
+    websocket: vi.fn(),
+    channelMessages: vi.fn(),
+    directMessages: vi.fn(),
+    thread: vi.fn(),
+  },
+  handleClickClackInbound: vi.fn(),
+  resolveClickClackInboundAccess: vi.fn(),
+  resolveWorkspaceId: vi.fn(),
+}));
+
+vi.mock("./access.js", () => ({
+  resolveClickClackInboundAccess: mocks.resolveClickClackInboundAccess,
+}));
+
+vi.mock("./http-client.js", () => ({
+  createClickClackClient: vi.fn(() => mocks.client),
+}));
+
+vi.mock("./inbound.js", () => ({
+  handleClickClackInbound: mocks.handleClickClackInbound,
+}));
+
+vi.mock("./resolve.js", () => ({
+  resolveWorkspaceId: mocks.resolveWorkspaceId,
+}));
+
+import { startClickClackGatewayAccount } from "./gateway.js";
+
+function createGatewayContext(
+  abortSignal: AbortSignal,
+): ChannelGatewayContext<ResolvedClickClackAccount> {
+  const setStatus = vi.fn();
+  const log = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return {
+    cfg: {
+      channels: {
+        clickclack: {
+          baseUrl: "https://clickclack.example",
+          token: "test-token",
+          workspace: "main",
+          reconnectMs: 1,
+        },
+      },
+    } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"],
+    accountId: "default",
+    account: {} as ResolvedClickClackAccount,
+    runtime: {} as ChannelGatewayContext<ResolvedClickClackAccount>["runtime"],
+    abortSignal,
+    log,
+    getStatus: () =>
+      ({ accountId: "default" }) as ReturnType<
+        ChannelGatewayContext<ResolvedClickClackAccount>["getStatus"]
+      >,
+    setStatus,
+  };
+}
+
+describe("ClickClack gateway", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.me.mockResolvedValue({
+      id: "bot-user",
+      display_name: "Bot",
+      handle: "bot",
+      avatar_url: "",
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    mocks.client.events.mockResolvedValue([]);
+    mocks.resolveClickClackInboundAccess.mockResolvedValue({
+      shouldDispatch: true,
+      commandAuthorized: true,
+    });
+    mocks.resolveWorkspaceId.mockResolvedValue("workspace-1");
+    mocks.client.channelMessages.mockResolvedValue([
+      {
+        id: "msg-1",
+        workspace_id: "workspace-1",
+        channel_id: "chan-1",
+        author_id: "human-1",
+        thread_root_id: "msg-1",
+        body: "hello",
+        body_format: "markdown",
+        created_at: "2026-01-01T00:00:00.000Z",
+        author: {
+          id: "human-1",
+          kind: "human",
+          display_name: "Human",
+          handle: "human",
+          avatar_url: "",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    ]);
+  });
+
+  it("skips malformed websocket frames without stopping the monitor", async () => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    let runError: unknown;
+    const run = startClickClackGatewayAccount(ctx).catch((error: unknown) => {
+      runError = error;
+    });
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    socket.emit("message", Buffer.from("{not json"));
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(runError).toBeUndefined();
+    expect(ctx.log?.warn).toHaveBeenCalledWith(
+      "[default] skipped malformed ClickClack websocket event",
+    );
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          id: "evt-1",
+          cursor: "cursor-1",
+          type: "message.created",
+          workspace_id: "workspace-1",
+          channel_id: "chan-1",
+          seq: 2,
+          created_at: "2026-01-01T00:00:00.000Z",
+          payload: { message_id: "msg-1", author_id: "human-1" },
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
+    expect(mocks.handleClickClackInbound.mock.calls[0]?.[0].access).toEqual({
+      shouldDispatch: true,
+      commandAuthorized: true,
+    });
+    abort.abort();
+    await run;
+    expect(runError).toBeUndefined();
+  });
+
+  it("drops messages denied by ClickClack sender access before inbound handling", async () => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    mocks.resolveClickClackInboundAccess.mockResolvedValue({
+      shouldDispatch: false,
+      commandAuthorized: false,
+    });
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          id: "evt-1",
+          cursor: "cursor-1",
+          type: "message.created",
+          workspace_id: "workspace-1",
+          channel_id: "chan-1",
+          seq: 2,
+          created_at: "2026-01-01T00:00:00.000Z",
+          payload: { message_id: "msg-1", author_id: "human-1" },
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(mocks.resolveClickClackInboundAccess).toHaveBeenCalledTimes(1));
+    expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
+    abort.abort();
+    await run;
+  });
+
+  it("refuses to dispatch when admission is denied but the command would be authorized", async () => {
+    // Admission (`ingress.admission === "dispatch"`) gates the pipeline ahead of
+    // command authorization: a sender the ingress gate refuses must never reach
+    // the inbound handler even if the command gate would have said yes.
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    mocks.resolveClickClackInboundAccess.mockResolvedValue({
+      shouldDispatch: false,
+      commandAuthorized: true,
+    });
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          id: "evt-1",
+          cursor: "cursor-1",
+          type: "message.created",
+          workspace_id: "workspace-1",
+          channel_id: "chan-1",
+          seq: 2,
+          created_at: "2026-01-01T00:00:00.000Z",
+          payload: { message_id: "msg-1", author_id: "human-1" },
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(mocks.resolveClickClackInboundAccess).toHaveBeenCalledTimes(1));
+    expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
+    abort.abort();
+    await run;
+  });
+});

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -1,0 +1,214 @@
+/**
+ * Gateway loop for polling ClickClack backlog events, opening the realtime
+ * websocket, and dispatching user messages into RemoteClaw.
+ */
+import type { ChannelGatewayContext } from "remoteclaw/plugin-sdk/clickclack";
+import type { RawData } from "ws";
+import { resolveClickClackInboundAccess } from "./access.js";
+import { resolveClickClackAccount } from "./accounts.js";
+import { createClickClackClient } from "./http-client.js";
+import { handleClickClackInbound } from "./inbound.js";
+import { resolveWorkspaceId } from "./resolve.js";
+import type {
+  ClickClackEvent,
+  ClickClackMessage,
+  CoreConfig,
+  ResolvedClickClackAccount,
+} from "./types.js";
+
+/** ClickClack's `after_seq` cursor is exclusive, so step back one to include it. */
+const REFETCH_WINDOW_BEFORE = 1;
+/** Covers a same-tick burst without pulling unrelated history. */
+const REFETCH_WINDOW_SIZE = 10;
+
+function payloadString(event: ClickClackEvent, key: string): string {
+  const value = event.payload?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+async function resolveEventMessage(params: {
+  client: ReturnType<typeof createClickClackClient>;
+  event: ClickClackEvent;
+}): Promise<ClickClackMessage | null> {
+  const messageId = payloadString(params.event, "message_id");
+  if (!messageId) {
+    return null;
+  }
+  const directConversationId = payloadString(params.event, "direct_conversation_id");
+  if (directConversationId && typeof params.event.seq === "number") {
+    // ClickClack event payloads carry ids and cursors but not the message
+    // body/author, so refetch a narrow window around the sequence and keep the
+    // API's copy authoritative.
+    const messages = await params.client.directMessages(
+      directConversationId,
+      params.event.seq - REFETCH_WINDOW_BEFORE,
+      REFETCH_WINDOW_SIZE,
+    );
+    return messages.find((message) => message.id === messageId) ?? null;
+  }
+  if (params.event.type === "thread.reply_created") {
+    const rootId = payloadString(params.event, "root_message_id");
+    if (!rootId) {
+      return null;
+    }
+    const thread = await params.client.thread(rootId);
+    return thread.replies.find((message) => message.id === messageId) ?? null;
+  }
+  if (params.event.channel_id && typeof params.event.seq === "number") {
+    const messages = await params.client.channelMessages(
+      params.event.channel_id,
+      params.event.seq - REFETCH_WINDOW_BEFORE,
+      REFETCH_WINDOW_SIZE,
+    );
+    return messages.find((message) => message.id === messageId) ?? null;
+  }
+  return null;
+}
+
+function decodeSocketMessage(data: RawData): string {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  return Buffer.concat(data).toString("utf8");
+}
+
+function parseSocketEvent(data: RawData): ClickClackEvent | null {
+  try {
+    return JSON.parse(decodeSocketMessage(data)) as ClickClackEvent;
+  } catch {
+    return null;
+  }
+}
+
+async function processEvent(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  client: ReturnType<typeof createClickClackClient>;
+  event: ClickClackEvent;
+  botUserId: string;
+}) {
+  if (params.event.type !== "message.created" && params.event.type !== "thread.reply_created") {
+    return;
+  }
+  if (payloadString(params.event, "author_id") === params.botUserId) {
+    return;
+  }
+  const message = await resolveEventMessage({ client: params.client, event: params.event });
+  if (!message || message.author_id === params.botUserId) {
+    return;
+  }
+  if (message.author?.kind === "bot") {
+    return;
+  }
+  // Admission is resolved and enforced BEFORE the message reaches the inbound
+  // handler: a message the ingress gate did not admit never enters the agent
+  // pipeline, regardless of its command authorization outcome.
+  const access = await resolveClickClackInboundAccess({
+    account: params.account,
+    config: params.config,
+    message,
+  });
+  if (!access.shouldDispatch) {
+    return;
+  }
+  await handleClickClackInbound({
+    account: params.account,
+    config: params.config,
+    message,
+    access,
+  });
+}
+
+export async function startClickClackGatewayAccount(
+  ctx: ChannelGatewayContext<ResolvedClickClackAccount>,
+) {
+  const configuredAccount = resolveClickClackAccount({
+    cfg: ctx.cfg,
+    accountId: ctx.account.accountId,
+  });
+  if (!configuredAccount.configured) {
+    throw new Error(`ClickClack is not configured for account "${configuredAccount.accountId}"`);
+  }
+  const client = createClickClackClient({
+    baseUrl: configuredAccount.baseUrl,
+    token: configuredAccount.token,
+  });
+  const workspaceId = await resolveWorkspaceId(client, configuredAccount.workspace);
+  const me = await client.me();
+  const account = {
+    ...configuredAccount,
+    workspace: workspaceId,
+    botUserId: configuredAccount.botUserId ?? me.id,
+  };
+  ctx.setStatus({
+    accountId: account.accountId,
+    running: true,
+    configured: true,
+    enabled: account.enabled,
+    baseUrl: account.baseUrl,
+  });
+  // Backlog replay and the websocket feed must dispatch identically — keeping
+  // one binding stops the two call sites from drifting apart.
+  const dispatch = (event: ClickClackEvent) =>
+    processEvent({
+      account,
+      config: ctx.cfg,
+      client,
+      event,
+      botUserId: account.botUserId,
+    });
+  let afterCursor = "";
+  let initialized = false;
+  while (!ctx.abortSignal.aborted) {
+    const backlog = await client.events(workspaceId, afterCursor);
+    if (!initialized) {
+      // First pass establishes the cursor without replaying historical backlog
+      // into fresh gateway sessions.
+      for (const event of backlog) {
+        afterCursor = event.cursor || afterCursor;
+      }
+      initialized = true;
+    } else {
+      for (const event of backlog) {
+        afterCursor = event.cursor || afterCursor;
+        await dispatch(event);
+      }
+    }
+    const socket = client.websocket(workspaceId, afterCursor);
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        socket.close();
+        resolve();
+      };
+      ctx.abortSignal.addEventListener("abort", abort, { once: true });
+      socket.on("message", (data) => {
+        void (async () => {
+          const event = parseSocketEvent(data);
+          if (!event) {
+            ctx.log?.warn?.(`[${account.accountId}] skipped malformed ClickClack websocket event`);
+            return;
+          }
+          afterCursor = event.cursor || afterCursor;
+          await dispatch(event);
+        })().catch(reject);
+      });
+      socket.on("close", () => {
+        ctx.abortSignal.removeEventListener("abort", abort);
+        resolve();
+      });
+      socket.on("error", reject);
+    });
+    if (!ctx.abortSignal.aborted) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, account.reconnectMs);
+      });
+    }
+  }
+  ctx.setStatus({ accountId: account.accountId, running: false });
+}

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -1,0 +1,166 @@
+/**
+ * Thin ClickClack REST/websocket client used by gateway, resolver, and outbound
+ * delivery code.
+ *
+ * Talks directly to the operator-configured `baseUrl` rather than routing
+ * through the fork's SSRF dispatcher: ClickClack is a self-hosted deployment
+ * whose endpoint comes from trusted local config, never from inbound payloads.
+ * See #2861 for the explicit posture call.
+ */
+import { WebSocket } from "ws";
+import type {
+  ClickClackChannel,
+  ClickClackEvent,
+  ClickClackMessage,
+  ClickClackUser,
+  ClickClackWorkspace,
+} from "./types.js";
+
+type ClientOptions = {
+  baseUrl: string;
+  token: string;
+  fetch?: typeof fetch;
+};
+
+/**
+ * Creates a typed client for the ClickClack API using bearer-token auth.
+ */
+export function createClickClackClient(options: ClientOptions) {
+  const baseUrl = options.baseUrl.replace(/\/$/, "");
+  const headers = {
+    Authorization: `Bearer ${options.token}`,
+    Accept: "application/json",
+  };
+
+  async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const requestHeaders = new Headers(init.headers);
+    for (const [key, value] of Object.entries(headers)) {
+      requestHeaders.set(key, value);
+    }
+    if (init.body && !(init.body instanceof FormData)) {
+      requestHeaders.set("Content-Type", "application/json");
+    }
+    const url = `${baseUrl}${path}`;
+    const requestInit = { ...init, headers: requestHeaders };
+    // Deliberately a raw `fetch` rather than the SSRF dispatcher — see the
+    // module header for the posture. Spelled as a direct call (not an aliased
+    // `fetcher` binding) so `scripts/check-no-raw-channel-fetch.mjs` can see the
+    // callsite and the exception stays on that gate's allowlist ledger instead
+    // of being invisible to it.
+    const response = await (options.fetch
+      ? options.fetch(url, requestInit)
+      : fetch(url, requestInit));
+    if (!response.ok) {
+      // Name the endpoint: this surfaces to the operator as a channel-exit
+      // reason and burns a restart attempt, so "403" alone cannot be acted on.
+      // Path and status only — never headers, which carry the bearer token.
+      throw new Error(
+        `ClickClack ${init.method ?? "GET"} ${path} -> ${response.status}: ${await response.text()}`,
+      );
+    }
+    return (await response.json()) as T;
+  }
+
+  return {
+    me: async (): Promise<ClickClackUser> => {
+      const data = await request<{ user: ClickClackUser }>("/api/me");
+      return data.user;
+    },
+    workspaces: async (): Promise<ClickClackWorkspace[]> => {
+      const data = await request<{ workspaces: ClickClackWorkspace[] }>("/api/workspaces");
+      return data.workspaces;
+    },
+    channels: async (workspaceId: string): Promise<ClickClackChannel[]> => {
+      const data = await request<{ channels: ClickClackChannel[] }>(
+        `/api/workspaces/${encodeURIComponent(workspaceId)}/channels`,
+      );
+      return data.channels;
+    },
+    channelMessages: async (
+      channelId: string,
+      afterSeq: number,
+      limit = 20,
+    ): Promise<ClickClackMessage[]> => {
+      const data = await request<{ messages: ClickClackMessage[] }>(
+        `/api/channels/${encodeURIComponent(channelId)}/messages?after_seq=${afterSeq}&limit=${limit}`,
+      );
+      return data.messages;
+    },
+    directMessages: async (
+      conversationId: string,
+      afterSeq: number,
+      limit = 20,
+    ): Promise<ClickClackMessage[]> => {
+      const data = await request<{ messages: ClickClackMessage[] }>(
+        `/api/dms/${encodeURIComponent(conversationId)}/messages?after_seq=${afterSeq}&limit=${limit}`,
+      );
+      return data.messages;
+    },
+    thread: async (
+      messageId: string,
+    ): Promise<{ root: ClickClackMessage; replies: ClickClackMessage[] }> =>
+      await request<{ root: ClickClackMessage; replies: ClickClackMessage[] }>(
+        `/api/messages/${encodeURIComponent(messageId)}/thread`,
+      ),
+    createChannelMessage: async (channelId: string, body: string): Promise<ClickClackMessage> => {
+      const data = await request<{ message: ClickClackMessage }>(
+        `/api/channels/${encodeURIComponent(channelId)}/messages`,
+        { method: "POST", body: JSON.stringify({ body }) },
+      );
+      return data.message;
+    },
+    createThreadReply: async (messageId: string, body: string): Promise<ClickClackMessage> => {
+      const data = await request<{ message: ClickClackMessage }>(
+        `/api/messages/${encodeURIComponent(messageId)}/thread/replies`,
+        { method: "POST", body: JSON.stringify({ body }) },
+      );
+      return data.message;
+    },
+    createDirectConversation: async (
+      workspaceId: string,
+      memberIds: string[],
+    ): Promise<{ id: string }> => {
+      const data = await request<{ conversation: { id: string } }>("/api/dms", {
+        method: "POST",
+        body: JSON.stringify({ workspace_id: workspaceId, member_ids: memberIds }),
+      });
+      return data.conversation;
+    },
+    createDirectMessage: async (
+      conversationId: string,
+      body: string,
+    ): Promise<ClickClackMessage> => {
+      const data = await request<{ message: ClickClackMessage }>(
+        `/api/dms/${encodeURIComponent(conversationId)}/messages`,
+        { method: "POST", body: JSON.stringify({ body }) },
+      );
+      return data.message;
+    },
+    events: async (workspaceId: string, afterCursor?: string): Promise<ClickClackEvent[]> => {
+      const query = new URLSearchParams({ workspace_id: workspaceId });
+      if (afterCursor) {
+        query.set("after_cursor", afterCursor);
+      }
+      const data = await request<{ events: ClickClackEvent[] }>(
+        `/api/realtime/events?${query.toString()}`,
+      );
+      return data.events;
+    },
+    websocket: (workspaceId: string, afterCursor?: string): WebSocket => {
+      const url = new URL(`${baseUrl}/api/realtime/ws`);
+      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+      url.searchParams.set("workspace_id", workspaceId);
+      if (afterCursor) {
+        url.searchParams.set("after_cursor", afterCursor);
+      }
+      return new WebSocket(url, {
+        headers: {
+          Authorization: `Bearer ${options.token}`,
+        },
+      });
+    },
+  };
+}
+
+/** Client shape returned by `createClickClackClient`. */
+export type ClickClackClient = ReturnType<typeof createClickClackClient>;

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -1,0 +1,223 @@
+// Clickclack tests cover inbound plugin behavior.
+import type { PluginRuntime } from "remoteclaw/plugin-sdk/clickclack";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../test-utils/plugin-runtime-mock.js";
+import { handleClickClackInbound } from "./inbound.js";
+import { setClickClackRuntime } from "./runtime.js";
+import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const sendClickClackTextMock = vi.hoisted(() => vi.fn());
+const dispatchInboundReplyWithBaseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./outbound.js", () => ({
+  sendClickClackText: sendClickClackTextMock,
+}));
+
+// Only the reply-dispatch helper is stubbed; `resolveStableChannelMessageIngress`
+// stays real so the allowlist assertions below exercise the actual ingress gate.
+vi.mock("remoteclaw/plugin-sdk/clickclack", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("remoteclaw/plugin-sdk/clickclack")>()),
+  dispatchInboundReplyWithBase: dispatchInboundReplyWithBaseMock,
+}));
+
+function createRuntime(): PluginRuntime {
+  return createPluginRuntimeMock({
+    channel: {
+      routing: {
+        resolveAgentRoute({
+          accountId,
+          peer,
+        }: Parameters<PluginRuntime["channel"]["routing"]["resolveAgentRoute"]>[0]) {
+          return {
+            agentId: "test-agent",
+            channel: "clickclack",
+            accountId: accountId ?? "default",
+            sessionKey: `agent:test-agent:clickclack:${peer?.kind ?? "channel"}:${peer?.id ?? "general"}`,
+            mainSessionKey: "agent:test-agent:main",
+            lastRoutePolicy: "session",
+            matchedBy: "default",
+          };
+        },
+        buildAgentSessionKey({
+          agentId,
+          channel,
+          accountId,
+          peer,
+        }: Parameters<PluginRuntime["channel"]["routing"]["buildAgentSessionKey"]>[0]) {
+          return `agent:${agentId}:${channel}:${accountId ?? "default"}:${peer?.kind ?? "channel"}:${peer?.id ?? "general"}`;
+        },
+      },
+    },
+  } as unknown as PluginRuntime);
+}
+
+function createAgentAccount(
+  overrides: Partial<ResolvedClickClackAccount> = {},
+): ResolvedClickClackAccount {
+  const base = {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    baseUrl: "http://127.0.0.1:8080",
+    token: "ccb_default",
+    workspace: "wsp_1",
+    defaultTo: "channel:general",
+    allowFrom: ["*"],
+    reconnectMs: 1_500,
+    config: {
+      allowFrom: ["*"],
+    },
+  } satisfies ResolvedClickClackAccount;
+
+  return {
+    ...base,
+    ...overrides,
+    config: {
+      ...base.config,
+      ...overrides.config,
+    },
+  };
+}
+
+function createMessage(overrides: Partial<ClickClackMessage> = {}): ClickClackMessage {
+  return {
+    id: "msg_1",
+    workspace_id: "wsp_1",
+    channel_id: "chn_1",
+    author_id: "usr_owner",
+    thread_root_id: "msg_1",
+    body: "/fast on",
+    body_format: "markdown",
+    created_at: "2026-05-09T12:00:00.000Z",
+    author: {
+      id: "usr_owner",
+      kind: "human",
+      display_name: "Peter",
+      handle: "steipete",
+      avatar_url: "",
+      created_at: "2026-05-09T12:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+const cfg = {
+  agents: {
+    defaults: {
+      model: "test-model",
+    },
+  },
+} satisfies CoreConfig;
+
+describe("handleClickClackInbound", () => {
+  beforeEach(() => {
+    sendClickClackTextMock.mockReset();
+    dispatchInboundReplyWithBaseMock.mockReset();
+  });
+
+  it("marks agent turns command-authorized for allowlisted senders", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
+    setClickClackRuntime(runtime);
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        allowFrom: ["usr_owner"],
+        config: { allowFrom: ["usr_owner"] },
+      }),
+      config: cfg,
+      message: createMessage(),
+    });
+
+    expect(dispatchInboundReplyWithBaseMock).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundReplyWithBaseMock.mock.calls[0]?.[0].ctxPayload.CommandAuthorized).toBe(
+      true,
+    );
+  });
+
+  it("propagates the account reply timeout into dispatch reply options", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+
+    await handleClickClackInbound({
+      account: createAgentAccount({ timeoutSeconds: 42 }),
+      config: cfg,
+      message: createMessage(),
+    });
+
+    expect(dispatchInboundReplyWithBaseMock).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundReplyWithBaseMock.mock.calls[0]?.[0].replyOptions).toEqual({
+      timeoutOverrideSeconds: 42,
+    });
+  });
+
+  it("accepts ClickClack DM target syntax in allowFrom", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
+    setClickClackRuntime(runtime);
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        allowFrom: ["dm:usr_owner"],
+        config: { allowFrom: ["dm:usr_owner"] },
+      }),
+      config: cfg,
+      message: createMessage({
+        channel_id: undefined,
+        direct_conversation_id: "dcn_1",
+      }),
+    });
+
+    expect(dispatchInboundReplyWithBaseMock).toHaveBeenCalledTimes(1);
+    expect(dispatchInboundReplyWithBaseMock.mock.calls[0]?.[0].ctxPayload.ChatType).toBe("direct");
+    expect(dispatchInboundReplyWithBaseMock.mock.calls[0]?.[0].ctxPayload.CommandAuthorized).toBe(
+      true,
+    );
+  });
+
+  it("does not dispatch agent turns from senders outside allowFrom", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
+    setClickClackRuntime(runtime);
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        allowFrom: ["usr_owner"],
+        config: { allowFrom: ["usr_owner"] },
+      }),
+      config: cfg,
+      message: createMessage({
+        author_id: "usr_attacker",
+        author: {
+          id: "usr_attacker",
+          kind: "human",
+          display_name: "Attacker",
+          handle: "attacker",
+          avatar_url: "",
+          created_at: "2026-05-09T12:00:00.000Z",
+        },
+      }),
+    });
+
+    expect(dispatchInboundReplyWithBaseMock).not.toHaveBeenCalled();
+    expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("honors a caller-supplied denial without re-resolving access", async () => {
+    // The gateway resolves access once and passes it down; `handleClickClackInbound`
+    // must still refuse to dispatch on a denied admission even though the caller
+    // reports the command itself as authorized.
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+
+    await handleClickClackInbound({
+      account: createAgentAccount(),
+      config: cfg,
+      message: createMessage(),
+      access: { shouldDispatch: false, commandAuthorized: true },
+    });
+
+    expect(dispatchInboundReplyWithBaseMock).not.toHaveBeenCalled();
+    expect(sendClickClackTextMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -1,0 +1,188 @@
+/**
+ * Converts authorized ClickClack messages into RemoteClaw agent replies and
+ * routes resulting outbound text back to ClickClack.
+ *
+ * Upstream also carried a `replyMode: "model"` branch that called
+ * `runtime.llm.complete(...)` for short in-process bot replies. This fork's
+ * `PluginRuntime` ships no `llm` surface (CLI runtimes own model execution), so
+ * that branch is dropped and every admitted message routes through the standard
+ * agent pipeline. Reply dispatch likewise goes through the fork's
+ * `dispatchInboundReplyWithBase` helper rather than upstream's
+ * `runtime.channel.inbound.dispatchReply`, which this repo's channel runtime
+ * does not expose.
+ *
+ * One setting goes further than upstream: upstream declared `timeoutSeconds` in
+ * its schema/types but never consumed it. Here it is wired to the reply
+ * dispatcher's `timeoutOverrideSeconds`, so the value an operator configures
+ * actually bounds the agent turn.
+ */
+import {
+  dispatchInboundReplyWithBase,
+  type RemoteClawConfig,
+} from "remoteclaw/plugin-sdk/clickclack";
+import { resolveClickClackInboundAccess, type ClickClackInboundAccess } from "./access.js";
+import { sendClickClackText } from "./outbound.js";
+import { getClickClackRuntime } from "./runtime.js";
+import { buildClickClackTarget } from "./target.js";
+import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const CHANNEL_ID = "clickclack" as const;
+
+function resolveAccountAgentRoute(params: {
+  cfg: RemoteClawConfig;
+  account: ResolvedClickClackAccount;
+  target: string;
+  isDirect: boolean;
+}) {
+  const runtime = getClickClackRuntime();
+  const route = runtime.channel.routing.resolveAgentRoute({
+    cfg: params.cfg,
+    channel: CHANNEL_ID,
+    accountId: params.account.accountId,
+    peer: {
+      kind: params.isDirect ? "direct" : "channel",
+      id: params.target,
+    },
+  });
+  const agentId = params.account.agentId ?? route.agentId;
+  if (agentId === route.agentId) {
+    return route;
+  }
+  return {
+    ...route,
+    agentId,
+    sessionKey: runtime.channel.routing.buildAgentSessionKey({
+      agentId,
+      channel: CHANNEL_ID,
+      accountId: params.account.accountId,
+      peer: {
+        kind: params.isDirect ? "direct" : "channel",
+        id: params.target,
+      },
+    }),
+  };
+}
+
+/**
+ * Dispatches one already-fetched ClickClack message through the agent pipeline.
+ *
+ * Admission is checked first and short-circuits the whole handler: a message
+ * the ingress gate did not admit is dropped before any routing, session, or
+ * command-authorization work happens. `access.commandAuthorized` only rides
+ * along into the dispatched context — it never substitutes for admission.
+ */
+export async function handleClickClackInbound(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  message: ClickClackMessage;
+  access?: ClickClackInboundAccess;
+}) {
+  const runtime = getClickClackRuntime();
+  const message = params.message;
+  const access =
+    params.access ??
+    (await resolveClickClackInboundAccess({
+      account: params.account,
+      config: params.config,
+      message,
+    }));
+  if (!access.shouldDispatch) {
+    return;
+  }
+  const isDirect = Boolean(message.direct_conversation_id);
+  const target = buildClickClackTarget(
+    isDirect
+      ? { chatType: "direct", kind: "dm", id: message.author_id }
+      : { chatType: "group", kind: "channel", id: message.channel_id ?? "" },
+  );
+  const route = resolveAccountAgentRoute({
+    cfg: params.config as RemoteClawConfig,
+    account: params.account,
+    target,
+    isDirect,
+  });
+  const senderName = message.author?.display_name || message.author_id;
+  const previousTimestamp = runtime.channel.session.readSessionUpdatedAt({
+    storePath: runtime.channel.session.resolveStorePath(params.config.session?.store, {
+      agentId: route.agentId,
+    }),
+    sessionKey: route.sessionKey,
+  });
+  // Preserve both normalized channel fields and ClickClack-native ids so reply
+  // routing, session recovery, and command authorization see the same message.
+  const body = runtime.channel.reply.formatAgentEnvelope({
+    channel: "ClickClack",
+    from: senderName,
+    timestamp: new Date(message.created_at),
+    previousTimestamp,
+    envelope: runtime.channel.reply.resolveEnvelopeFormatOptions(params.config as RemoteClawConfig),
+    body: message.body,
+  });
+  const storePath = runtime.channel.session.resolveStorePath(params.config.session?.store, {
+    agentId: route.agentId,
+  });
+  const ctxPayload = runtime.channel.reply.finalizeInboundContext({
+    Body: body,
+    BodyForAgent: message.body,
+    RawBody: message.body,
+    CommandBody: message.body,
+    From: target,
+    To: target,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId ?? params.account.accountId,
+    ChatType: isDirect ? "direct" : "group",
+    WasMentioned: isDirect ? undefined : true,
+    ConversationLabel: isDirect ? senderName : message.channel_id,
+    GroupChannel: message.channel_id,
+    NativeChannelId: message.channel_id || message.direct_conversation_id,
+    MessageThreadId: message.parent_message_id ? message.thread_root_id : undefined,
+    ThreadParentId: message.parent_message_id ? message.thread_root_id : undefined,
+    SenderName: senderName,
+    SenderId: message.author_id,
+    Provider: CHANNEL_ID,
+    Surface: CHANNEL_ID,
+    MessageSid: message.id,
+    MessageSidFull: message.id,
+    ReplyToId: message.id,
+    Timestamp: message.created_at,
+    OriginatingChannel: CHANNEL_ID,
+    OriginatingTo: target,
+    CommandAuthorized: access.commandAuthorized,
+  });
+  await dispatchInboundReplyWithBase({
+    cfg: params.config as RemoteClawConfig,
+    channel: CHANNEL_ID,
+    accountId: params.account.accountId,
+    route: { agentId: route.agentId, sessionKey: route.sessionKey },
+    storePath,
+    ctxPayload,
+    core: runtime,
+    replyOptions: params.account.timeoutSeconds
+      ? { timeoutOverrideSeconds: params.account.timeoutSeconds }
+      : undefined,
+    deliver: async (payload) => {
+      const text = payload.text ?? "";
+      if (!text.trim()) {
+        return;
+      }
+      await sendClickClackText({
+        cfg: params.config,
+        accountId: params.account.accountId,
+        to: target,
+        text,
+        threadId: message.parent_message_id ? message.thread_root_id : undefined,
+        replyToId: message.id,
+      });
+    },
+    onRecordError: (error) => {
+      throw error instanceof Error
+        ? error
+        : new Error(`clickclack session record failed: ${String(error)}`);
+    },
+    onDispatchError: (error, info) => {
+      throw error instanceof Error
+        ? error
+        : new Error(`clickclack ${info.kind} dispatch failed: ${String(error)}`);
+    },
+  });
+}

--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -1,0 +1,44 @@
+/**
+ * Outbound ClickClack delivery helpers for channel messages, thread replies,
+ * and direct messages.
+ */
+import { resolveClickClackAccount } from "./accounts.js";
+import { createClickClackClient } from "./http-client.js";
+import { resolveChannelId, resolveWorkspaceId } from "./resolve.js";
+import { parseClickClackTarget } from "./target.js";
+import type { CoreConfig } from "./types.js";
+
+/**
+ * Sends text to a normalized ClickClack target and returns the created message
+ * id for receipt/session tracking.
+ */
+export async function sendClickClackText(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+  to: string;
+  text: string;
+  threadId?: string | number | null;
+  replyToId?: string | number | null;
+}) {
+  const account = resolveClickClackAccount({ cfg: params.cfg, accountId: params.accountId });
+  const client = createClickClackClient({ baseUrl: account.baseUrl, token: account.token });
+  const workspaceId = await resolveWorkspaceId(client, account.workspace);
+  const parsed = parseClickClackTarget(params.to);
+  const explicitThreadId = params.threadId == null ? "" : String(params.threadId);
+  const replyToId = params.replyToId == null ? "" : String(params.replyToId);
+  if (explicitThreadId || replyToId || parsed.kind === "thread") {
+    // Explicit thread/reply context wins over the target kind so RemoteClaw reply
+    // hooks keep conversations attached to the original ClickClack root.
+    const rootId = explicitThreadId || replyToId || parsed.id;
+    const message = await client.createThreadReply(rootId, params.text);
+    return { to: params.to, messageId: message.id };
+  }
+  if (parsed.kind === "dm") {
+    const dm = await client.createDirectConversation(workspaceId, [parsed.id]);
+    const message = await client.createDirectMessage(dm.id, params.text);
+    return { to: params.to, messageId: message.id };
+  }
+  const channelId = await resolveChannelId(client, workspaceId, parsed.id);
+  const message = await client.createChannelMessage(channelId, params.text);
+  return { to: params.to, messageId: message.id };
+}

--- a/extensions/clickclack/src/resolve.ts
+++ b/extensions/clickclack/src/resolve.ts
@@ -1,0 +1,44 @@
+/**
+ * ClickClack name/id resolution helpers for workspace and channel config.
+ */
+import type { ClickClackClient } from "./http-client.js";
+
+/**
+ * Resolves a workspace slug/name/id from config to a ClickClack workspace id.
+ */
+export async function resolveWorkspaceId(client: ClickClackClient, workspace: string) {
+  if (workspace.startsWith("wsp_")) {
+    return workspace;
+  }
+  const workspaces = await client.workspaces();
+  const found = workspaces.find(
+    (candidate) =>
+      candidate.id === workspace || candidate.slug === workspace || candidate.name === workspace,
+  );
+  if (!found) {
+    throw new Error(`ClickClack workspace not found: ${workspace}`);
+  }
+  return found.id;
+}
+
+/**
+ * Resolves a channel name/id from config or target input to a ClickClack
+ * channel id.
+ */
+export async function resolveChannelId(
+  client: ClickClackClient,
+  workspaceId: string,
+  channel: string,
+) {
+  if (channel.startsWith("chn_")) {
+    return channel;
+  }
+  const channels = await client.channels(workspaceId);
+  const found = channels.find(
+    (candidate) => candidate.id === channel || candidate.name === channel,
+  );
+  if (!found) {
+    throw new Error(`ClickClack channel not found: ${channel}`);
+  }
+  return found.id;
+}

--- a/extensions/clickclack/src/runtime.ts
+++ b/extensions/clickclack/src/runtime.ts
@@ -1,0 +1,14 @@
+/**
+ * Runtime store for host-provided RemoteClaw services used by the ClickClack
+ * bundled plugin.
+ */
+import { createPluginRuntimeStore } from "remoteclaw/plugin-sdk/clickclack";
+import type { PluginRuntime } from "remoteclaw/plugin-sdk/clickclack";
+
+const { setRuntime: setClickClackRuntime, getRuntime: getClickClackRuntime } =
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "clickclack",
+    errorMessage: "ClickClack runtime not initialized",
+  });
+
+export { getClickClackRuntime, setClickClackRuntime };

--- a/extensions/clickclack/src/target.test.ts
+++ b/extensions/clickclack/src/target.test.ts
@@ -1,0 +1,27 @@
+// Clickclack tests cover target plugin behavior.
+import { describe, expect, it } from "vitest";
+import {
+  buildClickClackTarget,
+  normalizeClickClackTarget,
+  parseClickClackTarget,
+} from "./target.js";
+
+describe("ClickClack targets", () => {
+  it("parses channel targets", () => {
+    expect(parseClickClackTarget("channel:general")).toEqual({
+      chatType: "group",
+      kind: "channel",
+      id: "general",
+    });
+    expect(normalizeClickClackTarget("general")).toBe("channel:general");
+  });
+
+  it("parses thread and dm targets", () => {
+    expect(buildClickClackTarget(parseClickClackTarget("thread:msg_1"))).toBe("thread:msg_1");
+    expect(parseClickClackTarget("dm:usr_1")).toEqual({
+      chatType: "direct",
+      kind: "dm",
+      id: "usr_1",
+    });
+  });
+});

--- a/extensions/clickclack/src/target.ts
+++ b/extensions/clickclack/src/target.ts
@@ -1,0 +1,51 @@
+/**
+ * Parser and formatter for ClickClack outbound target strings.
+ */
+import type { ClickClackTarget } from "./types.js";
+
+/**
+ * Parses `channel:name`, `thread:msg_id`, `dm:usr_id`, or a bare channel name.
+ */
+export function parseClickClackTarget(raw: string): ClickClackTarget {
+  const value = raw.trim();
+  if (!value) {
+    throw new Error("ClickClack target is required");
+  }
+  const [prefix, ...rest] = value.split(":");
+  const body = rest.join(":").trim();
+  if (prefix === "channel" && body) {
+    return { chatType: "group", kind: "channel", id: body };
+  }
+  if (prefix === "thread" && body) {
+    return { chatType: "group", kind: "thread", id: body };
+  }
+  if (prefix === "dm" && body) {
+    return { chatType: "direct", kind: "dm", id: body };
+  }
+  if (!body) {
+    return { chatType: "group", kind: "channel", id: value };
+  }
+  throw new Error(`Unsupported ClickClack target: ${raw}`);
+}
+
+/** Formats a parsed ClickClack target back into canonical target syntax. */
+export function buildClickClackTarget(target: ClickClackTarget): string {
+  return `${target.kind}:${target.id}`;
+}
+
+/** Normalizes user-entered ClickClack target text for channel routing. */
+export function normalizeClickClackTarget(raw: string): string {
+  return buildClickClackTarget(parseClickClackTarget(raw));
+}
+
+/**
+ * Reports whether a target string can be offered to the ClickClack parser.
+ *
+ * Every non-empty string qualifies: a bare name is a valid target because
+ * `parseClickClackTarget` defaults an unprefixed value to `channel:`. The
+ * `channel:` / `thread:` / `dm:` prefixes are therefore optional, not required —
+ * this is deliberately not a validity check.
+ */
+export function looksLikeClickClackTarget(raw: string): boolean {
+  return raw.trim().length > 0;
+}

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared ClickClack config, runtime account, API object, and target types.
+ */
+import type { RemoteClawConfig } from "remoteclaw/plugin-sdk/clickclack";
+
+/** User-configurable settings for one ClickClack account. */
+export type ClickClackAccountConfig = {
+  name?: string;
+  enabled?: boolean;
+  baseUrl?: string;
+  token?: unknown;
+  workspace?: string;
+  botUserId?: string;
+  agentId?: string;
+  timeoutSeconds?: number;
+  defaultTo?: string;
+  allowFrom?: string[];
+  reconnectMs?: number;
+};
+
+/** Root ClickClack channel config with optional named accounts. */
+export type ClickClackConfig = ClickClackAccountConfig & {
+  accounts?: Record<string, Partial<ClickClackAccountConfig>>;
+  defaultAccount?: string;
+};
+
+/** RemoteClaw config narrowed to include ClickClack channel settings. */
+export type CoreConfig = RemoteClawConfig & {
+  channels?: RemoteClawConfig["channels"] & {
+    clickclack?: ClickClackConfig;
+  };
+};
+
+/** Normalized account snapshot consumed by runtime paths. */
+export type ResolvedClickClackAccount = {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+  name?: string;
+  baseUrl: string;
+  token: string;
+  workspace: string;
+  botUserId?: string;
+  agentId?: string;
+  timeoutSeconds?: number;
+  defaultTo: string;
+  allowFrom: string[];
+  reconnectMs: number;
+  config: ClickClackAccountConfig;
+};
+
+/** User object returned by the ClickClack API. */
+export type ClickClackUser = {
+  id: string;
+  kind?: "human" | "bot";
+  owner_user_id?: string;
+  display_name: string;
+  handle: string;
+  avatar_url: string;
+  created_at: string;
+};
+
+/** Workspace object returned by the ClickClack API. */
+export type ClickClackWorkspace = {
+  id: string;
+  name: string;
+  slug: string;
+  created_at: string;
+};
+
+/** Channel object returned by the ClickClack API. */
+export type ClickClackChannel = {
+  id: string;
+  workspace_id: string;
+  name: string;
+  kind: string;
+  created_at: string;
+};
+
+/** Message object returned by ClickClack channel, DM, and thread endpoints. */
+export type ClickClackMessage = {
+  id: string;
+  workspace_id: string;
+  channel_id?: string;
+  direct_conversation_id?: string;
+  author_id: string;
+  parent_message_id?: string;
+  thread_root_id: string;
+  channel_seq?: number;
+  thread_seq?: number;
+  body: string;
+  body_format: "markdown";
+  created_at: string;
+  author?: ClickClackUser;
+};
+
+/** Realtime event envelope returned by ClickClack polling/websocket APIs. */
+export type ClickClackEvent = {
+  id: string;
+  cursor: string;
+  type: string;
+  workspace_id: string;
+  channel_id?: string;
+  seq?: number;
+  created_at: string;
+  payload: Record<string, unknown>;
+};
+
+/** Parsed outbound destination for ClickClack delivery. */
+export type ClickClackTarget =
+  | { chatType: "group"; kind: "channel"; id: string }
+  | { chatType: "group"; kind: "thread"; id: string }
+  | { chatType: "direct"; kind: "dm"; id: string };

--- a/extensions/clickclack/tsconfig.json
+++ b/extensions/clickclack/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -127,6 +127,10 @@
       "types": "./dist/plugin-sdk/bluebubbles.d.ts",
       "default": "./dist/plugin-sdk/bluebubbles.js"
     },
+    "./plugin-sdk/clickclack": {
+      "types": "./dist/plugin-sdk/clickclack.d.ts",
+      "default": "./dist/plugin-sdk/clickclack.js"
+    },
     "./plugin-sdk/copilot-proxy": {
       "types": "./dist/plugin-sdk/copilot-proxy.d.ts",
       "default": "./dist/plugin-sdk/copilot-proxy.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,15 @@ importers:
         specifier: ^4.3.6
         version: 4.4.3
 
+  extensions/clickclack:
+    dependencies:
+      ws:
+        specifier: ^8.19.0
+        version: 8.21.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
+
   extensions/diagnostics-otel:
     dependencies:
       '@opentelemetry/api':

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -19,6 +19,9 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("browser", "src/browser/client-fetch.ts", 192),
   bundledPluginCallsite("chutes", "models.ts", 536),
   bundledPluginCallsite("chutes", "models.ts", 543),
+  // Self-hosted ClickClack deployment: `baseUrl` is operator-supplied local
+  // config, never a value taken from inbound traffic (#2861).
+  bundledPluginCallsite("clickclack", "src/http-client.ts", 52),
   bundledPluginCallsite("discord", "src/monitor/gateway-plugin.ts", 417),
   bundledPluginCallsite("discord", "src/monitor/gateway-plugin.ts", 483),
   bundledPluginCallsite("discord", "src/voice-message.ts", 298),

--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -54,6 +54,7 @@ const requiredSubpathEntries = [
   "msteams",
   "acpx",
   "bluebubbles",
+  "clickclack",
   "copilot-proxy",
   "device-pair",
   "diagnostics-otel",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -56,6 +56,8 @@ const requiredPathGroups = [
   "dist/plugin-sdk/diagnostics-otel.d.ts",
   "dist/plugin-sdk/diagnostics-prometheus.js",
   "dist/plugin-sdk/diagnostics-prometheus.d.ts",
+  "dist/plugin-sdk/clickclack.js",
+  "dist/plugin-sdk/clickclack.d.ts",
   "dist/plugin-sdk/diffs.js",
   "dist/plugin-sdk/diffs.d.ts",
   "dist/plugin-sdk/feishu.js",

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -22,6 +22,7 @@ const entrypoints = [
   "msteams",
   "acpx",
   "bluebubbles",
+  "clickclack",
   "copilot-proxy",
   "device-pair",
   "diagnostics-otel",

--- a/src/channels/access-group-members.test.ts
+++ b/src/channels/access-group-members.test.ts
@@ -1,0 +1,116 @@
+// Access-group member reads must not inherit from Object.prototype.
+//
+// Fork-owned coverage: `src/channels/message-access/message-access.test.ts` is a
+// verbatim upstream port kept byte-identical for re-sync, so the guard this fork
+// added (#2861) is pinned here instead. Channel ids became an open `string` when
+// plugin-provided channels started reaching the ingress kernel, which is what
+// makes a prototype-named key reachable at all.
+import { describe, expect, it } from "vitest";
+import { readAccessGroupMembers } from "./access-group-members.js";
+import { expandAccessGroupAllowFromEntries } from "./allow-from.js";
+import {
+  type InternalChannelIngressAdapter,
+  resolveChannelIngressState,
+} from "./message-access/index.js";
+
+const dangerousKeys = ["__proto__", "constructor", "prototype", "toString"];
+
+describe("readAccessGroupMembers", () => {
+  it("returns own-key arrays unchanged", () => {
+    const members = { "*": ["usr_shared"], clickclack: ["usr_scoped"] };
+
+    expect(readAccessGroupMembers(members, "*")).toEqual(["usr_shared"]);
+    expect(readAccessGroupMembers(members, "clickclack")).toEqual(["usr_scoped"]);
+  });
+
+  it("returns empty for a missing key", () => {
+    expect(readAccessGroupMembers({ "*": ["usr_shared"] }, "telegram")).toEqual([]);
+  });
+
+  it("returns empty for prototype-inherited keys instead of leaking or throwing", () => {
+    const members: Record<string, unknown> = { "*": ["usr_shared"] };
+
+    for (const key of dangerousKeys) {
+      expect(() => readAccessGroupMembers(members, key), `key ${key} must not throw`).not.toThrow();
+      expect(readAccessGroupMembers(members, key), `key ${key} must not leak`).toEqual([]);
+    }
+  });
+
+  it("returns empty when an own key holds a non-array value", () => {
+    const members = { clickclack: "usr_scoped" } as unknown as Record<string, unknown>;
+
+    expect(readAccessGroupMembers(members, "clickclack")).toEqual([]);
+  });
+
+  it("still honors an own key that happens to be named like a prototype member", () => {
+    // An object literal makes `constructor` an OWN property, which is the case
+    // the guard must still admit — it filters inherited keys, not this name.
+    const members = { constructor: ["usr_legit"] } as unknown as Record<string, unknown>;
+
+    expect(readAccessGroupMembers(members, "constructor")).toEqual(["usr_legit"]);
+  });
+});
+
+describe("access-group expansion with a prototype-named channel id", () => {
+  const accessGroups = {
+    owners: { type: "message.senders", members: { "*": ["usr_shared"] } },
+  } as unknown as Parameters<typeof expandAccessGroupAllowFromEntries>[0]["accessGroups"];
+
+  it("expands shared members without inheriting for allow-from", () => {
+    for (const channelId of dangerousKeys) {
+      const entries = expandAccessGroupAllowFromEntries({
+        entries: ["accessGroup:owners"],
+        accessGroups,
+        channelId,
+      });
+
+      expect(entries, `channelId ${channelId}`).toEqual(["usr_shared"]);
+    }
+  });
+
+  it("resolves ingress state without throwing for the ingress kernel", async () => {
+    const adapter: InternalChannelIngressAdapter = {
+      normalizeEntries({ entries }) {
+        return {
+          matchable: entries.map((entry, index) => ({
+            opaqueEntryId: `entry-${index + 1}`,
+            kind: "stable-id",
+            value: entry,
+          })),
+          invalid: [],
+          disabled: [],
+        };
+      },
+      matchSubject({ subject, entries }) {
+        const values = new Set(subject.identifiers.map((identifier) => identifier.value));
+        const matchedEntryIds = entries
+          .filter((entry) => values.has(entry.value))
+          .map((entry) => entry.opaqueEntryId);
+        return { matched: matchedEntryIds.length > 0, matchedEntryIds };
+      },
+    };
+
+    for (const channelId of dangerousKeys) {
+      const state = await resolveChannelIngressState({
+        channelId,
+        accountId: "default",
+        subject: {
+          identifiers: [{ opaqueId: "subject-1", kind: "stable-id", value: "usr_shared" }],
+        },
+        conversation: { kind: "group", id: "chn_1" },
+        adapter,
+        event: { kind: "message", authMode: "inbound", mayPair: false },
+        allowlists: { group: ["accessGroup:owners"] },
+        accessGroups,
+      } as unknown as Parameters<typeof resolveChannelIngressState>[0]);
+
+      // The shared `members["*"]` bucket still expands and matches the sender;
+      // nothing is inherited from Object.prototype for the prototype-named
+      // channel id, and no channel-scoped bucket is fabricated for it.
+      expect(state.allowlists.group.matchedEntryIds, `channelId ${channelId}`).toHaveLength(1);
+      expect(state.allowlists.group.accessGroups.matched, `channelId ${channelId}`).toEqual([
+        "owners",
+      ]);
+    }
+  });
+});

--- a/src/channels/access-group-members.ts
+++ b/src/channels/access-group-members.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared own-key reader for `message.senders` access-group member buckets.
+ *
+ * Two call sites expand `accessGroup:` references into concrete sender entries —
+ * the ingress kernel (`message-access/state.ts` `groupSenderEntries`) and the
+ * simple-matcher path (`allow-from.ts` `expandAccessGroupAllowFromEntries`) —
+ * and they are documented as mirrors of each other. The lookup lives here so a
+ * hardening applied to one cannot silently miss the other.
+ *
+ * `members` is a plain record keyed by channel id, and channel ids are an open
+ * `string` (plugin-provided channels supply their own). A key like `__proto__`
+ * or `constructor` would otherwise resolve to a value inherited from
+ * `Object.prototype` — truthy, so `??` never fires — and spreading that
+ * non-iterable value throws. Own-key array lookups behave exactly as before.
+ */
+export function readAccessGroupMembers(
+  members: Record<string, unknown>,
+  key: string,
+): readonly string[] {
+  if (!Object.hasOwn(members, key)) {
+    return [];
+  }
+  const value = members[key];
+  return Array.isArray(value) ? (value as string[]) : [];
+}

--- a/src/channels/allow-from.ts
+++ b/src/channels/allow-from.ts
@@ -1,5 +1,6 @@
 import type { AccessGroupsConfig } from "../config/types.access-groups.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
+import { readAccessGroupMembers } from "./access-group-members.js";
 
 export const ACCESS_GROUP_ALLOW_FROM_PREFIX = "accessGroup:";
 
@@ -47,8 +48,10 @@ export function expandAccessGroupAllowFromEntries(params: {
     // `members["*"]` is the channel-scope key for entries SHARED across all channels — not an
     // allowlist wildcard. A wildcard only arises if the operator lists `"*"` as a member VALUE,
     // which is explicit and symmetric with a direct `allowFrom: ["*"]`.
-    const sharedMembers = group.members["*"] ?? [];
-    const channelMembers = params.channelId ? (group.members[params.channelId] ?? []) : [];
+    const sharedMembers = readAccessGroupMembers(group.members, "*");
+    const channelMembers = params.channelId
+      ? readAccessGroupMembers(group.members, params.channelId)
+      : [];
     expanded.push(...sharedMembers, ...channelMembers);
   }
   return expanded;

--- a/src/channels/message-access/message-access.test.ts
+++ b/src/channels/message-access/message-access.test.ts
@@ -1,0 +1,244 @@
+// Message access tests cover channel message visibility and permission helpers.
+import { describe, expect, it } from "vitest";
+import {
+  decideChannelIngress,
+  resolveChannelIngressState,
+  type ChannelIngressPolicyInput,
+  type ChannelIngressStateInput,
+  type InternalChannelIngressAdapter,
+  type InternalChannelIngressSubject,
+} from "./index.js";
+
+const subject = (value: string): InternalChannelIngressSubject => ({
+  identifiers: [{ opaqueId: "subject-1", kind: "stable-id", value }],
+});
+
+const adapter: InternalChannelIngressAdapter = {
+  normalizeEntries({ entries }) {
+    return {
+      matchable: entries.map((entry, index) => ({
+        opaqueEntryId: `entry-${index + 1}`,
+        kind: "stable-id",
+        value: entry,
+        dangerous: entry.startsWith("display:"),
+      })),
+      invalid: [],
+      disabled: [],
+    };
+  },
+  matchSubject({ subject: subjectValue, entries }) {
+    const values = new Set(subjectValue.identifiers.map((identifier) => identifier.value));
+    const matchedEntryIds = entries
+      .filter((entry) => entry.value === "*" || values.has(entry.value))
+      .map((entry) => entry.opaqueEntryId);
+    return { matched: matchedEntryIds.length > 0, matchedEntryIds };
+  },
+};
+
+const lowerCaseAdapter: InternalChannelIngressAdapter = {
+  normalizeEntries({ entries }) {
+    return {
+      matchable: entries.map((entry, index) => ({
+        opaqueEntryId: `entry-${index + 1}`,
+        kind: "stable-id",
+        value: entry.toLowerCase(),
+      })),
+      invalid: [],
+      disabled: [],
+    };
+  },
+  matchSubject({ subject: subjectLocal, entries }) {
+    const values = new Set(
+      subjectLocal.identifiers.map((identifier) => identifier.value.toLowerCase()),
+    );
+    const matchedEntryIds = entries
+      .filter((entry) => entry.kind === "stable-id" && values.has(entry.value))
+      .map((entry) => entry.opaqueEntryId);
+    return { matched: matchedEntryIds.length > 0, matchedEntryIds };
+  },
+};
+
+function baseInput(overrides: Partial<ChannelIngressStateInput> = {}): ChannelIngressStateInput {
+  return {
+    channelId: "test",
+    accountId: "default",
+    subject: subject("sender-1"),
+    conversation: { kind: "direct", id: "dm-1" },
+    adapter,
+    event: { kind: "message", authMode: "inbound", mayPair: true },
+    allowlists: {},
+    ...overrides,
+  };
+}
+
+const policy: ChannelIngressPolicyInput = {
+  dmPolicy: "pairing",
+  groupPolicy: "allowlist",
+};
+
+function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
+  if (!record || typeof record !== "object") {
+    throw new Error("Expected record");
+  }
+  const actual = record as Record<string, unknown>;
+  for (const [key, value] of Object.entries(expected)) {
+    expect(actual[key]).toEqual(value);
+  }
+  return actual;
+}
+
+describe("channel message access ingress", () => {
+  it.each([
+    {
+      name: "keeps pairing-store entries DM-policy scoped",
+      input: baseInput({
+        subject: subject("paired-sender"),
+        allowlists: { pairingStore: ["paired-sender"] },
+      }),
+      policyLocal: { ...policy, dmPolicy: "open" as const },
+      expected: { admission: "drop", reasonCode: "dm_policy_not_allowlisted" },
+      secondPolicy: { ...policy, dmPolicy: "pairing" as const },
+      secondExpected: { admission: "dispatch", decision: "allow" },
+    },
+    {
+      name: "requires explicit group fallback to DM allowlists",
+      input: baseInput({
+        conversation: { kind: "group", id: "room-1" },
+        allowlists: { dm: ["sender-1"] },
+      }),
+      policyLocal: policy,
+      expected: { admission: "drop", reasonCode: "group_policy_empty_allowlist" },
+      secondPolicy: { ...policy, groupAllowFromFallbackToAllowFrom: true },
+      secondExpected: { admission: "dispatch", decision: "allow" },
+    },
+    {
+      name: "requires explicit dangerous identifier matching",
+      input: baseInput({
+        subject: subject("display:sender-1"),
+        allowlists: { dm: ["display:sender-1"] },
+      }),
+      policyLocal: { ...policy, dmPolicy: "allowlist" as const },
+      expected: { admission: "drop", reasonCode: "dm_policy_not_allowlisted" },
+      secondPolicy: {
+        ...policy,
+        dmPolicy: "allowlist" as const,
+        mutableIdentifierMatching: "enabled" as const,
+      },
+      secondExpected: { admission: "dispatch", decision: "allow" },
+    },
+  ])("$name", async ({ input, policyLocal, expected, secondPolicy, secondExpected }) => {
+    const state = await resolveChannelIngressState(input);
+    expectRecordFields(decideChannelIngress(state, policyLocal), expected);
+    expectRecordFields(decideChannelIngress(state, secondPolicy), secondExpected);
+  });
+
+  it("applies route sender allowlists without retaining raw sender values", async () => {
+    const rawSender = "route-sender@example.test";
+    const state = await resolveChannelIngressState(
+      baseInput({
+        subject: subject(rawSender),
+        conversation: { kind: "group", id: "room-1" },
+        routeFacts: [
+          {
+            id: "space-1",
+            kind: "route",
+            gate: "matched",
+            effect: "allow",
+            precedence: 0,
+            senderPolicy: "replace",
+            senderAllowFrom: [rawSender],
+          },
+        ],
+        allowlists: { group: ["group-sender"] },
+      }),
+    );
+
+    const decision = decideChannelIngress(state, policy);
+
+    const senderAllowlist = expectRecordFields(state.routeFacts[0]?.senderAllowlist, {
+      hasConfiguredEntries: true,
+    });
+    expectRecordFields(senderAllowlist.match, { matched: true });
+    expectRecordFields(decision, { admission: "dispatch", decision: "allow" });
+    expect(JSON.stringify(state)).not.toContain(rawSender);
+    expect(JSON.stringify(decision)).not.toContain(rawSender);
+  });
+
+  it("blocks matched routes with deny-when-empty sender policy", async () => {
+    const state = await resolveChannelIngressState(
+      baseInput({
+        routeFacts: [
+          {
+            id: "space-1",
+            kind: "route",
+            gate: "matched",
+            effect: "allow",
+            precedence: 0,
+            senderPolicy: "deny-when-empty",
+            senderAllowFrom: [],
+          },
+        ],
+        allowlists: { dm: ["sender-1"] },
+      }),
+    );
+
+    expectRecordFields(decideChannelIngress(state, policy), {
+      admission: "drop",
+      reasonCode: "route_sender_empty",
+    });
+    expect(state.routeFacts[0]).not.toHaveProperty("senderAllowFrom");
+  });
+
+  it.each([
+    {
+      name: "allows origin-subject events for the same normalized actor",
+      adapter,
+      current: "sender-1",
+      origin: "sender-1",
+      matched: true,
+      expected: { admission: "dispatch", decision: "allow" },
+    },
+    {
+      name: "does not authorize by default opaque identifier slots",
+      adapter,
+      current: "sender-1",
+      origin: "different-sender",
+      matched: false,
+      expected: { admission: "drop", decision: "block", reasonCode: "origin_subject_not_matched" },
+    },
+    {
+      name: "uses adapter-normalized identity values",
+      adapter: lowerCaseAdapter,
+      current: "Sender-1",
+      origin: "sender-1",
+      matched: true,
+      expected: { admission: "dispatch", decision: "allow" },
+    },
+  ])("$name", async (entry) => {
+    const state = await resolveChannelIngressState(
+      baseInput({
+        adapter: entry.adapter,
+        subject: subject(entry.current),
+        event: {
+          kind: "reaction",
+          authMode: "origin-subject",
+          mayPair: false,
+          originSubject: subject(entry.origin),
+        },
+      }),
+    );
+    const decision = decideChannelIngress(state, policy);
+
+    expect(state.event.originSubjectMatched).toBe(entry.matched);
+    expectRecordFields(decision, entry.expected);
+    if (entry.matched) {
+      const gate = decision.graph.gates.find(
+        (gateLocal) => gateLocal.phase === "sender" && gateLocal.kind === "dmSender",
+      );
+      expectRecordFields(gate, {
+        effect: "ignore",
+        reasonCode: "sender_not_required",
+      });
+    }
+  });
+});

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -7,6 +7,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "@remoteclaw/normalization-core/string-normalization";
+import { readAccessGroupMembers } from "../access-group-members.js";
 import { parseAccessGroupAllowFromEntry } from "../allow-from.js";
 import type {
   AccessGroupMembershipFact,
@@ -119,8 +120,8 @@ function groupSenderEntries(params: {
     return [];
   }
   return normalizeStringEntries([
-    ...(group.members["*"] ?? []),
-    ...(group.members[params.input.channelId] ?? []),
+    ...readAccessGroupMembers(group.members, "*"),
+    ...readAccessGroupMembers(group.members, params.input.channelId),
   ]);
 }
 

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -7,8 +7,17 @@ import type { AccessGroupConfig } from "../../config/types.access-groups.js";
 import type { ChatChannelId } from "../ids.js";
 import type { InboundImplicitMentionKind, InboundMentionFacts } from "../mention-gating.js";
 
-/** Channel identifier used in ingress diagnostics and config lookups. */
-export type ChannelIngressChannelId = ChatChannelId;
+/**
+ * Channel identifier used in ingress diagnostics and config lookups.
+ *
+ * Built-in chat channels are listed for autocomplete, but the ingress gate is
+ * also the contract plugin-provided channels wire into (the id only ever feeds
+ * string-keyed config, diagnostics, access-group, and pairing-store lookups —
+ * `normalizeChannelId` already accepts an arbitrary `string`). Keeping this
+ * pinned to `ChatChannelId` would force every plugin channel to cast at its
+ * ingress call site, which is the last place a cast belongs.
+ */
+export type ChannelIngressChannelId = ChatChannelId | (string & {});
 
 /** Redacted identifier category used by allowlist normalization and matching. */
 export type ChannelIngressIdentifierKind =

--- a/src/plugin-sdk/channel-core.ts
+++ b/src/plugin-sdk/channel-core.ts
@@ -31,7 +31,16 @@ import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { getChatChannelMeta, normalizeChatChannelId } from "../channels/registry.js";
 import type { RemoteClawConfig } from "../config/config.js";
 import type { ReplyToMode } from "../config/types.base.js";
+import { buildOutboundBaseSessionKey } from "../infra/outbound/base-session-key.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
+import type { OutboundSessionRoute } from "../infra/outbound/outbound-session.js";
+import { normalizeOutboundThreadId } from "../infra/outbound/thread-id.js";
+import type { RoutePeer } from "../routing/resolve-route.js";
+import { resolveThreadSessionKeys } from "../routing/session-key.js";
+import {
+  normalizeSessionKeyPreservingOpaquePeerIds,
+  parseThreadSessionSuffix,
+} from "../sessions/session-key-utils.js";
 
 function createInlineTextPairingAdapter(params: {
   idLabel: string;
@@ -306,6 +315,145 @@ export function createChatChannelPlugin<
     ...(params.threading ? { threading: resolveChatChannelThreading(params.threading) } : {}),
     ...(params.outbound ? { outbound: resolveChatChannelOutbound(params.outbound) } : {}),
   } as ChannelPlugin<TResolvedAccount, Probe, Audit>;
+}
+
+// --- Outbound session-route builders -------------------------------------
+//
+// Also carved from upstream `src/plugin-sdk/core.ts`: the two helpers a chat
+// channel's `messaging.resolveOutboundSessionRoute` hook composes. Every
+// dependency already exists in the fork (`buildOutboundBaseSessionKey`,
+// `resolveThreadSessionKeys`, `parseThreadSessionSuffix`,
+// `normalizeSessionKeyPreservingOpaquePeerIds`, `normalizeOutboundThreadId`);
+// only the two composing wrappers were missing.
+
+/**
+ * Builds the canonical outbound session route payload returned by a channel's
+ * `messaging.resolveOutboundSessionRoute` hook.
+ */
+export function buildChannelOutboundSessionRoute(params: {
+  cfg: RemoteClawConfig;
+  agentId: string;
+  channel: string;
+  accountId?: string | null;
+  peer: RoutePeer;
+  chatType: OutboundSessionRoute["chatType"];
+  from: string;
+  to: string;
+  threadId?: string | number;
+}): OutboundSessionRoute {
+  const baseSessionKey = buildOutboundBaseSessionKey({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: params.channel,
+    accountId: params.accountId,
+    peer: params.peer,
+  });
+  return {
+    sessionKey: baseSessionKey,
+    baseSessionKey,
+    peer: params.peer,
+    chatType: params.chatType,
+    from: params.from,
+    to: params.to,
+    ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
+  };
+}
+
+/** Candidate source used when choosing a thread id for outbound session routing. */
+export type ThreadAwareOutboundSessionRouteThreadSource =
+  | "replyToId"
+  | "threadId"
+  | "currentSession";
+
+/** Recovery context passed before reusing the current session's thread id. */
+export type ThreadAwareOutboundSessionRouteRecoveryContext = {
+  route: OutboundSessionRoute;
+  currentBaseSessionKey: string;
+  currentThreadId: string;
+};
+
+/** Recovers the current thread id when the current session shares this base route. */
+// Internal to the thread-aware route builder below. Upstream exports this, but
+// the fork keeps unconsumed surface unexported — the same posture the bundled
+// channel plugins document when they drop upstream fields they cannot back.
+function recoverCurrentThreadSessionId(params: {
+  route: OutboundSessionRoute;
+  currentSessionKey?: string | null;
+  canRecover?: (context: ThreadAwareOutboundSessionRouteRecoveryContext) => boolean;
+}): string | undefined {
+  const current = parseThreadSessionSuffix(params.currentSessionKey);
+  if (!current.baseSessionKey || !current.threadId) {
+    return undefined;
+  }
+  if (
+    normalizeSessionKeyPreservingOpaquePeerIds(current.baseSessionKey) !==
+    normalizeSessionKeyPreservingOpaquePeerIds(params.route.baseSessionKey)
+  ) {
+    return undefined;
+  }
+  const context = {
+    route: params.route,
+    currentBaseSessionKey: current.baseSessionKey,
+    currentThreadId: current.threadId,
+  };
+  if (params.canRecover && !params.canRecover(context)) {
+    return undefined;
+  }
+  return current.threadId;
+}
+
+function resolveThreadAwareOutboundCandidate(
+  threadId?: string | number | null,
+): { routeThreadId: string | number; sessionThreadId: string } | undefined {
+  const sessionThreadId = normalizeOutboundThreadId(threadId);
+  if (sessionThreadId === undefined) {
+    return undefined;
+  }
+  return {
+    routeThreadId: typeof threadId === "number" ? threadId : sessionThreadId,
+    sessionThreadId,
+  };
+}
+
+/** Adds thread-aware session keys and route thread ids to an outbound channel route. */
+export function buildThreadAwareOutboundSessionRoute(params: {
+  route: OutboundSessionRoute;
+  replyToId?: string | number | null;
+  threadId?: string | number | null;
+  currentSessionKey?: string | null;
+  precedence?: readonly ThreadAwareOutboundSessionRouteThreadSource[];
+  useSuffix?: boolean;
+  parentSessionKey?: string;
+  normalizeThreadId?: (threadId: string) => string;
+  canRecoverCurrentThread?: (context: ThreadAwareOutboundSessionRouteRecoveryContext) => boolean;
+}): OutboundSessionRoute {
+  const recoveredThreadId = recoverCurrentThreadSessionId({
+    route: params.route,
+    currentSessionKey: params.currentSessionKey,
+    canRecover: params.canRecoverCurrentThread,
+  });
+  const candidates: Record<
+    ThreadAwareOutboundSessionRouteThreadSource,
+    { routeThreadId: string | number; sessionThreadId: string } | undefined
+  > = {
+    replyToId: resolveThreadAwareOutboundCandidate(params.replyToId),
+    threadId: resolveThreadAwareOutboundCandidate(params.threadId),
+    currentSession: resolveThreadAwareOutboundCandidate(recoveredThreadId),
+  };
+  const precedence = params.precedence ?? ["replyToId", "threadId", "currentSession"];
+  const candidate = precedence.map((source) => candidates[source]).find(Boolean);
+  const threadKeys = resolveThreadSessionKeys({
+    baseSessionKey: params.route.baseSessionKey,
+    threadId: candidate?.sessionThreadId,
+    parentSessionKey: candidate ? params.parentSessionKey : undefined,
+    useSuffix: params.useSuffix,
+    normalizeThreadId: params.normalizeThreadId,
+  });
+  return {
+    ...params.route,
+    sessionKey: threadKeys.sessionKey,
+    ...(candidate !== undefined ? { threadId: candidate.routeThreadId } : {}),
+  };
 }
 
 // Shared base object for channel plugins that only need to override a few optional surfaces.

--- a/src/plugin-sdk/clickclack.ts
+++ b/src/plugin-sdk/clickclack.ts
@@ -1,0 +1,42 @@
+// Narrow plugin-sdk surface for the bundled clickclack plugin.
+// Keep this list additive and scoped to symbols used under extensions/clickclack.
+
+export {
+  createAccountListHelpers,
+  hasConfiguredAccountValue,
+  resolveMergedAccountConfig,
+} from "../channels/plugins/account-helpers.js";
+export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export type { ChannelGatewayContext } from "../channels/plugins/types.adapters.js";
+export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+export {
+  resolveStableChannelMessageIngress,
+  type StableChannelIngressIdentityParams,
+} from "../channels/message-access/index.js";
+export type { RemoteClawConfig } from "../config/config.js";
+export {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+  resolveSecretInputString,
+} from "../config/types.secrets.js";
+export { dispatchInboundReplyWithBase } from "./inbound-reply-dispatch.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { RemoteClawPluginApi } from "../plugins/types.js";
+export { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+export { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+export {
+  buildChannelOutboundSessionRoute,
+  buildThreadAwareOutboundSessionRoute,
+  createChatChannelPlugin,
+} from "./channel-core.js";
+// `src/infra/numeric-options.ts` narrows the shared helper to `{ min }` only;
+// clickclack's reconnect interval needs the `{ min, max }` form, so re-export
+// the normalization-core original rather than widening the infra facade.
+export { resolveIntegerOption } from "../../packages/normalization-core/src/number-coercion.js";
+export { buildSecretInputSchema } from "./secret-input-schema.js";
+export {
+  buildComputedAccountStatusSnapshot,
+  createDefaultChannelRuntimeState,
+} from "./status-helpers.js";
+export { normalizeOptionalString } from "./string-coerce-runtime.js";
+export { createPluginRuntimeStore, type PluginRuntime } from "./runtime-store.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 const bundledExtensionSubpathLoaders = [
   { id: "acpx", load: () => import("remoteclaw/plugin-sdk/acpx") },
   { id: "bluebubbles", load: () => import("remoteclaw/plugin-sdk/bluebubbles") },
+  { id: "clickclack", load: () => import("remoteclaw/plugin-sdk/clickclack") },
   { id: "copilot-proxy", load: () => import("remoteclaw/plugin-sdk/copilot-proxy") },
   { id: "device-pair", load: () => import("remoteclaw/plugin-sdk/device-pair") },
   { id: "diagnostics-otel", load: () => import("remoteclaw/plugin-sdk/diagnostics-otel") },

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -37,6 +37,7 @@
     "src/plugin-sdk/string-coerce-runtime.ts",
     "src/plugin-sdk/acpx.ts",
     "src/plugin-sdk/bluebubbles.ts",
+    "src/plugin-sdk/clickclack.ts",
     "src/plugin-sdk/copilot-proxy.ts",
     "src/plugin-sdk/device-pair.ts",
     "src/plugin-sdk/diagnostics-otel.ts",


### PR DESCRIPTION
Closes #2861.

Ports the upstream `clickclack` channel adapter onto the fork's
`createChatChannelPlugin` factory. The channel plumbing is a straight port; the
real work is rewiring ~17 `openclaw/plugin-sdk/*` imports onto this repo's
plugin-sdk decomposition through a new narrow `remoteclaw/plugin-sdk/clickclack`
surface (registered at the 6 usual wiring sites). No module needed a local shim.

## ⚠️ Do not merge without the independent security review

This is kept-surface channel ingress handling untrusted inbound. Two items are
flagged explicitly for that review:

1. **Network posture (unchanged from upstream, deliberate).** `http-client.ts`
   talks directly to the operator-configured `baseUrl` over HTTP + WebSocket
   rather than routing through the fork's SSRF dispatcher. `baseUrl` is trusted
   local config, never a value taken from inbound traffic. This PR makes the
   exception *auditable*: the call is spelled as a direct `fetch` so
   `check-no-raw-channel-fetch.mjs` can see the callsite, and it is registered in
   that gate's allowlist with a rationale. Previously an aliased `fetcher`
   binding hid it from the gate entirely.
2. **`ChannelIngressChannelId` widening** — see below.

## Security conformance (both #2861 points)

- **Hardcoded admission allowlist preserved.** `dmPolicy` / `groupPolicy` are
  literal `"allowlist"` in `extensions/clickclack/src/access.ts`; the adapter
  never reads them from config, and `config-schema.ts` is `.strict()`, so an
  operator cannot widen this channel to an open policy.
- **`admission=dispatch` honored before `commandAuthorized`.** `shouldDispatch`
  derives from `ingress.admission === "dispatch"` and short-circuits at two
  independent layers (`gateway.ts` before `handleClickClackInbound`, and again in
  `inbound.ts` before any routing/session/envelope work).

Both are **mutation-proven**, not just asserted: flipping either policy literal,
or the admission ordering, fails the suite. That mattered — the DM half was
originally covered by outcome-only assertions that a `dmPolicy: "open"` mutation
slipped straight through (absent a pairing store, open/pairing/allowlist produce
identical results for those inputs). It is now pinned at the seam and on the
resolved gate's `sender.policy`.

## Forced divergences from upstream

Each documented at its call site:

| Dropped | Why |
|---|---|
| `replyMode: "model"` branch | This fork's `PluginRuntime` ships no `llm` surface — CLI runtimes own model execution. Every admitted message routes through the standard agent pipeline. |
| `message` ChannelMessageAdapter | `ChannelPlugin` has no `message` field here, nothing reads it, and the name collides with an unrelated fork type. Outbound is served by `outbound.attachedResults.sendText`. |
| `toolsAllow` | No fork counterpart. Also removed from the `.strict()` schema, so a stale key is a hard error rather than a setting that appears to restrict tools but does not. |

`timeoutSeconds` goes the other way — upstream declared but never consumed it;
here it is wired to the reply dispatcher's `timeoutOverrideSeconds`.

## Supporting changes outside the extension

- **`ChannelIngressChannelId` widened** to `ChatChannelId | (string & {})` so
  plugin channels need no cast at their ingress call site. This *restores*
  upstream's own contract — upstream `ChatChannelId` is `string`; the fork
  narrowed it to a 9-literal union when gutting the dynamic catalog. All 13
  references are inside `src/channels/message-access/`, and the only
  security-relevant sink (the pairing store, via `as PairingChannel`) is
  unreachable here: it needs `useDefaultPairingStore`, which clickclack does not
  set, and `safeChannelKey()` sanitizes the value before it becomes a path.
- **Prototype-key hardening.** `group.members[channelId]` with a key like
  `__proto__` resolved to an `Object.prototype` value — truthy, so `??` never
  fired, and spreading it threw. Now routed through a shared
  `readAccessGroupMembers` own-key helper used by **both** the ingress kernel and
  `allow-from.ts`, which were documented mirrors that had silently diverged.
- **Route helpers carved** into `plugin-sdk/channel-core.ts`, where upstream also
  keeps them and which this repo already designates as the home for such carves.
- **`message-access.test.ts` restored from upstream.** That module had *zero*
  tests in this fork — a cardinality-zero gate on the code this PR widens. Ported
  verbatim (8 tests, no edits needed); its `channelId: "test"` exercises the
  widened arbitrary-string case directly. Fork-owned coverage for the new own-key
  guard lives in a separate file so the port stays byte-identical for re-sync.

## Verification

| Gate | Result |
|---|---|
| `pnpm check` | ✅ |
| `pnpm build` | ✅ |
| `pnpm release:check` | ✅ |
| extensions lane (full `vitest.extensions.config.ts`) | ✅ 500 files, 4792 passed / 31 skipped |
| clickclack suite | ✅ 5 files, 28 tests |
| `src/channels` + `src/plugin-sdk` + `package-manager-config` | ✅ 95 files, 825 tests |
| rebrand / zombie-import / stub-debt / obsolescence / throwing-stub / attestations / policy-doctor-boundary | ✅ |

The rebrand gate was canary-tested (a planted `openclaw` token fails it) rather
than trusted on a green exit — it reports a pass on an empty file set.

## Pre-existing defects found, deliberately not fixed here

- `scripts/check-plugin-sdk-exports.mjs:150` throws `ReferenceError:
  requiredSubpathExports is not defined` (identical at `main`), so the
  `clickclack` entry added at :57 is never exercised by it. **This PR's wiring is
  still verified** by two gates that do run — `src/plugin-sdk/subpaths.test.ts`
  performs a real dynamic `import("remoteclaw/plugin-sdk/clickclack")`, and
  `release:check` validates the built artifacts. Fixing the script risks turning a
  silent script red across ~40 unrelated subpaths; it wants its own issue.
- `scripts/check-docs-mdx.mjs` crashes (`ERR_MODULE_NOT_FOUND`).
- `check-no-raw-channel-fetch.mjs` is wired into no CI job and no pnpm script.
- `.fork-boundary-mock-baseline` is stale (129 < baseline 139).

Not ported: the upstream e2e fixture (`scripts/e2e/lib/release-user-journey/`
does not exist here) and the per-channel vitest shard config (the fork's CI lane
globs `extensions/**/*.test.ts`, so clickclack already runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
