### PR TITLE
fix(clickclack): default allowFrom to [] for fail-closed admission (#3054)

### DIFF
--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -44,6 +44,9 @@ Configure RemoteClaw:
 }
 ```
 
+`allowFrom` is required, not optional: it defaults to `[]` and an empty
+allowlist admits nobody. See [Access control](#access-control).
+
 Then run:
 
 ```bash
@@ -67,15 +70,36 @@ dropped before the message reaches the agent pipeline. There is no open-policy
 mode for this channel — the adapter pins its DM and group policies rather than
 reading them from config.
 
-Allowlist entries may be written as a bare user id or with a provider/DM prefix;
-all four forms below resolve to the same user:
+### ClickClack admits nobody until you set `allowFrom`
+
+`allowFrom` defaults to `[]`, and an empty allowlist means **deny-all — not
+allow-all**. An account with no `allowFrom` accepts no inbound message from
+anyone, and the bot will appear to ignore everything it receives.
+
+ClickClack has no guided onboarding flow. Selecting it in `remoteclaw onboard`
+enables the plugin, but the wizard then reports that this channel "does not
+support onboarding yet" and writes nothing under `channels.clickclack`. Every
+ClickClack channel config is written by hand, so **you must always set
+`allowFrom` yourself**, once per account: each account carries its own
+allowlist, and an account you add to `channels.clickclack.accounts` without one
+admits nobody.
+
+This is the intended fail-closed posture, and a deliberate RemoteClaw divergence
+from upstream OpenClaw, which defaults to `["*"]`.
+
+### Allowlist entries
+
+Entries may be written as a bare user id or with a provider/DM prefix; all four
+forms below resolve to the same user:
 
 ```json5
 allowFrom: ["usr_123", "clickclack:usr_123", "cc:usr_123", "dm:usr_123"]
 ```
 
-Use `["*"]` to admit every workspace member. Command authorization is evaluated
-only for senders that were already admitted — it never widens admission.
+Set `["*"]` explicitly to admit every workspace member — that opt-in still
+works, it is simply no longer what you get by default. Command authorization is
+evaluated only for senders that were already admitted — it never widens
+admission.
 
 ## Multiple bots
 
@@ -166,5 +190,5 @@ you control.
 
 - `ClickClack is not configured`: set `channels.clickclack.token` or `CLICKCLACK_BOT_TOKEN`.
 - `workspace not found`: set `workspace` to the workspace id or slug returned by ClickClack.
-- No inbound replies: confirm the sender is in `allowFrom`, the token has realtime read access, and the bot is not replying to its own messages.
+- No inbound replies: confirm `allowFrom` is set at all — it defaults to `[]`, which admits nobody — and that the sender is in it. Then check the token has realtime read access and the bot is not replying to its own messages.
 - Channel sends fail: verify the bot is a member of the workspace and has `bot:write`.

--- a/extensions/clickclack/src/access.test.ts
+++ b/extensions/clickclack/src/access.test.ts
@@ -10,6 +10,16 @@
 //  2. `shouldDispatch` derives from `ingress.admission === "dispatch"`, and
 //     admission is decided ahead of command authorization — a refused sender
 //     never becomes dispatchable by virtue of the command gate.
+//
+// A third point, added for #3054, closes the gap those two left open. Point 1
+// pins the admission MODE; it says nothing about the LIST that mode consults.
+// `allowFrom` is that list, and it now defaults to `[]`:
+//
+//  3. An account the operator never configured refuses EVERY sender, rather
+//     than admitting the whole workspace. Point 1 therefore holds for the
+//     SHIPPED DEFAULT, not merely for a fixture that happens to carry a list.
+//     Deliberate fork divergence from upstream OpenClaw, which defaults
+//     `["*"]` (open).
 import {
   type PluginRuntime,
   resolveStableChannelMessageIngress,
@@ -17,6 +27,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginRuntimeMock } from "../../test-utils/plugin-runtime-mock.js";
 import { resolveClickClackInboundAccess } from "./access.js";
+import { resolveClickClackAccount } from "./accounts.js";
 import { setClickClackRuntime } from "./runtime.js";
 import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
@@ -220,7 +231,49 @@ describe("ClickClack ingress admission (hardcoded allowlist policy)", () => {
     }
   });
 
+  it("refuses every sender for an account with no configured allowFrom (fail-closed default)", async () => {
+    // The SHIPPED default, exercised end-to-end. Every other case in this file
+    // hands `resolveClickClackInboundAccess` a hand-built `createAccount()`
+    // fixture carrying an explicit list, so the value `accounts.ts` actually
+    // resolves never reached the admission path — which is exactly how an open
+    // `["*"]` default sat under a green suite until #3054. Build the account
+    // through the real normalization instead, and assert the consequence.
+    setClickClackRuntime(createRuntime({ commandRequested: false }));
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          token: "ccb_default",
+          workspace: "wsp_1",
+        },
+      },
+    } satisfies CoreConfig;
+    const account = resolveClickClackAccount({ cfg });
+
+    // Asserted here as well as in accounts.test.ts so a revert to `["*"]`
+    // reports as "the default changed" rather than "the gate stopped working".
+    expect(account.allowFrom).toEqual([]);
+
+    const direct = await resolveClickClackInboundAccess({
+      account,
+      config: cfg,
+      message: directMessage("usr_anyone"),
+    });
+    const group = await resolveClickClackInboundAccess({
+      account,
+      config: cfg,
+      message: groupMessage("usr_anyone"),
+    });
+
+    expect(direct.shouldDispatch).toBe(false);
+    expect(group.shouldDispatch).toBe(false);
+  });
+
   it("keeps a wildcard allowFrom entry working for both conversation kinds", async () => {
+    // An operator who writes `["*"]` explicitly still opts into open admission.
+    // The fail-closed default is about the ABSENT-config case, not about
+    // removing the wildcard, so this stays valid behavior.
     setClickClackRuntime(createRuntime({ commandRequested: false }));
     const account = createAccount({ allowFrom: ["*"], config: { allowFrom: ["*"] } });
 

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -5,6 +5,7 @@ import {
   resolveClickClackAccount,
   resolveDefaultClickClackAccountId,
 } from "./accounts.js";
+import { clickClackPlugin } from "./channel.js";
 import type { CoreConfig } from "./types.js";
 
 describe("ClickClack account resolution", () => {
@@ -91,11 +92,12 @@ describe("ClickClack account resolution", () => {
         env: { CLICKCLACK_SERVICE_TOKEN: "  ccb_live  " },
       }),
     ).toEqual({
-      allowFrom: ["*"],
+      // Fail-closed default (#3054) — see the divergence note in accounts.ts.
+      allowFrom: [],
       accountId: "service",
       baseUrl: "https://app.clickclack.chat",
       config: {
-        allowFrom: ["*"],
+        allowFrom: [],
         baseUrl: "https://app.clickclack.chat",
         enabled: true,
         token: { source: "env", provider: "default", id: "CLICKCLACK_SERVICE_TOKEN" },
@@ -133,13 +135,13 @@ describe("ClickClack account resolution", () => {
     } satisfies CoreConfig;
 
     expect(resolveClickClackAccount({ cfg, accountId: "peter" })).toEqual({
-      allowFrom: ["*"],
+      allowFrom: [],
       accountId: "peter",
       agentId: "peter-bot",
       baseUrl: "https://app.clickclack.chat",
       config: {
         agentId: "peter-bot",
-        allowFrom: ["*"],
+        allowFrom: [],
         baseUrl: "https://app.clickclack.chat",
         enabled: true,
         timeoutSeconds: 120,
@@ -154,6 +156,25 @@ describe("ClickClack account resolution", () => {
       token: "ccb_peter",
       workspace: "wsp_1",
     });
+  });
+
+  it("exposes the fail-closed default through the channel plugin's resolveAllowFrom seam", () => {
+    // `channel.ts` re-exports the allowlist to the plugin host through its own
+    // accessor. The admission tests call `resolveClickClackAccount` directly, so
+    // a wildcard coalesce reintroduced AT THE SEAM would leave every other test
+    // green while handing the host an open allowlist. Pin the seam too (#3054).
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          token: "ccb_default",
+          workspace: "wsp_1",
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(clickClackPlugin.config.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([]);
   });
 
   it("normalizes reconnect intervals to the public config bounds", () => {

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -141,6 +141,19 @@ export function resolveClickClackAccount(params: {
     env: params.env,
   });
   const workspace = merged.workspace?.trim() ?? "";
+  // Fail closed: an account with no configured `allowFrom` admits NO senders.
+  //
+  // Deliberate divergence from upstream OpenClaw, which defaults `["*"]`.
+  // That default is open admission, not a permissive per-sender filter on top
+  // of a separate gate: `access.ts` hands this exact value to
+  // `resolveStableChannelMessageIngress` as the allowlist for its hardcoded
+  // `dmPolicy`/`groupPolicy: "allowlist"`, and a `"*"` entry matches any
+  // subject — so an unconfigured account would admit every workspace member.
+  // The shared ingress kernel likewise coalesces an absent list to `[]`
+  // (`message-access/runtime.ts`).
+  //
+  // Do NOT restore the wildcard during an upstream sync (#3054).
+  const allowFrom = merged.allowFrom ?? [];
   return {
     accountId,
     enabled,
@@ -153,14 +166,14 @@ export function resolveClickClackAccount(params: {
     agentId: normalizeOptionalString(merged.agentId),
     timeoutSeconds: merged.timeoutSeconds,
     defaultTo: merged.defaultTo?.trim() || "channel:general",
-    allowFrom: merged.allowFrom ?? ["*"],
+    allowFrom,
     reconnectMs: resolveIntegerOption(merged.reconnectMs, DEFAULT_RECONNECT_MS, {
       min: MIN_RECONNECT_MS,
       max: MAX_RECONNECT_MS,
     }),
     config: {
       ...merged,
-      allowFrom: merged.allowFrom ?? ["*"],
+      allowFrom,
     },
   };
 }


### PR DESCRIPTION
Closes #3054.

## The finding

`extensions/clickclack/src/accounts.ts` defaulted each account's `allowFrom` to `["*"]`,
byte-identical to upstream OpenClaw.

#3054 was filed as a *posture question* on the premise that this default was benign — that
`dmPolicy`/`groupPolicy: "allowlist"` is a separate admission gate which `allowFrom` does not
widen, so `["*"]` only made a per-sender *filter* permissive. **That premise is false**, and the
issue should be read with that correction in mind.

`allowFrom` IS the allowlist that the hardcoded `"allowlist"` mode consults. Verified against
source:

| Evidence | Location |
|---|---|
| The same call receives `allowFrom` **and** `dmPolicy`/`groupPolicy: "allowlist"`, and `shouldDispatch` derives from `ingress.admission` | `extensions/clickclack/src/access.ts` |
| The passed list becomes the DM allowlist | `src/channels/message-access/runtime.ts` (`allowlists.dm = rawAllowFrom`) |
| A `"*"` entry matches **any** subject | `src/channels/message-access/runtime-identity.ts` |

The hardcoded `"allowlist"` is the **MODE**; `allowFrom` is the **LIST**. An enabled ClickClack
account whose operator never set `allowFrom` therefore admitted **every member of the workspace**.

The already-green test `access.test.ts` — "keeps a wildcard allowFrom entry working for both
conversation kinds" — demonstrates exactly this: an arbitrary sender is dispatched in DM *and*
group under `["*"]`.

## Why the suite never caught it

Every admission fixture hand-built its account with an explicit list (`access.test.ts` used
`["usr_owner"]`), so the shipped default never reached the ingress gate. `accounts.test.ts`
asserted `["*"]` — it *pinned* the open default rather than catching it. That is the coverage hole
closed here.

## The change

Default `allowFrom` to `[]`. An unconfigured account admits nobody until the operator opts senders
in. The `dmPolicy`/`groupPolicy: "allowlist"` mode literals are untouched — only the list default
changes.

- **`accounts.ts`** — one hoisted `const allowFrom`, consumed by both the resolved account and its
  nested `config`, so the two sites cannot drift apart. Carries the anti-revert divergence note.
- **`access.test.ts`** — new end-to-end case building the account through the real
  `resolveClickClackAccount` normalization (not a fixture) and asserting `shouldDispatch === false`
  in DM and group. Header comment gains the MODE-vs-LIST conformance point.
- **`accounts.test.ts`** — new case pinning the `channel.ts` `resolveAllowFrom` seam, a distinct
  reintroduction site the admission tests do not cover.
- **docs** — ClickClack has **no onboarding adapter**, so `allowFrom` is *always* operator-written.
  Called out under Access control, Quick setup, and Troubleshooting.

Explicitly setting `allowFrom: ["*"]` still opts into open admission — that test is retained
deliberately. This narrows only the absent-config default.

## ⚠️ Intentional divergence from upstream

**Upstream OpenClaw defaults `["*"]`; this fork now defaults `[]`.** Confirmed against
`openclaw/main` (upstream `accounts.ts` has `?? ["*"]` at both sites and upstream `access.ts`
hardcodes `"allowlist"` the same way — i.e. upstream carries the same open-admission shape).

**A content-only upstream sync must not silently restore the wildcard.** The in-code note in
`accounts.ts` says so explicitly.

Known limitation, tracked in #3058: those anti-revert markers all live inside files a wholesale
sync overwrites. A sync applying upstream's `accounts.ts` *and* `accounts.test.ts` together would
flip guard and detector in one move; the fork-authored `access.test.ts` assertion survives that
particular combination, so this is not defenseless — but it is not *structurally* guaranteed
either. The durable fix is a `scripts/` gate outside the synced tree, matching the existing
fork-integrity idiom.

## Breaking change (intended)

An operator running ClickClack **with no `allowFrom` configured** loses inbound admission on
upgrade. That is the point of the change — such a deployment was accepting messages from anyone in
the workspace. The remedy is one config line, documented in all three doc locations.

Note there is currently **no in-product signal** when a message is dropped by an empty allowlist —
tracked in #3057, with a caution that naive per-message drop logging would be a log-flooding vector
on an inbound path.

## Verification

- `extensions/clickclack` — **5 files / 30 tests pass**. Not in `vitest.quarantine.ts`, so the
  required `test-extensions` lane genuinely runs these.
- **Mutation-tested, not just green**: reverting the default to `?? ["*"]` fails 4 tests; injecting
  a wildcard coalesce *only* at the `channel.ts` seam fails exactly the new seam test. Both guards
  discriminate.
- `pnpm check` — 0 warnings, 0 errors. Docs site build (the required `docs` job) — 496 pages, and
  the new copy verified in the rendered HTML.
- All standalone fork-integrity gates pass: zombie-import, stub-debt, throwing-stub-callers,
  attestations, obsolescence-audit, policy-doctor-boundary.
- Two independent fresh-context adversarial review rounds. Round 1 caught a real docs error (an
  earlier draft claimed the onboard quickstart writes `allowFrom` — it does not; clickclack has no
  onboarding adapter, so `quickstartAllowFrom: true` is inert for it). Round 2 confirmed **no
  fail-open branch** exists on this admission path: DM blocks in `sender-gates.ts`, group blocks
  explicitly with `group_policy_empty_allowlist`, and the pairing store cannot widen under
  `"allowlist"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)