### PR TITLE
feat(outbound): quarantine ambiguous send failures and harden queue entry ids (#3051)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -437,6 +437,7 @@ export default defineConfig({
                     { slug: "gateway/heartbeat" },
                     { slug: "gateway/doctor" },
                     { slug: "gateway/logging" },
+                    { slug: "gateway/message-delivery" },
                     { slug: "gateway/gateway-lock" },
                     { slug: "gateway/background-process" },
                     { slug: "gateway/multiple-gateways" },

--- a/docs/gateway/message-delivery.md
+++ b/docs/gateway/message-delivery.md
@@ -1,0 +1,111 @@
+---
+summary: "Outbound delivery guarantees, the needs-review reconciliation queue, and what backups of it contain"
+read_when:
+  - Reasoning about duplicate or missing outbound messages
+  - Taking, restoring, or storing backups of the state directory
+  - Reconciling entries in delivery-queue/needs-review
+title: "Message delivery"
+---
+
+# Message delivery
+
+## Delivery guarantee: at-least-once
+
+RemoteClaw delivers outbound messages **at least once**.
+
+It does **not** provide exactly-once delivery, and it cannot. The acknowledgement
+that a message reached a third-party chat platform travels back over the same
+unreliable link the message went out on, so there is no bookkeeping on the
+gateway side that makes "the platform accepted it" and "we recorded that it
+accepted it" one atomic fact. That is the Two Generals problem — it is a property
+of talking to a system we do not control, not a gap a better queue closes.
+
+Practical consequences:
+
+- **A message can be delivered more than once.** Assume it, and design around it.
+- **Idempotency and de-duplication belong to the consumer and the platform.**
+  RemoteClaw does not attach an idempotency key to outbound sends, so nothing
+  downstream can collapse a duplicate on your behalf. If a workflow reacts to
+  agent output, make the reaction idempotent.
+- **The duplicate window is bounded and surfaced, not eliminated.** The gateway
+  narrows it in two places and makes what survives visible rather than silent:
+  - a per-entry in-flight marker means a process that dies mid-send does not
+    blind-replay on the next start;
+  - a send that fails ambiguously — a timeout, a reset, a 5xx after the request
+    reached the transport — is not retried either, because "we got no result" is
+    not "nothing arrived".
+
+  In both cases the entry is moved to a quarantine directory for a human instead
+  of being re-sent. Failures that provably did **not** reach the recipient (the
+  connection was refused, the name did not resolve, the platform rejected the
+  chat outright, or the send never started) still retry normally.
+
+  A residual window remains. The clearest example: the in-flight marker is
+  written with an atomic rename but is not flushed to stable storage, so a power
+  loss can take the marker with it and a post-reboot recovery pass has nothing
+  left to refuse.
+
+## The `needs-review` reconciliation queue
+
+Entries whose delivery outcome cannot be determined are moved to:
+
+```text
+$REMOTECLAW_STATE_DIR/delivery-queue/needs-review/<id>.json
+```
+
+They are **never retried automatically**. Every recovery pass — that is, every
+gateway start — logs the standing backlog, so quarantined mail stays visible long
+after the start that quarantined it.
+
+To reconcile one:
+
+1. Open the entry and read `to`, `payloads`, and `platformSendStartedAt`.
+2. Check the recipient's message history around that time.
+   `deliveredBeforeFailure`, when present, tells you how many message parts were
+   confirmed sent before the failure — the rest are the ones in question. When it
+   is absent, nothing was confirmed either way.
+3. If the message arrived, delete the file.
+4. If it did not and you want it sent, move the file back into
+   `delivery-queue/`, set its `recoveryState` to `null` and its `retryCount` to
+   `0`, then restart the gateway. Recovery only runs at startup; leaving
+   `recoveryState` set only re-quarantines the entry, and leaving `retryCount` at
+   its current value can file it under `failed/` without sending.
+
+Prune reconciled entries. Nothing expires them for you, and § Backups below is
+the reason that matters.
+
+## Backups contain undelivered message content
+
+<Warning>
+  **`delivery-queue/needs-review/` holds message payloads, and it is included in
+  backups.** Treat any backup of the state directory as carrying message content
+  at full sensitivity — recipient identifiers and message bodies, in cleartext.
+</Warning>
+
+The rest of the delivery queue is filtered out of backups as volatile: it churns
+during a live backup and has no restoration value. `needs-review/` is
+deliberately carved out of that filter, because it is the opposite kind of data —
+terminal, unique, and the operator's only record that a message's outcome is
+undetermined. Dropping it on restore would silently erase a to-do list.
+
+That carve-out has a cost worth stating plainly: **backups travel further than
+live state.** They go off-box, to object storage or another operator's laptop,
+and they are retained long after the entry they contain was reconciled. Live
+state sits in a `0700` directory on one host under one trust boundary; a backup
+does not.
+
+So:
+
+- Hold backups of the state directory to the same standard as message
+  transcripts, not to the standard of configuration. Encrypt them at rest, and
+  keep the retention window as short as your recovery objective allows.
+- **Reconcile and prune `needs-review/` on a schedule.** An entry deleted before
+  the next backup never enters the backup chain at all — this is the cheapest
+  control available, and it is the same hygiene the queue already asks for.
+- If you need to share a backup for support or diagnostics, remove
+  `delivery-queue/needs-review/` first. Nothing in it is needed to reproduce a
+  configuration problem.
+
+Related: [Security](/gateway/security) for the on-disk trust boundary and
+filesystem permissions, and [Logging](/gateway/logging) for redaction and
+retention of the log surfaces that reference these entries.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -435,6 +435,21 @@ This is required for session continuity and (optionally) session memory indexing
 boundary and lock down permissions on `~/.remoteclaw` (see the audit section below). If you need
 stronger isolation between agents, run them under separate OS users or separate hosts.
 
+## Undelivered messages live on disk — and in backups
+
+Outbound messages whose delivery outcome could not be determined are quarantined to
+`~/.remoteclaw/delivery-queue/needs-review/*.json` for an operator to reconcile by hand. Those
+files contain the **full message payload and the recipient identifier**, in cleartext.
+
+Unlike the rest of the delivery queue, `needs-review/` is deliberately **not** filtered out of
+backups — it is the operator's only record that a message's outcome is undetermined, and dropping
+it on restore would erase that silently. The trade-off is that backups travel further than live
+state: off-box, and retained long after the entry was reconciled. Treat a backup of the state
+directory as carrying message content at full sensitivity, and reconcile/prune `needs-review/` on
+a schedule so entries do not accumulate into the backup chain.
+
+Details, including how to reconcile an entry: [Message delivery](/gateway/message-delivery).
+
 ## Node execution (system.run)
 
 If a macOS node is paired, the Gateway can invoke `system.run` on that node. This is **remote code execution** on the Mac:

--- a/src/infra/backup-volatile-filter.ts
+++ b/src/infra/backup-volatile-filter.ts
@@ -119,6 +119,15 @@ export function isVolatileBackupPath(absolutePath: string, plan: VolatileFilterP
       // restore loses the operator's to-do list with no trace it existed.
       // ("awaiting review", not "pending" — in the queue's own vocabulary a
       // pending entry is one still queued to send, the opposite of this.)
+      //
+      // Sensitivity note: these entries carry the undelivered message PAYLOAD
+      // and the recipient identifier, so this carve-out puts message content
+      // into every backup — and backups travel off-box with long retention,
+      // unlike the 0700 live state dir. That trade is deliberate and documented
+      // for operators in `docs/gateway/message-delivery.md` § Backups contain
+      // undelivered message content, which is also where the reconcile/prune
+      // expectation that keeps the exposure bounded lives. Narrowing this
+      // carve-out means re-reading that page, not just this comment.
       const needsReviewRoot = path.posix.join(stateDirPosix, "delivery-queue", "needs-review");
       const isAwaitingReview = isUnder(filePosix, needsReviewRoot);
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -32,6 +32,7 @@ const queueMocks = vi.hoisted(() => ({
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
   failPartialDelivery: vi.fn(async () => {}),
+  failUnknownDelivery: vi.fn(async () => {}),
   markDeliveryAttemptStarted: vi.fn(async () => {}),
   withActiveDeliveryClaim: vi.fn<
     (
@@ -65,6 +66,7 @@ vi.mock("./delivery-queue.js", () => ({
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
   failPartialDelivery: queueMocks.failPartialDelivery,
+  failUnknownDelivery: queueMocks.failUnknownDelivery,
   markDeliveryAttemptStarted: queueMocks.markDeliveryAttemptStarted,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
 }));
@@ -227,6 +229,8 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.failDelivery.mockResolvedValue(undefined);
     queueMocks.failPartialDelivery.mockClear();
     queueMocks.failPartialDelivery.mockResolvedValue(undefined);
+    queueMocks.failUnknownDelivery.mockClear();
+    queueMocks.failUnknownDelivery.mockResolvedValue(undefined);
     queueMocks.markDeliveryAttemptStarted.mockClear();
     queueMocks.markDeliveryAttemptStarted.mockResolvedValue(undefined);
     queueMocks.withActiveDeliveryClaim.mockClear();
@@ -843,10 +847,11 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("records a bestEffort failure where NOTHING landed as a plain, replayable failure", async () => {
-    // "onError fired" is not "something landed". Quarantining a send that never
-    // reached the recipient turns a routine transient failure into a permanent
-    // manual-reconciliation item that is never delivered.
+  it("records a bestEffort failure where NOTHING landed as an unknown outcome", async () => {
+    // "onError fired" is not "nothing landed" either: `network blip` reached the
+    // transport and told us nothing about what the platform did with it. It is
+    // recorded as an unknown outcome — NOT as a partial delivery (no landed
+    // count is known) and NOT as a plain replayable failure (#3051 item 1).
     const sendWhatsApp = vi.fn().mockRejectedValue(new Error("network blip"));
     const onError = vi.fn();
 
@@ -863,8 +868,33 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([]);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(queueMocks.failPartialDelivery).not.toHaveBeenCalled();
-    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("network blip"),
+    );
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+  });
+
+  it("classifies a bestEffort failure from the error OBJECT, not just its message", async () => {
+    // The bestEffort path only kept `describeDeliveryError(err)` — a string, with
+    // the errno already thrown away. A refused connection reported through
+    // onError has to stay replayable, so the raw error has to survive to the
+    // classifier.
+    const refused = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const sendWhatsApp = vi.fn().mockRejectedValue(refused);
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+    });
+
+    expect(queueMocks.failUnknownDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
   });
 
   it("records a bestEffort failure even when the caller supplies no onError", async () => {
@@ -886,7 +916,10 @@ describe("deliverOutboundPayloads", () => {
 
     expect(results).toEqual([]);
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
-    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.any(String),
+    );
   });
 
   it("still forwards to a caller-supplied onError while tracking the failure itself", async () => {
@@ -971,9 +1004,11 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("records a first-chunk failure as a plain, replayable failure", async () => {
-    // Nothing landed, so the entry must stay on the normal retry path rather
-    // than being quarantined for a human.
+  it("records a first-chunk failure as an unknown outcome, not a replayable one", async () => {
+    // Nothing was OBSERVED to land, which is weaker than "nothing landed": the
+    // request reached the transport and the platform's answer never came back.
+    // Replaying it is how the recipient gets the message twice, so it is
+    // surfaced for review instead (#3051 item 1).
     const sendWhatsApp = vi.fn().mockRejectedValue(new Error("rate limited"));
 
     await expect(
@@ -987,10 +1022,237 @@ describe("deliverOutboundPayloads", () => {
     ).rejects.toThrow("rate limited");
 
     expect(queueMocks.failPartialDelivery).not.toHaveBeenCalled();
-    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
       "mock-queue-id",
       expect.stringContaining("rate limited"),
     );
+  });
+
+  it("keeps a refused connection on the normal retry path", async () => {
+    // The connection was never established, so no byte of the request was
+    // written and a replay cannot duplicate. Quarantining this would put routine
+    // transient outages into the operator's manual-reconciliation queue.
+    const sendWhatsApp = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:443"), { code: "ECONNREFUSED" }),
+      );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: whatsappSplitsIntoTwoChunksConfig,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: TWO_CHUNK_TEXT }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("ECONNREFUSED");
+
+    expect(queueMocks.failUnknownDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("ECONNREFUSED"),
+    );
+  });
+
+  it("keeps a platform rejection on the normal retry path", async () => {
+    // "chat not found" is the platform telling us it did not accept the message.
+    // That is a guaranteed non-delivery, not an ambiguity — routing it to
+    // needs-review would bury it among the genuinely undetermined entries and
+    // skip the failed/ disposition recovery already gives it.
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("Bad Request: chat not found"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: whatsappSplitsIntoTwoChunksConfig,
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: TWO_CHUNK_TEXT }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("chat not found");
+
+    expect(queueMocks.failUnknownDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("chat not found"),
+    );
+  });
+
+  // The send-attempt flag is what separates "never left the process" (replay) from
+  // "may have landed" (quarantine), and it is recorded in ONE helper that every
+  // platform send must go through. Only asserting it for handler.sendText leaves
+  // the other three families protected by a comment: they can each be unwrapped
+  // with the suite fully green, and the failure mode is silent duplicate
+  // delivery. One test per family, so a dropped wrapper is caught by CI.
+  it("quarantines an ambiguous handler.sendMedia failure", async () => {
+    const sendText = vi.fn();
+    const sendMedia = vi.fn().mockRejectedValue(new Error("upload stalled"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText, sendMedia },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:1",
+        payloads: [{ text: "caption", mediaUrl: "https://example.com/a.png" }],
+      }),
+    ).rejects.toThrow("upload stalled");
+
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("upload stalled"),
+    );
+  });
+
+  it("quarantines an ambiguous handler.sendPayload failure", async () => {
+    const sendText = vi.fn();
+    const sendPayload = vi.fn().mockRejectedValue(new Error("gateway timeout"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText, sendPayload },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:1",
+        payloads: [{ text: "hi", channelData: { matrix: { kind: "custom" } } }],
+      }),
+    ).rejects.toThrow("gateway timeout");
+
+    expect(sendPayload).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("gateway timeout"),
+    );
+  });
+
+  it("quarantines an ambiguous signal text-send failure", async () => {
+    const sendSignal = vi.fn().mockRejectedValue(new Error("socket hang up"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "signal",
+        to: "+1555",
+        payloads: [{ text: "hi" }],
+        deps: { sendSignal },
+      }),
+    ).rejects.toThrow("socket hang up");
+
+    expect(sendSignal).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("socket hang up"),
+    );
+  });
+
+  it("quarantines an ambiguous signal media-send failure", async () => {
+    const sendSignal = vi.fn().mockRejectedValue(new Error("socket hang up"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "signal",
+        to: "+1555",
+        payloads: [{ text: "caption", mediaUrl: "https://example.com/a.png" }],
+        deps: { sendSignal },
+      }),
+    ).rejects.toThrow("socket hang up");
+
+    expect(sendSignal).toHaveBeenCalledTimes(1);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("socket hang up"),
+    );
+  });
+
+  it("quarantines when ANY bestEffort payload failed ambiguously", async () => {
+    // Classifying from the first error alone lets a clean ECONNREFUSED on
+    // payload 1 mask an ambiguous post-transmission failure on payload 2 —
+    // clearing the marker and replaying the payload that may have arrived.
+    const sendWhatsApp = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
+      )
+      .mockRejectedValueOnce(new Error("socket hang up"));
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }, { text: "b" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(2);
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.any(String),
+    );
+  });
+
+  it("keeps a failure raised before any send on the normal retry path", async () => {
+    // A media payload on an adapter with no sendMedia and no text fallback
+    // throws before the transport is touched. Nothing was attempted, so nothing
+    // can have landed — this must stay replayable, or every pre-send validation
+    // error would land in the operator's reconciliation queue.
+    const sendText = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:1",
+        payloads: [{ text: "   ", mediaUrl: "https://example.com/file.png" }],
+      }),
+    ).rejects.toThrow("no text fallback is available");
+
+    expect(sendText).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
   });
 
   it("acks the queue entry when delivery is aborted", async () => {
@@ -1047,12 +1309,14 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("does NOT ack a transport error that merely calls itself AbortError", async () => {
+  it("quarantines a transport error that merely calls itself AbortError", async () => {
     // `isAbortError` is name-based. A client-side request timeout that aborts
     // its own controller surfaces a DOMException named "AbortError" without the
     // CALLER ever cancelling — BlueBubbles' fetch timeout does exactly this.
     // That is an unknown send outcome (the server may have delivered it), not a
-    // cancellation, and acking it would silently drop the message.
+    // cancellation: acking it would silently drop the message, and recording it
+    // as a plain failure would clear the marker and replay a message that may
+    // already be on the recipient's device (#3051 item 1).
     const sendWhatsApp = vi
       .fn()
       .mockRejectedValue(new DOMException("This operation was aborted", "AbortError"));
@@ -1068,7 +1332,36 @@ describe("deliverOutboundPayloads", () => {
     ).rejects.toThrow("aborted");
 
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
-    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failUnknownDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.any(String),
+    );
+  });
+
+  it("still acks a caller-cancelled abort raised before any send", async () => {
+    // The one clean discard: the CALLER's own signal is aborted and no send was
+    // ever entered. Widening the ambiguity rule must not swallow this case —
+    // acking here is what keeps a cancelled reply out of needs-review.
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: "a" }],
+        deps: { sendWhatsApp },
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toThrow("Operation aborted");
+
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.failUnknownDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
   it("marks the queue entry as send-in-flight before the platform send", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -45,6 +45,7 @@ import {
   enqueueDelivery,
   failDelivery,
   failPartialDelivery,
+  failUnknownDelivery,
   markDeliveryAttemptStarted,
   withActiveDeliveryClaim,
 } from "./delivery-queue.js";
@@ -53,6 +54,7 @@ import type { OutboundIdentity } from "./identity.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
+import { didSendDefinitelyNotLand } from "./send-outcome.js";
 import type { OutboundSessionContext } from "./session-context.js";
 import type { OutboundChannel } from "./targets.js";
 
@@ -512,16 +514,6 @@ export async function deliverOutboundPayloads(
   // entry whose payloads all failed — silently dropping the message.
   let hadPayloadFailure = false;
   let firstPayloadError: string | undefined;
-  const wrappedParams = {
-    ...params,
-    onError: (err: unknown, payload: NormalizedOutboundPayload) => {
-      hadPayloadFailure = true;
-      // Keep the cause: "partial delivery failure (bestEffort)" alone tells an
-      // operator triaging the entry nothing about why it failed.
-      firstPayloadError ??= describeDeliveryError(err);
-      params.onError?.(err, payload);
-    },
-  };
 
   // The core fills this as each payload lands, so the queue bookkeeping below
   // can tell "nothing reached the recipient" (safe to replay whole) from "some
@@ -530,7 +522,40 @@ export async function deliverOutboundPayloads(
   // ordinary, not exotic: chunk 1 can land and chunk 2 throw.
   const landed: OutboundDeliveryResult[] = [];
 
-  const recordQueueFailure = async (error: string): Promise<void> => {
+  // `landed` records sends that RESOLVED. This records that one was ENTERED.
+  // The two answer different questions, and the failure path needs both: a throw
+  // with nothing landed is safe to replay only if no send ever reached the
+  // transport (#3051 item 1). The core owns the writes; see `attemptPlatformSend`.
+  const sendProgress: PlatformSendProgress = { platformSendAttempted: false };
+
+  // Whether ANY payload under bestEffort failed in a way that might have landed.
+  // OR-accumulated rather than taken from the first error: a clean ECONNREFUSED
+  // on payload 1 would otherwise mask an ambiguous post-transmission timeout on
+  // payload 2, clearing the marker and replaying the payload that may have
+  // arrived. Classified at failure time, when `platformSendAttempted` reflects
+  // exactly the sends made before THAT payload's error.
+  let sawAmbiguousPayloadFailure = false;
+  const wrappedParams = {
+    ...params,
+    onError: (err: unknown, payload: NormalizedOutboundPayload) => {
+      hadPayloadFailure = true;
+      const described = describeDeliveryError(err);
+      sawAmbiguousPayloadFailure ||= !didSendDefinitelyNotLand({
+        platformSendAttempted: sendProgress.platformSendAttempted,
+        error: err,
+        describedError: described,
+      });
+      // Keep the cause: "partial delivery failure (bestEffort)" alone tells an
+      // operator triaging the entry nothing about why it failed.
+      firstPayloadError ??= described;
+      params.onError?.(err, payload);
+    },
+  };
+
+  const recordQueueFailure = async (
+    error: string,
+    definitelyDidNotLand: boolean,
+  ): Promise<void> => {
     if (!queueId) {
       return;
     }
@@ -539,18 +564,36 @@ export async function deliverOutboundPayloads(
       // operator who opens the quarantined entry otherwise sees the full payload
       // list with no way to tell which part arrived.
       await failPartialDelivery(queueId, error, undefined, landed.length).catch(() => {});
-    } else {
-      await failDelivery(queueId, error).catch(() => {});
+      return;
     }
+    if (definitelyDidNotLand) {
+      await failDelivery(queueId, error).catch(() => {});
+      return;
+    }
+    // A send reached the transport and then failed without reporting anything
+    // landed. That is not "nothing arrived" — it is "we cannot tell", and
+    // replaying it is how the recipient gets the message twice. Surface it for
+    // an operator instead of silently re-sending (#3051 item 1). This BOUNDS the
+    // duplicate window; it does not close it.
+    await failUnknownDelivery(queueId, error).catch(() => {});
+    // Say so at the moment of the decision. The entry only MOVES to
+    // `needs-review/` on the next gateway start, so without this line a message
+    // whose outcome is undetermined is invisible until then — on a long-running
+    // gateway, indefinitely. "Surfaced for review" has to mean surfaced now.
+    log.warn(
+      "deliverOutboundPayloads: send outcome is unknown — the message may or may not have been delivered. It will NOT be retried automatically; it is held for manual reconciliation and moves to delivery-queue/needs-review/ on the next gateway start",
+      { channel, to, queueId, error },
+    );
   };
 
   const runDelivery = async (): Promise<OutboundDeliveryResult[]> => {
     try {
-      const results = await deliverOutboundPayloadsCore(wrappedParams, landed);
+      const results = await deliverOutboundPayloadsCore(wrappedParams, landed, sendProgress);
       if (queueId) {
         if (hadPayloadFailure) {
           await recordQueueFailure(
             `partial delivery failure (bestEffort): ${firstPayloadError ?? "unknown error"}`,
+            !sawAmbiguousPayloadFailure,
           );
         } else {
           await ackDelivery(queueId).catch(() => {}); // Best-effort cleanup.
@@ -571,7 +614,15 @@ export async function deliverOutboundPayloads(
         if (cancelledByCaller && landed.length === 0) {
           await ackDelivery(queueId).catch(() => {});
         } else {
-          await recordQueueFailure(describeDeliveryError(err));
+          const described = describeDeliveryError(err);
+          await recordQueueFailure(
+            described,
+            didSendDefinitelyNotLand({
+              platformSendAttempted: sendProgress.platformSendAttempted,
+              error: err,
+              describedError: described,
+            }),
+          );
         }
       }
       // Tell whoever catches this how far the send got. Crash recovery calls
@@ -619,18 +670,40 @@ export async function deliverOutboundPayloads(
 }
 
 /**
+ * Whether any platform send call was entered, shared by reference with the queue
+ * wrapper so it survives this function throwing part-way.
+ */
+type PlatformSendProgress = { platformSendAttempted: boolean };
+
+/**
  * Core delivery logic (extracted for queue wrapper).
  *
- * `results` is accepted from the caller — required, not defaulted — rather than
- * created here, so the queue wrapper still sees which payloads landed when this
- * function throws part-way. A default would silently let a future caller drop
- * that wiring and lose the partial-send signal.
+ * `results` and `progress` are accepted from the caller — required, not
+ * defaulted — rather than created here, so the queue wrapper still sees which
+ * payloads landed and whether the transport was ever reached when this function
+ * throws part-way. A default would silently let a future caller drop that wiring
+ * and lose the signal.
  */
 async function deliverOutboundPayloadsCore(
   params: DeliverOutboundPayloadsCoreParams,
   results: OutboundDeliveryResult[],
+  progress: PlatformSendProgress,
 ): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
+
+  /**
+   * Every platform send goes through here, so "did anything reach the transport?"
+   * has exactly one place to be recorded. The flag is set BEFORE the await: the
+   * question is whether the request was issued, not whether it came back.
+   *
+   * A new send path that calls the handler directly instead of through this
+   * helper silently re-opens the ambiguous-error replay window (#3051 item 1) —
+   * its failures would look like "never left the process" and be replayed.
+   */
+  const attemptPlatformSend = async <T>(send: () => Promise<T>): Promise<T> => {
+    progress.platformSendAttempted = true;
+    return await send();
+  };
   const accountId = params.accountId;
   const deps = params.deps;
   const abortSignal = params.abortSignal;
@@ -682,7 +755,7 @@ async function deliverOutboundPayloadsCore(
   ) => {
     throwIfAborted(abortSignal);
     if (!handler.chunker || textLimit === undefined) {
-      results.push(await handler.sendText(text, overrides));
+      results.push(await attemptPlatformSend(() => handler.sendText(text, overrides)));
       return;
     }
     if (chunkMode === "newline") {
@@ -702,7 +775,7 @@ async function deliverOutboundPayloadsCore(
         }
         for (const chunk of chunks) {
           throwIfAborted(abortSignal);
-          results.push(await handler.sendText(chunk, overrides));
+          results.push(await attemptPlatformSend(() => handler.sendText(chunk, overrides)));
         }
       }
       return;
@@ -710,7 +783,7 @@ async function deliverOutboundPayloadsCore(
     const chunks = handler.chunker(text, textLimit);
     for (const chunk of chunks) {
       throwIfAborted(abortSignal);
-      results.push(await handler.sendText(chunk, overrides));
+      results.push(await attemptPlatformSend(() => handler.sendText(chunk, overrides)));
     }
   };
 
@@ -718,13 +791,15 @@ async function deliverOutboundPayloadsCore(
     throwIfAborted(abortSignal);
     return {
       channel: "signal" as const,
-      ...(await sendSignal(to, text, {
-        cfg,
-        maxBytes: signalMaxBytes,
-        accountId: accountId ?? undefined,
-        textMode: "plain",
-        textStyles: styles,
-      })),
+      ...(await attemptPlatformSend(() =>
+        sendSignal(to, text, {
+          cfg,
+          maxBytes: signalMaxBytes,
+          accountId: accountId ?? undefined,
+          textMode: "plain",
+          textStyles: styles,
+        }),
+      )),
     };
   };
 
@@ -755,15 +830,17 @@ async function deliverOutboundPayloadsCore(
     };
     return {
       channel: "signal" as const,
-      ...(await sendSignal(to, formatted.text, {
-        cfg,
-        mediaUrl,
-        maxBytes: signalMaxBytes,
-        accountId: accountId ?? undefined,
-        textMode: "plain",
-        textStyles: formatted.styles,
-        mediaLocalRoots,
-      })),
+      ...(await attemptPlatformSend(() =>
+        sendSignal(to, formatted.text, {
+          cfg,
+          mediaUrl,
+          maxBytes: signalMaxBytes,
+          accountId: accountId ?? undefined,
+          textMode: "plain",
+          textStyles: formatted.styles,
+          mediaLocalRoots,
+        }),
+      )),
     };
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(
@@ -823,8 +900,14 @@ async function deliverOutboundPayloadsCore(
         replyToId: effectivePayload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
       };
-      if (handler.sendPayload && effectivePayload.channelData) {
-        const delivery = await handler.sendPayload(effectivePayload, sendOverrides);
+      // Bound to a local so the send closure keeps the optional-property
+      // narrowing from this branch. `createPluginHandler` builds every handler
+      // method as a closure, so there is no `this` to lose.
+      const sendPayload = handler.sendPayload;
+      if (sendPayload && effectivePayload.channelData) {
+        const delivery = await attemptPlatformSend(() =>
+          sendPayload(effectivePayload, sendOverrides),
+        );
         results.push(delivery);
         emitMessageSent({
           success: true,
@@ -886,7 +969,9 @@ async function deliverOutboundPayloadsCore(
           results.push(delivery);
           lastMessageId = delivery.messageId;
         } else {
-          const delivery = await handler.sendMedia(caption, url, sendOverrides);
+          const delivery = await attemptPlatformSend(() =>
+            handler.sendMedia(caption, url, sendOverrides),
+          );
           results.push(delivery);
           lastMessageId = delivery.messageId;
         }

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -11,7 +11,9 @@ import {
   enqueueDelivery,
   failDelivery,
   failPartialDelivery,
+  failUnknownDelivery,
   hasUnknownSendOutcome,
+  InvalidQueueEntryIdError,
   loadPendingDeliveries,
   markDeliveryAttemptStarted,
   type QueuedDelivery,
@@ -163,6 +165,171 @@ describe("send-in-flight marker", () => {
   });
 });
 
+describe("failUnknownDelivery (#3051)", () => {
+  it("keeps the marker so the entry is quarantined, not replayed", async () => {
+    const id = await enqueueTestDelivery();
+    await markDeliveryAttemptStarted(id, stateDir);
+
+    await failUnknownDelivery(id, "socket hang up", stateDir);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+    expect(entry.retryCount).toBe(1);
+    expect(entry.lastError).toBe("socket hang up");
+  });
+
+  it("leaves deliveredBeforeFailure unset — the count is unknowable, not zero", async () => {
+    // Writing 0 would render to an operator as "confirmed nothing arrived",
+    // which is exactly the claim this outcome cannot make.
+    const id = await enqueueTestDelivery();
+
+    await failUnknownDelivery(id, "socket hang up", stateDir);
+
+    expect((await readEntry(id)).deliveredBeforeFailure).toBeUndefined();
+  });
+
+  it("is quarantined by recovery rather than re-sent", async () => {
+    const id = await enqueueTestDelivery();
+    await failUnknownDelivery(id, "socket hang up", stateDir);
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const { summary, log } = await runRecovery(deliver);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+    expect(fs.existsSync(path.join(resolveNeedsReviewDir(stateDir), `${id}.json`))).toBe(true);
+    // No landed count was recorded, so the operator log must not imply one.
+    // Assert the line exists before asserting what it omits — a `find` that
+    // returns undefined would otherwise let a vanished log line read as a pass.
+    const incident = log.warn.mock.calls
+      .map(String)
+      .find((line) => line.includes(id) && line.includes("undetermined send outcome"));
+    expect(incident).toBeDefined();
+    expect(incident).not.toContain("confirmed sent");
+    expect(incident).not.toMatch(/\bdelivered\b/);
+  });
+});
+
+describe("entry id shape guard (#3051)", () => {
+  /** Write a raw entry file under an arbitrary filename, bypassing enqueue. */
+  async function plantRawEntry(fileStem: string, entry: Record<string, unknown>): Promise<void> {
+    const queueDir = path.join(stateDir, "delivery-queue");
+    await fs.promises.mkdir(queueDir, { recursive: true, mode: 0o700 });
+    await fs.promises.writeFile(
+      path.join(queueDir, `${fileStem}.json`),
+      JSON.stringify(entry, null, 2),
+    );
+  }
+
+  const plantedEntry = {
+    id: "not-a-uuid",
+    enqueuedAt: 1,
+    retryCount: 0,
+    channel: "whatsapp",
+    to: "+1555",
+    payloads: [{ text: "planted" }],
+    recoveryState: "send_attempt_started",
+  };
+
+  it("refuses to load an entry whose id is not a queue id", async () => {
+    await plantRawEntry("planted", plantedEntry);
+
+    expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+  });
+
+  it("never lets a traversing id reach outside the queue directory", async () => {
+    // Staged so the escape is REACHABLE rather than merely malformed: the
+    // planted id resolves to a real file one level above the queue directory,
+    // so without the guard recovery re-reads it, rewrites it, and renames it —
+    // a queue operation mutating an arbitrary file outside its own directory.
+    //
+    // Reaching this already requires write access to the state dir, a trusted
+    // boundary, so it is defense in depth rather than a live exposure (#3051
+    // item 4). The point is that a malformed id fails closed BEFORE
+    // `needs-review/${id}.json` or any sibling path is built from it.
+    const outsideFile = path.join(stateDir, "escape-target.json");
+    await fs.promises.writeFile(
+      outsideFile,
+      JSON.stringify({ ...plantedEntry, id: "../escape-target" }, null, 2),
+    );
+    // The scan reads by FILENAME and takes the id from the JSON body, so a
+    // well-named file can carry a traversing id.
+    await plantRawEntry("00000000-0000-4000-8000-000000000000", {
+      ...plantedEntry,
+      id: "../escape-target",
+    });
+
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(0);
+    expect(summary.quarantineFailed).toBe(0);
+    // The file above the queue directory is untouched, and nothing was moved
+    // into (or through) the quarantine directory on its behalf.
+    expect(fs.existsSync(outsideFile)).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", "escape-target.json"))).toBe(false);
+    expect(fs.existsSync(resolveNeedsReviewDir(stateDir))).toBe(false);
+  });
+
+  it("skips one malformed entry without stalling recovery of the rest", async () => {
+    // Fail-closed must stay contained: a single planted entry cannot be allowed
+    // to become a denial of service on every other pending delivery.
+    await plantRawEntry("planted", plantedEntry);
+    const good = await enqueueTestDelivery();
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(summary.recovered).toBe(1);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", `${good}.json`))).toBe(false);
+  });
+
+  it("reports the refused entry instead of dropping it silently", async () => {
+    // A rejected entry is never retried, never quarantined and never counted, so
+    // without a report the operator's only evidence is a .json that never leaves
+    // delivery-queue/. An unobservable fail-closed guard is indistinguishable
+    // from no guard at all.
+    await plantRawEntry("planted", plantedEntry);
+    const log = createLog();
+
+    await runRecovery(
+      vi.fn<DeliverFn>(async () => undefined),
+      log,
+    );
+
+    const reported = log.error.mock.calls.map(String).find((line) => line.includes("planted.json"));
+    expect(reported).toContain("will NOT be delivered or retried");
+    expect(reported).toContain("malformed id");
+  });
+
+  it("rejects a mutation of an entry whose id is malformed", async () => {
+    // updateQueueEntry is reached with the CALLER's id, so a well-formed
+    // filename can still hold a malformed id. Every mutation parses through the
+    // same guard, so quarantine/fail/mark all fail closed rather than persisting
+    // an id that a later path build would trust.
+    await plantRawEntry("planted", plantedEntry);
+
+    await expect(markDeliveryAttemptStarted("planted", stateDir)).rejects.toThrow(
+      InvalidQueueEntryIdError,
+    );
+    await expect(quarantineUnknownSend("planted", stateDir)).rejects.toThrow(
+      InvalidQueueEntryIdError,
+    );
+  });
+
+  it("accepts the ids enqueueDelivery actually mints", async () => {
+    // Guards against a pattern so strict it rejects real traffic.
+    const id = await enqueueTestDelivery();
+
+    const pending = await loadPendingDeliveries(stateDir);
+
+    expect(pending.map((entry) => entry.id)).toEqual([id]);
+  });
+});
+
 describe("quarantineUnknownSend", () => {
   it("moves the entry to needs-review/ stamped unknown_after_send", async () => {
     const id = await enqueueTestDelivery();
@@ -250,7 +417,9 @@ describe("recoverPendingDeliveries", () => {
     expect((await readEntry(id, resolveNeedsReviewDir(stateDir))).recoveryState).toBe(
       "unknown_after_send",
     );
-    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("outcome unknown"));
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("may or may not have reached the recipient"),
+    );
     // The operator log must name where the entry went and when the send began.
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(resolveNeedsReviewDir(stateDir)));
   });
@@ -604,9 +773,31 @@ describe("recoverPendingDeliveries", () => {
     // The incident record, not the remediation one that follows it.
     const incident = log.warn.mock.calls
       .map(String)
-      .find((line) => line.includes(id) && line.includes("interrupted mid-send"));
+      .find((line) => line.includes(id) && line.includes("undetermined send outcome"));
     expect(incident).toContain("2 message part(s) confirmed sent");
     expect(incident).not.toContain("of 1");
+  });
+
+  it("does not claim the send was 'interrupted' — a live ambiguous failure was not", async () => {
+    // The original wording was written for the process-crash case (#2934). A
+    // live-path quarantine (#3051) is the opposite shape: the send ran to
+    // completion and the platform's answer never came back. "Interrupted
+    // mid-send" sends an operator hunting for a crash that never happened.
+    const id = await enqueueTestDelivery();
+    await failUnknownDelivery(id, "socket hang up", stateDir);
+    const log = createLog();
+
+    await runRecovery(
+      vi.fn<DeliverFn>(async () => undefined),
+      log,
+    );
+
+    const incident = log.warn.mock.calls
+      .map(String)
+      .find((line) => line.includes(id) && line.includes("undetermined send outcome"));
+    expect(incident).toBeDefined();
+    expect(incident).not.toContain("interrupted mid-send");
+    expect(incident).toContain("may or may not have reached the recipient");
   });
 
   it("tells the operator to reset retryCount when un-quarantining a maxed-out entry", async () => {
@@ -629,7 +820,29 @@ describe("recoverPendingDeliveries", () => {
       .map(String)
       .find((line) => line.includes(id) && line.includes("To reconcile"));
     expect(remediation).toContain('"retryCount" to 0');
-    expect(remediation).toContain(`"retryCount" at 6 (max 5)`);
+    expect(remediation).toContain(`leaving it at 6 (max 5) files the entry under failed/`);
+  });
+
+  it("does not claim failed/ for an entry nowhere near the retry cap", async () => {
+    // A live ambiguous send failure quarantines at retryCount 1, where the
+    // unconditional "leaving retryCount at N files it under failed/ without
+    // sending" is simply false. A runbook an operator catches lying is a runbook
+    // they stop following.
+    const id = await enqueueTestDelivery();
+    await failUnknownDelivery(id, "socket hang up", stateDir);
+    const log = createLog();
+
+    await runRecovery(
+      vi.fn<DeliverFn>(async () => undefined),
+      log,
+    );
+
+    const remediation = log.warn.mock.calls
+      .map(String)
+      .find((line) => line.includes(id) && line.includes("To reconcile"));
+    expect(remediation).toContain('"retryCount" to 0');
+    expect(remediation).not.toContain("files the entry under failed/");
+    expect(remediation).toContain("4 attempt(s) left");
   });
 
   it("still routes a permanent error with nothing landed to failed/", async () => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -1,3 +1,38 @@
+/**
+ * Write-ahead delivery queue.
+ *
+ * ## Delivery semantics: at-least-once
+ *
+ * This queue provides **at-least-once** delivery. It does NOT provide
+ * exactly-once, and it cannot: the acknowledgement that a message reached a
+ * third-party chat platform travels back over the same unreliable link as the
+ * message, so there is no sequence of writes on this side that makes "sent" and
+ * "recorded as sent" a single atomic fact. That is the Two Generals problem, and
+ * it is not a gap to be closed by a better queue — it is a property of talking to
+ * a system we do not control.
+ *
+ * What follows from that:
+ *
+ * - A message may be delivered more than once. Consumers and platforms own
+ *   idempotency and de-duplication; this queue does not supply an idempotency key
+ *   to the platform, so nothing downstream can collapse a duplicate for us.
+ * - Every mechanism here NARROWS the duplicate window rather than eliminating it.
+ *   The `recoveryState` marker (#2934) removes the process-crash case: an entry
+ *   interrupted mid-send is quarantined instead of blind-replayed. The
+ *   send-outcome classifier (`send-outcome.ts`, #3051) removes the
+ *   ambiguous-transport case: a failure that might have landed is quarantined
+ *   rather than retried. Neither claims the window is closed — a duplicate is
+ *   still reachable, for example when the marker write itself is lost to a
+ *   power-loss before it is flushed to stable storage.
+ * - The residual window is BOUNDED and SURFACED, not eliminated. What survives
+ *   lands in `delivery-queue/needs-review/` for an operator, which is the
+ *   deliberate trade: for a messaging product a message that visibly needs a
+ *   human beats a message the recipient silently receives twice.
+ *
+ * Operator-facing description of the same contract, including the sensitivity of
+ * `needs-review/` in backups: `docs/gateway/message-delivery.md`.
+ */
+
 import fs from "node:fs";
 import path from "node:path";
 import type { ReplyPayload } from "../../auto-reply/types.js";
@@ -9,7 +44,10 @@ import {
   readDeliveredBeforeFailure,
 } from "./delivered-before-failure.js";
 import { describeDeliveryError } from "./describe-delivery-error.js";
+import { isPermanentDeliveryError } from "./send-outcome.js";
 import type { OutboundChannel } from "./targets.js";
+
+export { isPermanentDeliveryError } from "./send-outcome.js";
 
 const QUEUE_DIRNAME = "delivery-queue";
 const FAILED_DIRNAME = "failed";
@@ -157,6 +195,63 @@ async function writeQueueEntryAtomic(filePath: string, entry: QueuedDelivery): P
   await fs.promises.rename(tmp, filePath);
 }
 
+/**
+ * Shape of the ids {@link enqueueDelivery} mints via `generateSecureUuid()`
+ * (`node:crypto` `randomUUID`).
+ *
+ * A shape check, not a version check: the guard exists to keep an id from
+ * becoming an attacker-chosen path segment, and every RFC 4122 layout is equally
+ * safe as one. Anchored at both ends, so nothing containing a separator, a `..`,
+ * a NUL, or a trailing extension can match.
+ */
+const QUEUE_ENTRY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Raised when an on-disk entry carries an id that is not a queue id. */
+export class InvalidQueueEntryIdError extends Error {
+  constructor(rawId: unknown) {
+    super(
+      `Delivery queue entry has a malformed id (${JSON.stringify(rawId)}) — refusing to use it as a filename`,
+    );
+    this.name = "InvalidQueueEntryIdError";
+  }
+}
+
+/**
+ * Parse one queue entry out of on-disk JSON.
+ *
+ * This is the ONLY place an entry id crosses from untrusted bytes into the
+ * process, and therefore the only place the id-shape guard has to live.
+ * {@link ackDelivery}, {@link moveToFailed} and {@link quarantineUnknownSend}
+ * each turn an id back into `<dir>/${id}.json` and validate nothing themselves —
+ * they inherit the guard because an id can only reach them from one of exactly
+ * two sources: {@link enqueueDelivery}'s freshly-minted `randomUUID`, or this
+ * function. Guarding the untrusted source gives all three one fail-closed check
+ * instead of three that can drift apart (#3051 item 4).
+ *
+ * Stated precisely because a future refactor will trust it: the invariant is
+ * "every parsed id passed the guard", NOT "these functions validate their
+ * argument". A new id source — anything that derives an id from a filename, a
+ * request, or an operator-supplied string — breaks it and must guard itself.
+ *
+ * Fails closed: a malformed id throws before any caller can build a path from it.
+ * That is contained, not fatal — {@link loadPendingDeliveries} already treats a
+ * per-entry throw as "skip this file", so one planted entry cannot stall recovery
+ * of the rest, and {@link recoverPendingDeliveries} logs and skips the entry it
+ * cannot re-read.
+ *
+ * Reaching this guard already requires write access to the state directory, which
+ * is a trusted boundary in this threat model. It is defense in depth for the case
+ * where that boundary has already failed — not the boundary itself.
+ */
+function parseQueuedDeliveryEntry(raw: string): QueuedDelivery {
+  const parsed = JSON.parse(raw) as QueuedDelivery;
+  const id: unknown = parsed?.id;
+  if (typeof id !== "string" || !QUEUE_ENTRY_ID_PATTERN.test(id)) {
+    throw new InvalidQueueEntryIdError(id);
+  }
+  return parsed;
+}
+
 /** Read-modify-write a pending queue entry. Throws ENOENT if it is already gone. */
 async function updateQueueEntry(
   id: string,
@@ -165,7 +260,7 @@ async function updateQueueEntry(
 ): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
+  const entry = parseQueuedDeliveryEntry(raw);
   await writeQueueEntryAtomic(filePath, mutate(entry));
 }
 
@@ -208,10 +303,13 @@ export async function enqueueDelivery(
 /**
  * Record that delivery for `id` has entered the send path.
  *
- * This is the write that closes the duplicate-delivery window: if the process
- * dies anywhere between here and the matching ack/fail, the entry is left on
- * disk carrying `send_attempt_started`, and {@link recoverPendingDeliveries}
- * quarantines it instead of re-sending a message that may already have landed.
+ * This is the write that narrows the duplicate-delivery window to the
+ * process-crash case: if the process dies anywhere between here and the matching
+ * ack/fail, the entry is left on disk carrying `send_attempt_started`, and
+ * {@link recoverPendingDeliveries} quarantines it instead of re-sending a message
+ * that may already have landed. It narrows that window rather than closing it —
+ * a marker still in the page cache when the machine loses power is lost with it.
+ * Delivery stays at-least-once; see § Delivery semantics at the top of this file.
  *
  * The marked window is deliberately wider than the wire call — it opens before
  * payload normalization and the `message_sending` hook, so a crash before
@@ -336,12 +434,11 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
  * re-sends whatever already arrived. Chunked text makes that ordinary: one
  * chunk lands, the next throws.
  *
- * Known residual: "no payload observed to land" is not the same as "nothing
- * reached the platform". A request that times out or resets *after* hitting the
- * wire produces no result object, so it is recorded here and replayed — the
- * queue's long-standing at-least-once behaviour for ambiguous transport errors.
- * Closing that needs transport-level error classification and is out of scope
- * for the crash-window fix (#2934).
+ * "Nothing landed" is a stronger claim than "no payload was observed to land": a
+ * request that times out or resets *after* hitting the wire also produces no
+ * result object. Callers must not conflate the two — route the ambiguous case to
+ * {@link failUnknownDelivery} instead. `deliver.ts` makes that split with
+ * `didSendDefinitelyNotLand` (`send-outcome.ts`, #3051 item 1).
  */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   await updateQueueEntry(id, stateDir, (entry) => ({
@@ -351,6 +448,37 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
     lastError: error,
     recoveryState: undefined,
     platformSendStartedAt: undefined,
+  }));
+}
+
+/**
+ * Update a queue entry after a send whose outcome could not be determined: a
+ * platform send was attempted, it failed, and nothing was observed to land — but
+ * the failure does not prove nothing arrived. A request that times out or resets
+ * after reaching the wire looks identical here to one that never left.
+ *
+ * Recording it as a plain failure would clear the in-flight marker and re-arm a
+ * replay of a message that may already be on the recipient's device. So the entry
+ * keeps the unknown-outcome marker and recovery quarantines it for a human
+ * (#3051 item 1).
+ *
+ * Sibling of {@link failPartialDelivery}, and the difference is only in what is
+ * claimed: that one knows how many parts landed, this one records that the count
+ * is unknowable. `deliveredBeforeFailure` is deliberately left unset rather than
+ * written as `0` — `0` would render to an operator as "confirmed nothing arrived",
+ * which is precisely the thing this outcome cannot confirm.
+ */
+export async function failUnknownDelivery(
+  id: string,
+  error: string,
+  stateDir?: string,
+): Promise<void> {
+  await updateQueueEntry(id, stateDir, (entry) => ({
+    ...entry,
+    retryCount: entry.retryCount + 1,
+    lastAttemptAt: Date.now(),
+    lastError: error,
+    recoveryState: "unknown_after_send",
   }));
 }
 
@@ -397,7 +525,7 @@ async function loadPendingDelivery(id: string, stateDir?: string): Promise<Queue
     }
     const raw = await fs.promises.readFile(jsonPath, "utf-8");
     // Normalize in memory only — the scan already persisted any migration.
-    return normalizeLegacyQueuedDeliveryEntry(JSON.parse(raw) as QueuedDelivery).entry;
+    return normalizeLegacyQueuedDeliveryEntry(parseQueuedDeliveryEntry(raw)).entry;
   } catch (err) {
     if (getErrnoCode(err) === "ENOENT") {
       return null;
@@ -406,8 +534,19 @@ async function loadPendingDelivery(id: string, stateDir?: string): Promise<Queue
   }
 }
 
-/** Load all pending delivery entries from the queue directory. */
-export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDelivery[]> {
+/**
+ * Load all pending delivery entries from the queue directory.
+ *
+ * `onSkipped` reports each entry the scan refused. Optional so existing callers
+ * are unaffected, but recovery passes one: an entry rejected here is silently
+ * dropped from every count, never retried and never quarantined, so without a
+ * report the only evidence is a `.json` that never leaves `delivery-queue/`. An
+ * unobservable fail-closed guard is indistinguishable from no guard at all.
+ */
+export async function loadPendingDeliveries(
+  stateDir?: string,
+  onSkipped?: (file: string, err: unknown) => void,
+): Promise<QueuedDelivery[]> {
   const queueDir = resolveQueueDir(stateDir);
   let files: string[];
   try {
@@ -440,14 +579,16 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
         continue;
       }
       const raw = await fs.promises.readFile(filePath, "utf-8");
-      const parsed = JSON.parse(raw) as QueuedDelivery;
+      const parsed = parseQueuedDeliveryEntry(raw);
       const { entry, migrated } = normalizeLegacyQueuedDeliveryEntry(parsed);
       if (migrated) {
         await writeQueueEntryAtomic(filePath, entry);
       }
       entries.push(entry);
-    } catch {
-      // Skip malformed or inaccessible entries.
+    } catch (err) {
+      // Skip malformed or inaccessible entries — one bad file must not stall
+      // recovery of the rest — but do not skip them quietly.
+      onSkipped?.(file, err);
     }
   }
   return entries;
@@ -609,6 +750,23 @@ function describeDeliveredBeforeFailure(entry: QueuedDelivery): string {
 }
 
 /**
+ * Explain why the reconcile runbook asks for a `retryCount` reset, truthfully
+ * for THIS entry.
+ *
+ * The consequence is not the same at every count: at or over the cap the entry
+ * is filed under `failed/` unsent, below it the accumulated count only shortens
+ * the remaining retries. Stating the cap outcome unconditionally was accurate
+ * while quarantine implied a long retry history, but a live ambiguous send
+ * failure quarantines at `retryCount: 1` — where that sentence is simply false,
+ * and a runbook an operator catches lying is a runbook they stop following.
+ */
+function describeRetryCountResetReason(entry: QueuedDelivery): string {
+  return entry.retryCount >= MAX_RETRIES
+    ? ` Resetting "retryCount" is required here: leaving it at ${entry.retryCount} (max ${MAX_RETRIES}) files the entry under failed/ without sending.`
+    : ` Leaving "retryCount" at ${entry.retryCount} (max ${MAX_RETRIES}) still sends, with ${MAX_RETRIES - entry.retryCount} attempt(s) left instead of a full set.`;
+}
+
+/**
  * On gateway startup, scan the delivery queue and retry any pending entries.
  * Uses exponential backoff and moves entries that exceed MAX_RETRIES to failed/.
  *
@@ -637,7 +795,11 @@ export async function recoverPendingDeliveries(opts: {
     );
   }
 
-  const pending = await loadPendingDeliveries(opts.stateDir);
+  const pending = await loadPendingDeliveries(opts.stateDir, (file, err) => {
+    opts.log.error(
+      `Delivery queue entry ${file} could not be read and will NOT be delivered or retried — it stays in ${resolveQueueDir(opts.stateDir)} until an operator removes it: ${String(err)}`,
+    );
+  });
   if (pending.length === 0) {
     return { ...createEmptyRecoverySummary(), awaitingReviewAtStart };
   }
@@ -710,10 +872,10 @@ export async function recoverPendingDeliveries(opts: {
         // Two records on purpose: what happened, then what to do about it. One
         // combined line buries the incident under a four-step runbook.
         opts.log.warn(
-          `Delivery ${current.id} to ${current.channel}:${current.to} was interrupted mid-send at ${formatSendStartedAt(current)}${describeDeliveredBeforeFailure(current)} — outcome unknown, refusing to replay. Moved to ${path.join(resolveNeedsReviewDir(opts.stateDir), `${current.id}.json`)}`,
+          `Delivery ${current.id} to ${current.channel}:${current.to} left an undetermined send outcome from ${formatSendStartedAt(current)}${describeDeliveredBeforeFailure(current)} — it may or may not have reached the recipient, refusing to replay. Moved to ${path.join(resolveNeedsReviewDir(opts.stateDir), `${current.id}.json`)}`,
         );
         opts.log.warn(
-          `To reconcile delivery ${current.id}: check the recipient's message history around that time, then delete the file if it arrived. To send it after all, move the file back into ${resolveQueueDir(opts.stateDir)}, set its "recoveryState" to null and its "retryCount" to 0, then restart the gateway — recovery only runs at startup, leaving "recoveryState" set only re-quarantines it, and leaving "retryCount" at ${current.retryCount} (max ${MAX_RETRIES}) files it under failed/ without sending.`,
+          `To reconcile delivery ${current.id}: check the recipient's message history around that time, then delete the file if it arrived. To send it after all, move the file back into ${resolveQueueDir(opts.stateDir)}, set its "recoveryState" to null and its "retryCount" to 0, then restart the gateway — recovery only runs at startup, and leaving "recoveryState" set only re-quarantines it.${describeRetryCountResetReason(current)}`,
         );
         summary.needsReview += 1;
         return;
@@ -868,22 +1030,3 @@ export async function recoverPendingDeliveries(opts: {
 }
 
 export { MAX_RETRIES };
-
-const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
-  /no conversation reference found/i,
-  /chat not found/i,
-  /user not found/i,
-  /bot was blocked by the user/i,
-  /forbidden: bot was kicked/i,
-  /chat_id is empty/i,
-  /recipient is not a valid/i,
-  /outbound not configured for channel/i,
-  /ambiguous discord recipient/i,
-  // Slack: a required OAuth scope is missing from the app — cannot self-resolve
-  // without app reconfiguration, so retries only waste attempts (#2098).
-  /missing_scope/i,
-];
-
-export function isPermanentDeliveryError(error: string): boolean {
-  return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
-}

--- a/src/infra/outbound/send-outcome.test.ts
+++ b/src/infra/outbound/send-outcome.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { didSendDefinitelyNotLand, isPermanentDeliveryError } from "./send-outcome.js";
+
+function classify(params: {
+  platformSendAttempted?: boolean;
+  error?: unknown;
+  describedError?: string;
+}): boolean {
+  return didSendDefinitelyNotLand({
+    platformSendAttempted: params.platformSendAttempted ?? true,
+    error: params.error ?? new Error("boom"),
+    describedError: params.describedError ?? "boom",
+  });
+}
+
+function errnoError(code: string): Error & { code: string } {
+  return Object.assign(new Error(`connect ${code}`), { code });
+}
+
+describe("didSendDefinitelyNotLand", () => {
+  it("treats a failure raised before any send as definitely not landed", () => {
+    // Payload normalization, a message_sending hook, handler construction, an
+    // abort checked ahead of the first write — nothing reached the transport, so
+    // the entry is safe to replay whole.
+    expect(classify({ platformSendAttempted: false })).toBe(true);
+  });
+
+  it.each(["ECONNREFUSED", "ENOTFOUND", "EAI_AGAIN"])(
+    "treats %s as definitely not landed — the connection never carried a request",
+    (code) => {
+      expect(classify({ error: errnoError(code) })).toBe(true);
+    },
+  );
+
+  it("finds the errno under a fetch wrapper", () => {
+    // undici reports a refused connection as `TypeError: fetch failed` with the
+    // real errno one level down. Reading only the thrown error's own `code`
+    // would classify every fetch-based channel's refusals as ambiguous.
+    const wrapped = Object.assign(new TypeError("fetch failed"), {
+      cause: errnoError("ECONNREFUSED"),
+    });
+    expect(classify({ error: wrapped })).toBe(true);
+  });
+
+  it.each(["ECONNRESET", "EPIPE", "ETIMEDOUT"])(
+    "treats %s as AMBIGUOUS — it can surface after the request was written",
+    (code) => {
+      expect(classify({ error: errnoError(code) })).toBe(false);
+    },
+  );
+
+  it("treats a platform rejection as definitely not landed", () => {
+    // The platform answered and refused. That is a rejection, not an ambiguity —
+    // routing it to a human's reconciliation queue would bury a guaranteed
+    // non-delivery among the genuinely undetermined ones.
+    expect(
+      classify({
+        error: new Error("Bad Request: chat not found"),
+        describedError: "Bad Request: chat not found",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a bare AbortError as AMBIGUOUS", () => {
+    // A name-based abort check cannot tell a caller cancellation from a
+    // transport that aborts its own controller on timeout (BlueBubbles' fetch
+    // does exactly that, #3049). Only a send verified against the CALLER's own
+    // AbortSignal is a clean discard, and that check lives in deliver.ts.
+    const err = new DOMException("This operation was aborted", "AbortError");
+    expect(classify({ error: err, describedError: "This operation was aborted" })).toBe(false);
+  });
+
+  it("treats an unrecognized transport failure as AMBIGUOUS", () => {
+    // The default has to be "we cannot tell". An unknown error that reached the
+    // wire may have been delivered, and replaying it is how a recipient gets the
+    // message twice.
+    expect(classify({ error: new Error("socket hang up") })).toBe(false);
+  });
+
+  it("treats a 5xx after the request reached the platform as AMBIGUOUS", () => {
+    expect(
+      classify({
+        error: new Error("Request failed with status 502"),
+        describedError: "Request failed with status 502",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not spin on a cyclic cause chain", () => {
+    const a: { code?: string; cause?: unknown } = { code: "ENOSUCHCODE" };
+    const b: { code?: string; cause?: unknown } = { code: "ENOSUCHCODE", cause: a };
+    a.cause = b;
+    expect(classify({ error: a })).toBe(false);
+  });
+
+  it("ignores a non-string code", () => {
+    expect(classify({ error: { code: 111 } })).toBe(false);
+  });
+
+  it("handles a non-object error", () => {
+    expect(classify({ error: "ECONNREFUSED", describedError: "ECONNREFUSED" })).toBe(false);
+  });
+});
+
+describe("isPermanentDeliveryError", () => {
+  // Moved out of delivery-queue.ts so deliver.ts can classify send outcomes
+  // without importing the queue module; behavior is unchanged.
+  it("matches a known permanent rejection", () => {
+    expect(isPermanentDeliveryError("Bad Request: chat not found")).toBe(true);
+  });
+
+  it("does not match a transient transport error", () => {
+    expect(isPermanentDeliveryError("socket hang up")).toBe(false);
+  });
+});

--- a/src/infra/outbound/send-outcome.ts
+++ b/src/infra/outbound/send-outcome.ts
@@ -1,0 +1,133 @@
+/**
+ * What a failed send tells us about whether the message reached the recipient.
+ *
+ * The delivery queue has exactly two dispositions for a failure and they are
+ * opposites: re-arm a replay (correct only when the send definitely did NOT
+ * land) or quarantine it for a human (correct whenever it might have). This
+ * module owns the predicate that chooses between them.
+ *
+ * Its own module rather than part of `delivery-queue.ts` so `deliver.ts` can use
+ * it without importing the queue: `deliver.test.ts` mocks the queue module
+ * wholesale, and a mocked classifier would make a broken one untestable — the
+ * same reason `delivered-before-failure.ts` is separate.
+ *
+ * This narrows the duplicate window; it does not close it. See `delivery-queue.ts`
+ * § Delivery semantics for the at-least-once contract this operates under.
+ */
+
+const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
+  /no conversation reference found/i,
+  /chat not found/i,
+  /user not found/i,
+  /bot was blocked by the user/i,
+  /forbidden: bot was kicked/i,
+  /chat_id is empty/i,
+  /recipient is not a valid/i,
+  /outbound not configured for channel/i,
+  /ambiguous discord recipient/i,
+  // Slack: a required OAuth scope is missing from the app — cannot self-resolve
+  // without app reconfiguration, so retries only waste attempts (#2098).
+  /missing_scope/i,
+];
+
+/**
+ * A platform-level rejection that retrying can never satisfy: the chat is gone,
+ * the recipient blocked us, the app lacks a scope. Retrying is pointless, and —
+ * the property this module cares about — the platform told us it did not accept
+ * the message, so nothing was delivered.
+ */
+export function isPermanentDeliveryError(error: string): boolean {
+  return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
+/**
+ * Errno codes produced strictly BEFORE any byte of the request is written: the
+ * name never resolved, or the connection was refused. A send that fails with one
+ * of these cannot have been delivered, so replaying it cannot duplicate.
+ *
+ * Deliberately tiny, and deliberately not a per-error-code classification matrix
+ * (#3051 rules one out): a code only belongs here if it is provably
+ * pre-transmission. `ECONNRESET`, `EPIPE` and `ETIMEDOUT` are absent on purpose —
+ * each can surface after the request was written, which is exactly the ambiguity
+ * this guard exists to catch. Under-inclusion is the safe error here: an
+ * unlisted pre-transmission code costs an operator one needless reconciliation,
+ * while a wrongly-listed post-transmission code costs a recipient a duplicate.
+ */
+const CONNECTION_NEVER_ESTABLISHED_CODES: ReadonlySet<string> = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+]);
+
+/**
+ * Bound on the `cause` walk below. `fetch` reports a refused connection as
+ * `TypeError: fetch failed` with the real errno one level down, so the walk has
+ * to go deeper than the thrown error — but a cyclic or adversarially-nested
+ * `cause` chain must not spin.
+ */
+const MAX_ERROR_CAUSE_DEPTH = 5;
+
+function hasConnectionNeverEstablishedCode(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH; depth += 1) {
+    if (!current || typeof current !== "object") {
+      return false;
+    }
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && CONNECTION_NEVER_ESTABLISHED_CODES.has(code)) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * Whether this failure proves the message did not reach the recipient.
+ *
+ * `true` means the entry can go back on the retry path: a replay cannot
+ * duplicate, because nothing was delivered. `false` means the outcome is
+ * genuinely unknown and the entry must be surfaced for review rather than
+ * silently re-sent (#3051 item 1).
+ *
+ * The binary is deliberately coarse — three questions, in order:
+ *
+ * 1. Did any send call reach the transport at all? A failure raised before the
+ *    first send (payload normalization, a `message_sending` hook, handler
+ *    construction, an abort checked ahead of the first write) definitely did not
+ *    land.
+ * 2. Did the connection fail to establish? See
+ *    {@link CONNECTION_NEVER_ESTABLISHED_CODES}.
+ * 3. Did the platform reject it outright? See {@link isPermanentDeliveryError} —
+ *    "chat not found" is a rejection, not an ambiguity, and routing it to a
+ *    human's reconciliation queue would bury a guaranteed non-delivery in the
+ *    one place reserved for genuinely undetermined ones.
+ *
+ * Everything else — a timeout, a reset, a 5xx, an unrecognized transport
+ * error — is treated as MAYBE-LANDED. That is the conservative direction: the
+ * cost is an operator looking at an entry that turns out to have failed cleanly;
+ * the cost of the opposite mistake is a recipient receiving the message twice.
+ *
+ * Note on `AbortError`: not special-cased here. A name-based abort check cannot
+ * distinguish a caller cancellation from a transport that aborts its own
+ * controller on timeout (BlueBubbles' fetch does exactly that, #3049), so only a
+ * genuinely caller-cancelled send — verified against the caller's own
+ * `AbortSignal`, upstream in `deliver.ts` — is treated as a clean discard. A
+ * bare `AbortError` reaching here is ambiguous and stays ambiguous.
+ */
+export function didSendDefinitelyNotLand(params: {
+  /** Whether any platform send call was entered before the failure. */
+  platformSendAttempted: boolean;
+  /** The thrown error, for errno inspection. */
+  error: unknown;
+  /** `describeDeliveryError(error)`, for the permanent-rejection patterns. */
+  describedError: string;
+}): boolean {
+  if (!params.platformSendAttempted) {
+    return true;
+  }
+  if (hasConnectionNeverEstablishedCode(params.error)) {
+    return true;
+  }
+  return isPermanentDeliveryError(params.describedError);
+}


### PR DESCRIPTION
Implements the council-resolved subset of #3051: **items 4, 5, and the minimal guardrail half of item 1**. Items 2 and 3 are deliberately untouched (see § Deferred).

## What changes

### Item 1(a) — the delivery contract is now written down

`delivery-queue.ts` carries an explicit **at-least-once** statement. Exactly-once delivery is not provided and cannot be across an external chat transport (Two Generals); consumers and platforms own idempotency and dedup. The recovery mechanisms *narrow* the duplicate window — they do not eliminate it.

> **The duplicate window is bounded and surfaced, not closed.** Nothing in this PR makes duplicate delivery impossible. It converts a class of silent replays into entries an operator can see and reconcile.

### Item 1(b) — stop replaying maybe-landed sends

In the single-chunk live-send path, a non-abort throw with nothing confirmed landed ran `recordQueueFailure → failDelivery`, which **clears the recovery marker** — so a later retry or restart replayed a message that may already have arrived.

That case now routes to a new `failUnknownDelivery`, which stamps `recoveryState: "unknown_after_send"` and leaves the entry for recovery to move into `needs-review/`. Surfaced for review instead of silently re-sent.

`deliveredBeforeFailure` is deliberately left **unset** rather than `0` — writing `0` would render to an operator as "confirmed nothing arrived", which is exactly the claim this outcome cannot make.

**Classification is a conservative binary** (`send-outcome.ts`, new module):

| Definitely-didn't-land → retry as today | Anything else after a send was attempted → quarantine |
|---|---|
| No platform send attempted at all | Post-transmission socket errors |
| `ECONNREFUSED` / `ENOTFOUND` / `EAI_AGAIN` anywhere in the `cause` chain | Timeouts, 5xx, unrecognized errors |
| Permanent platform rejection (`isPermanentDeliveryError`) | Bare `AbortError` |

Two deliberate exclusions:

- **`ECONNRESET` / `EPIPE` / `ETIMEDOUT` are NOT** treated as definitely-didn't-land — they can fire after the bytes are on the wire.
- **Bare `AbortError` is NOT** special-cased. #3049 established that a transport timeout can surface as a `DOMException` named `AbortError` (BlueBubbles); treating it as definitely-didn't-land would reopen the exact hole #3049 closed. Only a genuinely *caller-cancelled* abort (`isAbortError(err) && abortSignal.aborted === true`) keeps its existing `ackDelivery` path, unchanged.

Per scope clause (c): **no** per-error-code classification matrix and **no** receiver-side idempotency keys. Idempotency keys are the real durable fix and remain the tracked follow-up.

The flag that drives this decision is recorded in exactly one helper, `attemptPlatformSend`, that every one of the 7 platform-send sites goes through.

### Item 4 — fail closed on a malformed entry id

Every on-disk read now goes through `parseQueuedDeliveryEntry`, which rejects any `id` that is not a UUID **before** it can be interpolated into a `needs-review/${id}.json` (or sibling) path.

One guard at the single deserialization point, so `ackDelivery`, `moveToFailed` and the quarantine paths **inherit** it rather than each growing their own check — ids reaching those functions now come only from `randomUUID` or from a value that already passed the guard. All three on-disk parsers (`updateQueueEntry`, `loadPendingDelivery`, `loadPendingDeliveries`) route through it.

### Item 5 — backup sensitivity is documented

`needs-review/` is carved out of the volatile-backup filter (`src/infra/backup-volatile-filter.ts`), so quarantined entries **retain undelivered message payloads** and inherit message-content sensitivity into backups that travel off-box with long retention. New operator page `docs/gateway/message-delivery.md` (contract + a 4-step reconcile runbook + the backup warning), cross-linked from the gateway security page.

## Verification

- `pnpm check` — green (oxfmt, tsgo, oxlint type-aware, all lint gates)
- Full unit lane (`pnpm test:macmini`) — **1041 files / 10077 tests passed**
- Touched suites — 130/130 (`deliver`, `delivery-queue`, `send-outcome`, `describe-delivery-error`)
- Consumer lanes — gateway `server-restart-sentinel` 4/4, auto-reply `route-reply` 19/19
- Fork gates — rebrand (scanning all 10 changed files), zombie-import, stub-debt, throwing-stub-callers, attestations, obsolescence-audit, policy-doctor-boundary: all green
- Docs build — 497 pages, new page verified present in `dist` with its content and inbound link

**Both new guards were mutation-tested, not just asserted.** Disabling the id guard fails exactly 4 tests; unwrapping `attemptPlatformSend` from each of the 4 non-`sendText` platform-send families fails exactly the one test that gates it; reverting the ambiguity accumulator to first-error-wins fails exactly its test. Sources restored byte-identical (checksum-verified) after each mutation.

## For the reviewer — two things flagged, not settled

**1. `isPermanentDeliveryError` in the definitely-didn't-land set — RATIFICATION-PENDING.**
The council's list reads "definitely-didn't-land (AbortError, connection-refused, DNS failure, pre-send validation error)" — a *category* with examples. I read `isPermanentDeliveryError` as belonging to that category: it is the codebase's pre-existing predicate for exactly it (`chat not found`, `user not found`, `bot was blocked by the user`, `missing_scope`), and recovery already uses it to route to `failed/`. Excluding it would put guaranteed-not-delivered messages into a human-reconciliation queue — operator noise on the most common live-send failure class — and destroy their existing `failed/` disposition. Reusing one existing predicate is not the "rich classification matrix" clause (c) forbids.
**If that reading is wrong, reversing it is deleting one clause** from `didSendDefinitelyNotLand`.

**2. The live path and the recovery path now disagree — in-scope-correct, needs tracking.**
This PR changes the live-send path only. `recoverPendingDeliveries`' own retry catch still routes any non-permanent, non-partial failure to `failDelivery`, which clears `recoveryState` and re-arms a replay. So the **identical** error — a socket hang up after the request hit the wire — is now quarantined on the live path and replayed on the recovery path. Concretely: gateway restarts → recovery retries a queued message → the retry times out post-transmission → marker cleared → next restart re-sends → recipient gets it twice.

That is the same hole this PR closes on the live path. Leaving it is faithful to the restricted scope (the council selected the live-send path), but the two paths now disagree and it should be tracked before it is forgotten.

## Deferred — not in this PR

- **Item 2** — fsync durability of the marker write. To be pushed upstream rather than fork-diverged.
- **Item 3** — recipient `to` PII redaction in logs. A separate subsystem logging-policy decision; no blanket phone/email/JID regex was added here. `current.to` is still logged verbatim and stored plaintext.
- **Receiver-side idempotency keys** — the real durable fix for the residual duplicate window, tracked as a separate follow-up.

Closes nothing — #3051 stays open for items 2 and 3.
