### PR TITLE
fix(outbound): quarantine ambiguous failures on the recovery re-send path (#3061)

### DIFF
--- a/docs/gateway/message-delivery.md
+++ b/docs/gateway/message-delivery.md
@@ -40,10 +40,23 @@ Practical consequences:
   connection was refused, the name did not resolve, the platform rejected the
   chat outright, or the send never started) still retry normally.
 
-  A residual window remains. The clearest example: the in-flight marker is
-  written with an atomic rename but is not flushed to stable storage, so a power
-  loss can take the marker with it and a post-reboot recovery pass has nothing
-  left to refuse.
+  This applies to **both** senders: the live send, and the retry the recovery
+  pass makes on its own at startup. They classify a failure with the same
+  predicate, so an ambiguous one is quarantined whichever of the two hit it —
+  a recovery retry that times out after reaching the wire is held for review
+  rather than replayed on the next restart.
+
+  Residual windows remain:
+  - the in-flight marker is written with an atomic rename but is not flushed to
+    stable storage, so a power loss can take the marker with it and a
+    post-reboot recovery pass has nothing left to refuse;
+  - under `bestEffort` a sender reports per-payload failures instead of
+    throwing, and that report does not carry how far each payload got. When a
+    **recovery retry** fails that way with nothing landed, the entry is retried
+    rather than held — so a payload that did reach the recipient can arrive
+    twice. A retry that landed part of the message is still quarantined, and the
+    live send, which keeps the per-payload detail, still quarantines the
+    ambiguous case.
 
 ## The `needs-review` reconciliation queue
 

--- a/src/infra/backup-volatile-filter.ts
+++ b/src/infra/backup-volatile-filter.ts
@@ -128,6 +128,10 @@ export function isVolatileBackupPath(absolutePath: string, plan: VolatileFilterP
       // undelivered message content, which is also where the reconcile/prune
       // expectation that keeps the exposure bounded lives. Narrowing this
       // carve-out means re-reading that page, not just this comment.
+      // `session-delivery-queue/needs-review` is intentionally NOT carved out:
+      // the session queue has no quarantine concept today, so there is nothing
+      // there to preserve. Revisit this carve-out if it gains one — otherwise
+      // those entries would be silently filtered out of backups.
       const needsReviewRoot = path.posix.join(stateDirPosix, "delivery-queue", "needs-review");
       const isAwaitingReview = isUnder(filePosix, needsReviewRoot);
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -12,7 +12,10 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import { createIMessageTestPlugin } from "../../test-utils/imessage-test-plugin.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import { resolvePreferredRemoteClawTmpDir } from "../tmp-remoteclaw-dir.js";
-import { readDeliveredBeforeFailure } from "./delivered-before-failure.js";
+import {
+  readDeliveredBeforeFailure,
+  readPlatformSendAttempted,
+} from "./delivered-before-failure.js";
 
 const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
@@ -974,6 +977,60 @@ describe("deliverOutboundPayloads", () => {
     }).catch((e: unknown) => e);
 
     expect(readDeliveredBeforeFailure(err)).toBe(0);
+  });
+
+  it("annotates the rethrown error with whether a platform send was attempted", async () => {
+    // The landed count alone is not enough for the catcher: a zero count is what
+    // BOTH a pre-send throw and a post-transmission timeout look like, and those
+    // have opposite dispositions. Recovery re-runs `didSendDefinitelyNotLand`
+    // over this flag, so an unannotated throw makes it replay an ambiguous send
+    // (#3061).
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("socket hang up"));
+
+    const err = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }],
+      deps: { sendWhatsApp },
+      skipQueue: true,
+    }).catch((e: unknown) => e);
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(readDeliveredBeforeFailure(err)).toBe(0);
+    expect(readPlatformSendAttempted(err)).toBe(true);
+  });
+
+  it("annotates a failure raised before any send as send-not-attempted", async () => {
+    // The other half of the same contract, and the reason the recovery path can
+    // keep retrying: a media payload on an adapter with no sendMedia and no text
+    // fallback throws before the transport is touched. Reported as `true`, every
+    // pre-send validation error would become manual reconciliation work.
+    const sendText = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const err = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "   ", mediaUrl: "https://example.com/file.png" }],
+      skipQueue: true,
+    }).catch((e: unknown) => e);
+
+    expect(sendText).not.toHaveBeenCalled();
+    expect(readDeliveredBeforeFailure(err)).toBe(0);
+    expect(readPlatformSendAttempted(err)).toBe(false);
   });
 
   it("records a mid-chunk failure as an unknown outcome — earlier chunks already landed", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -39,7 +39,10 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { throwIfAborted } from "./abort.js";
-import { annotateDeliveredBeforeFailure } from "./delivered-before-failure.js";
+import {
+  annotateDeliveredBeforeFailure,
+  annotatePlatformSendAttempted,
+} from "./delivered-before-failure.js";
 import {
   ackDelivery,
   enqueueDelivery,
@@ -629,7 +632,18 @@ export async function deliverOutboundPayloads(
       // this function with skipQueue set, so it owns its own queue bookkeeping
       // and has no other way to tell a total failure (safe to replay whole)
       // from a partial one (replaying duplicates what already arrived).
-      throw annotateDeliveredBeforeFailure(err, landed.length);
+      //
+      // Both facts, not just the count: with nothing landed, `platformSendAttempted`
+      // is the only thing separating "this failure proves nothing arrived" from
+      // "the outcome is unobserved". Without it the recovery pass has to assume
+      // the first and replay — the duplicate this classification exists to
+      // prevent, one restart later (#3061). This is the only throw that can
+      // carry the flag out of this function, and it is annotated at the same
+      // statement as the count so the two cannot drift apart.
+      throw annotatePlatformSendAttempted(
+        annotateDeliveredBeforeFailure(err, landed.length),
+        sendProgress.platformSendAttempted,
+      );
     }
   };
 

--- a/src/infra/outbound/delivered-before-failure.ts
+++ b/src/infra/outbound/delivered-before-failure.ts
@@ -6,12 +6,26 @@
  * The sender knows, so it annotates the error on the way out and the queue's
  * recovery pass reads it back.
  *
+ * Two facts travel this way, and they answer different questions:
+ *
+ * - how many payloads LANDED ({@link annotateDeliveredBeforeFailure}) — "is a
+ *   whole replay safe, or would it re-send what already arrived?";
+ * - whether a platform send was ATTEMPTED
+ *   ({@link annotatePlatformSendAttempted}) — "with nothing landed, did this
+ *   failure PROVE nothing arrived, or is the outcome merely unobserved?"
+ *
+ * Both are needed: with the count alone a caller cannot reconstruct
+ * `didSendDefinitelyNotLand` (`send-outcome.ts`), so it must treat every
+ * nothing-landed failure as a clean one and replay it — which is exactly how an
+ * ambiguous send becomes a duplicate (#3061).
+ *
  * Its own module rather than part of `delivery-queue.ts` so `deliver.ts` can use
  * it without importing the queue: `deliver.test.ts` mocks the queue module
  * wholesale, and a mocked annotation would make a broken one untestable.
  */
 
 const DELIVERED_BEFORE_FAILURE_KEY = "remoteClawDeliveredBeforeFailure";
+const PLATFORM_SEND_ATTEMPTED_KEY = "remoteClawPlatformSendAttempted";
 
 /**
  * Record how many payloads reached the platform before the send failed.
@@ -48,4 +62,57 @@ export function readDeliveredBeforeFailure(err: unknown): number | undefined {
   }
   const value = (err as Record<string, unknown>)[DELIVERED_BEFORE_FAILURE_KEY];
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/**
+ * Record whether any platform send call was ENTERED before the send failed.
+ *
+ * The sibling of {@link annotateDeliveredBeforeFailure}, and deliberately a
+ * second key rather than a widened first one: the two are written together but
+ * mean different things, and a reader that only needs one should not have to
+ * know the other's shape.
+ *
+ * This is the input `didSendDefinitelyNotLand` (`send-outcome.ts`) cannot
+ * recover from the error alone. A failure raised before the first send —
+ * payload normalization, a `message_sending` hook, handler construction, an
+ * abort checked ahead of the first write — definitely did not land and is safe
+ * to replay; one raised after the request hit the wire may have landed and is
+ * not. Both surface as "nothing landed", so without this flag the two are
+ * indistinguishable across the throw.
+ *
+ * Non-enumerable for the same reason as the count: it must not leak into
+ * `JSON.stringify` of the error, and it returns the error so it can be used
+ * inline at a `throw`.
+ */
+export function annotatePlatformSendAttempted<T>(err: T, platformSendAttempted: boolean): T {
+  if (err && typeof err === "object") {
+    try {
+      Object.defineProperty(err, PLATFORM_SEND_ATTEMPTED_KEY, {
+        value: platformSendAttempted,
+        enumerable: false,
+        configurable: true,
+        writable: true,
+      });
+    } catch {
+      // Frozen or non-extensible error. Losing the annotation costs precision;
+      // throwing here would replace the real delivery failure with a TypeError.
+    }
+  }
+  return err;
+}
+
+/**
+ * Read the annotation left by {@link annotatePlatformSendAttempted}.
+ *
+ * `undefined` means the sender did not report one — not that no send was
+ * attempted. Callers must decide what an unreported outcome means for them; the
+ * conservative reading depends on what they do with it, so this module does not
+ * pick a default on their behalf.
+ */
+export function readPlatformSendAttempted(err: unknown): boolean | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const value = (err as Record<string, unknown>)[PLATFORM_SEND_ATTEMPTED_KEY];
+  return typeof value === "boolean" ? value : undefined;
 }

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RemoteClawConfig } from "../../config/config.js";
-import { annotateDeliveredBeforeFailure } from "./delivered-before-failure.js";
+import {
+  annotateDeliveredBeforeFailure,
+  annotatePlatformSendAttempted,
+} from "./delivered-before-failure.js";
 import {
   ackDelivery,
   clearDeliveryAttemptMarker,
@@ -79,6 +82,16 @@ async function runRecovery(
 async function readEntry(id: string, dir?: string): Promise<QueuedDelivery> {
   const filePath = path.join(dir ?? path.join(stateDir, "delivery-queue"), `${id}.json`);
   return JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
+}
+
+/**
+ * Every path under the state directory, sorted. Asserting a refused entry
+ * produced no file ANYWHERE is stronger than checking the one directory an
+ * escape was expected to reach — a traversal that lands somewhere unanticipated
+ * still shows up as a new path.
+ */
+async function listStateDirTree(): Promise<string[]> {
+  return (await fs.promises.readdir(stateDir, { recursive: true })).toSorted();
 }
 
 describe("send-in-flight marker", () => {
@@ -327,6 +340,82 @@ describe("entry id shape guard (#3051)", () => {
     const pending = await loadPendingDeliveries(stateDir);
 
     expect(pending.map((entry) => entry.id)).toEqual([id]);
+  });
+
+  // #3061 item 3: the guard's only job is to keep an attacker-chosen string out
+  // of a path build, so the payloads it must refuse are worth naming one by one.
+  // "not-a-uuid" above is refused by almost any pattern; these are the ones a
+  // silently-loosened pattern lets through — a dropped anchor, an added `m`
+  // flag, a character class widened to include `/` or `.` — each with the suite
+  // still green and the failure mode a queue operation writing outside its own
+  // directory.
+  const traversalIds: readonly { label: string; id: string }[] = [
+    { label: "a relative traversal", id: "../../etc/passwd" },
+    { label: "an absolute path", id: "/etc/passwd" },
+    { label: "a bare parent reference", id: ".." },
+    { label: "an embedded separator", id: "00000000-0000-4000-8000-000000000000/x" },
+    // `$` in JS matches only the true end of input — unlike flavours where it
+    // also matches before a trailing newline. Pinned so adding an `m` flag (or
+    // porting the pattern) cannot reintroduce that escape unnoticed.
+    { label: "a trailing newline", id: "00000000-0000-4000-8000-000000000000\n" },
+    { label: "a NUL byte", id: "00000000-0000-4000-8000-000000000000\u0000.json" },
+  ];
+
+  it.each(traversalIds)("refuses $label as an entry id", async ({ id }) => {
+    // Read through the scan rather than the guard directly: this is the path an
+    // on-disk id actually travels, and it is where a caller would otherwise pick
+    // the value up and hand it to `${dir}/${id}.json`.
+    await plantRawEntry("00000000-0000-4000-8000-000000000000", { ...plantedEntry, id });
+    const skipped: unknown[] = [];
+
+    const pending = await loadPendingDeliveries(stateDir, (_file, err) => skipped.push(err));
+
+    expect(pending).toEqual([]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toBeInstanceOf(InvalidQueueEntryIdError);
+  });
+
+  it("accepts a canonical uuid, in either case", async () => {
+    // The complement of the table above: a shape check, not a version check, so
+    // every RFC 4122 layout is equally acceptable and the pattern is
+    // case-insensitive. Without this, "reject everything" would pass the table.
+    for (const id of [
+      "0b6d4f6e-6b7a-4f0e-9c2a-1d3e5f7a9b1c",
+      "AABBCCDD-1122-4EEF-8899-001122334455",
+      // A v1 layout, to pin "shape check, not version check".
+      "00000000-0000-1000-8000-000000000000",
+    ]) {
+      await plantRawEntry(id, { ...plantedEntry, id });
+    }
+
+    const pending = await loadPendingDeliveries(stateDir);
+
+    expect(pending).toHaveLength(3);
+  });
+
+  it("builds no path from any refused id, in the queue directory or outside it", async () => {
+    // The property that matters is not "it threw" but "nothing was created or
+    // moved on its behalf" — no `needs-review/${id}.json`, no `failed/${id}.json`,
+    // no sibling anywhere. Compare the whole state directory before and after a
+    // full recovery pass: an escape that lands somewhere unanticipated still
+    // shows up as a new path.
+    for (const [index, { id }] of traversalIds.entries()) {
+      await plantRawEntry(`0000000${index}-0000-4000-8000-000000000000`, {
+        ...plantedEntry,
+        id,
+      });
+    }
+    const before = await listStateDirTree();
+
+    const deliver = vi.fn<DeliverFn>(async () => undefined);
+    const { summary } = await runRecovery(deliver);
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(0);
+    expect(summary.quarantineFailed).toBe(0);
+    expect(summary.failed).toBe(0);
+    expect(fs.existsSync(resolveNeedsReviewDir(stateDir))).toBe(false);
+    expect(await listStateDirTree()).toEqual(before);
   });
 });
 
@@ -679,6 +768,162 @@ describe("recoverPendingDeliveries", () => {
     const entry = await readEntry(id);
     expect(entry.recoveryState).toBeUndefined();
     expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  // #3061: recovery's own re-send has the same ambiguous-failure window as the
+  // live path, and before this it resolved it the opposite way — the live send
+  // quarantined the failure, recovery cleared the marker and replayed it on the
+  // next restart. These four pin the symmetry: same classifier, same three arms,
+  // so only the genuinely undetermined subset is quarantined.
+  it("quarantines a re-send that failed ambiguously after reaching the transport (#3061)", async () => {
+    // The bug this closes: a send was attempted, nothing was OBSERVED to land,
+    // and the transport failed post-transmission. That is "we cannot tell", not
+    // "nothing arrived" — replaying it is how the recipient gets it twice.
+    const id = await enqueueTestDelivery();
+    const ambiguous = vi.fn<DeliverFn>(async () => {
+      throw annotatePlatformSendAttempted(
+        annotateDeliveredBeforeFailure(
+          Object.assign(new Error("socket hang up"), { code: "ETIMEDOUT" }),
+          0,
+        ),
+        true,
+      );
+    });
+
+    const { summary } = await runRecovery(ambiguous);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+    // Unknowable, not zero: `0` reads to an operator as "confirmed nothing
+    // arrived", which is exactly what this outcome cannot confirm.
+    expect(entry.deliveredBeforeFailure).toBeUndefined();
+  });
+
+  it("does not replay an ambiguously-failed re-send on the next startup (#3061)", async () => {
+    // The disposition only matters if it survives the restart. Quarantine has to
+    // take the entry out of the pending scan, not just stamp it.
+    const id = await enqueueTestDelivery();
+    await runRecovery(
+      vi.fn<DeliverFn>(async () => {
+        throw annotatePlatformSendAttempted(
+          annotateDeliveredBeforeFailure(new Error("socket hang up"), 0),
+          true,
+        );
+      }),
+    );
+
+    const replay = vi.fn<DeliverFn>(async () => undefined);
+    const { summary } = await runRecovery(replay);
+
+    expect(replay).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+    expect(fs.existsSync(path.join(resolveNeedsReviewDir(stateDir), `${id}.json`))).toBe(true);
+  });
+
+  it("still replays a re-send that failed before reaching the transport (#3061)", async () => {
+    // The blanket-quarantine mistake, guarded: a deterministic pre-send throw
+    // (payload normalization, a hook, handler construction) definitely did not
+    // land, so it must stay on the retry path exactly as the live send treats it.
+    // Quarantining it would put routine validation errors into the operator's
+    // manual queue and stop them ever being sent.
+    const id = await enqueueTestDelivery();
+    const preSend = vi.fn<DeliverFn>(async () => {
+      throw annotatePlatformSendAttempted(
+        annotateDeliveredBeforeFailure(new Error("no text fallback is available"), 0),
+        false,
+      );
+    });
+
+    const { summary } = await runRecovery(preSend);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+    expect(entry.retryCount).toBe(1);
+  });
+
+  it("still replays a re-send whose connection was never established (#3061)", async () => {
+    // A send WAS attempted, so the flag alone would quarantine this — the errno
+    // arm of `didSendDefinitelyNotLand` is what keeps routine transient outages
+    // out of the reconciliation queue. Recovery re-runs the whole predicate, not
+    // just the new flag.
+    const id = await enqueueTestDelivery();
+    const refused = vi.fn<DeliverFn>(async () => {
+      throw annotatePlatformSendAttempted(
+        annotateDeliveredBeforeFailure(
+          Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:443"), {
+            code: "ECONNREFUSED",
+          }),
+          0,
+        ),
+        true,
+      );
+    });
+
+    await runRecovery(refused);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  it("keeps the partial-delivery disposition ahead of the ambiguity check (#3061)", async () => {
+    // Both properties hold at once here (a send was attempted AND part of it
+    // landed), and the landed count has to win: it is the more specific record,
+    // and it is the only thing that tells the operator which parts arrived.
+    const id = await enqueueTestDelivery();
+    const partial = vi.fn<DeliverFn>(async () => {
+      throw annotatePlatformSendAttempted(
+        annotateDeliveredBeforeFailure(new Error("socket hang up"), 1),
+        true,
+      );
+    });
+
+    await runRecovery(partial);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(entry.deliveredBeforeFailure).toBe(1);
+  });
+
+  it("keeps a permanent rejection on failed/ even though a send was attempted (#3061)", async () => {
+    // The third arm. "chat not found" is the platform saying it did NOT accept
+    // the message — a guaranteed non-delivery, not an ambiguity. Routing it to
+    // needs-review would bury a known outcome among the undetermined ones.
+    const id = await enqueueTestDelivery();
+    const permanent = vi.fn<DeliverFn>(async () => {
+      throw annotatePlatformSendAttempted(
+        annotateDeliveredBeforeFailure(new Error("Bad Request: chat not found"), 0),
+        true,
+      );
+    });
+
+    const { summary } = await runRecovery(permanent);
+
+    expect(summary.failed).toBe(1);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", "failed", `${id}.json`))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", `${id}.json`))).toBe(false);
+  });
+
+  it("treats an unannotated failure as replay-whole (#3061)", async () => {
+    // A DeliverFn that is not the outbound sender cannot report the flag, and
+    // guessing "attempted" on its behalf would quarantine every failure it ever
+    // raises. Unreported keeps the historical behaviour — the same default the
+    // landed count takes.
+    const id = await enqueueTestDelivery();
+    const unannotated = vi.fn<DeliverFn>(async () => {
+      throw new Error("socket hang up");
+    });
+
+    await runRecovery(unannotated);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+    expect(entry.retryCount).toBe(1);
   });
 
   it("does not ack a bestEffort retry whose payloads all failed", async () => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -42,9 +42,10 @@ import { generateSecureUuid } from "../secure-random.js";
 import {
   annotateDeliveredBeforeFailure,
   readDeliveredBeforeFailure,
+  readPlatformSendAttempted,
 } from "./delivered-before-failure.js";
 import { describeDeliveryError } from "./describe-delivery-error.js";
-import { isPermanentDeliveryError } from "./send-outcome.js";
+import { didSendDefinitelyNotLand, isPermanentDeliveryError } from "./send-outcome.js";
 import type { OutboundChannel } from "./targets.js";
 
 export { isPermanentDeliveryError } from "./send-outcome.js";
@@ -952,6 +953,16 @@ export async function recoverPendingDeliveries(opts: {
         if (sawPayloadFailure) {
           // Route it exactly as a thrown failure would be: what already landed
           // decides between "retry it whole" and "a human has to reconcile it".
+          //
+          // Deliberately NOT annotated with `platformSendAttempted`: under
+          // `bestEffort` the sender REPORTS per-payload errors and resolves
+          // instead of throwing, and how far each payload got does not cross
+          // that resolve boundary — this error is synthesized here, not caught
+          // from the sender. So with nothing landed the entry replays, where the
+          // live path (which still holds the per-payload detail) would quarantine
+          // an ambiguous one. Narrow, deliberate, and documented as a residual in
+          // `docs/gateway/message-delivery.md` § Delivery guarantee rather than
+          // papered over with a guess (#3060, #3061).
           const landed = Array.isArray(sent) ? sent.length : 0;
           throw annotateDeliveredBeforeFailure(
             new Error(
@@ -1005,6 +1016,48 @@ export async function recoverPendingDeliveries(opts: {
             opts.log.error(`Failed to move entry ${current.id} to failed/: ${String(moveErr)}`);
           }
           summary.failed += 1;
+          return;
+        }
+
+        // Nothing landed and retrying is not hopeless — but "no payload was
+        // observed to land" is not "nothing arrived". Re-run the LIVE path's
+        // own classifier rather than assuming the clean case: a re-send that
+        // times out or resets after the request hit the wire may already be on
+        // the recipient's device, and clearing the marker here replays it on the
+        // next restart. Before #3061 this branch always cleared, so the two
+        // paths disagreed about the identical failure — the live send
+        // quarantined it and recovery duplicated it.
+        //
+        // The live path's predicate verbatim, not a recovery-local variant: a
+        // pre-send throw that never reached the transport and a connection that
+        // was never established both still retry, so only the genuinely
+        // undetermined subset is quarantined. Its third arm — an outright
+        // platform rejection — is unreachable from here, since the permanent
+        // branch above already filed that case under failed/; it is kept anyway,
+        // because diverging from the shared predicate is how these two paths
+        // came to disagree in the first place.
+        //
+        // Unreported flag means the DeliverFn is not the outbound sender and
+        // cannot tell us, so keep the historical replay-whole behaviour — the
+        // same default the landed count takes above. The real sender always
+        // reports it: every throw out of `deliverOutboundPayloads` passes the
+        // annotating site, including its pre-send failures.
+        const definitelyDidNotLand = didSendDefinitelyNotLand({
+          platformSendAttempted: readPlatformSendAttempted(err) ?? false,
+          error: err,
+          describedError: errMsg,
+        });
+
+        if (!definitelyDidNotLand) {
+          try {
+            await failUnknownDelivery(current.id, errMsg, opts.stateDir);
+          } catch {
+            // Best-effort update.
+          }
+          summary.failed += 1;
+          opts.log.warn(
+            `Retry for delivery ${current.id} failed without a determinable outcome — it may or may not have reached the recipient, so it will be quarantined rather than replayed: ${errMsg}`,
+          );
           return;
         }
 


### PR DESCRIPTION
Closes #3061.

> ⚠️ **Item 1 is a runtime change on the delivery path and needs an independent security review before merge.** It changes which failures a recovery re-send quarantines instead of replaying. Notes for that review are in § For the reviewer.

## Why

#3060 taught the **live** send path to stop replaying ambiguous failures: a send was attempted, `landed.length === 0`, and the transport threw a non-permanent error *after* the request hit the wire (`ETIMEDOUT`, `ECONNRESET`, a 5xx). "We got no result" is not "nothing arrived", so it quarantines via `failUnknownDelivery` rather than clearing the marker.

The **recovery re-send** path — `recoverPendingDeliveries`' own retry catch — was left with the pre-#3060 behaviour for that identical case. It decided with only two inputs, the landed count and `isPermanentDeliveryError`, so the ambiguous case fell into the terminal `else` → `failDelivery` → marker cleared → replayed on the next restart. The two senders disagreed about the same failure: the live one held it for a human, recovery duplicated it.

Root cause: the cross-throw annotation channel (`delivered-before-failure.ts`) carried only the landed count, never whether a platform send was **attempted** — so the recovery catch could not reconstruct the live path's `didSendDefinitelyNotLand(...)` decision.

## What changed

**1. Propagate `platformSendAttempted` across the throw** *(runtime)*

- `delivered-before-failure.ts` gains a second non-enumerable annotation (`annotatePlatformSendAttempted` / `readPlatformSendAttempted`) mirroring the existing landed-count pair.
- `deliver.ts` writes it at the one throw that can carry it out of the function, in the same statement as the count so the two cannot drift apart.
- The recovery catch's terminal `else` reads it back and re-runs the **live path's own predicate**, verbatim.

Branch order in the catch — unchanged prefix, one arm inserted third:

| | Condition | Disposition |
|---|---|---|
| 1 | `landedBeforeFailure > 0` | `failPartialDelivery` — quarantine, count recorded |
| 2 | `isPermanentDeliveryError` | clear marker + `moveToFailed` |
| 3 | **new** — `!didSendDefinitelyNotLand(...)` | `failUnknownDelivery` — quarantine, count left unset |
| 4 | else | `failDelivery` — retry |

Deliberately **not** a blanket `failUnknownDelivery` in the `else`. A deterministic pre-send throw (payload normalization, a `message_sending` hook, handler construction) never reached the transport, and a refused connection never established one — both still retry, exactly as the live path treats them. Only the genuinely undetermined subset moves. M2 in the mutation table below is that mistake, deliberately introduced to confirm the suite catches it.

An absent annotation defaults to `false` → retry, i.e. the historical behaviour, matching the `readDeliveredBeforeFailure(err) ?? 0` precedent directly above it. The real sender always annotates — every throw out of `deliverOutboundPayloads` passes the single annotating site, including its pre-send failures — so the default only governs third-party `DeliverFn`s and non-object/frozen errors.

**2. `docs/gateway/message-delivery.md` reconciled** *(doc)*

The page claimed ambiguous sends are quarantined without carving out the recovery re-send. Rather than adding a caveat, it now states the unified behaviour (both senders classify with the same predicate) and names the residuals precisely — the pre-existing power-loss window, plus the `bestEffort` one below.

**3. Traversal vectors for the queue-entry id guard** *(test)*

**Correction to the issue's premise:** #3061 states no test exercises `parseQueuedDeliveryEntry` / `InvalidQueueEntryIdError`. That was true of the state the review ran against, but the *merged* #3060 (`5facad9`) added a 6-test `entry id shape guard (#3051)` suite. This PR therefore extends that suite with the enumerated payloads it did **not** cover — `../../etc/passwd`, an absolute path, a bare `..`, a trailing newline, a NUL byte (an embedded separator was already covered indirectly) — plus a canonical-uuid accept case in both cases and a v1 layout, and a whole-state-directory before/after comparison proving no refused id yields *any* constructed path, in `needs-review/`, `failed/`, or anywhere else.

**4. Session-queue carve-out comment** *(comment)*

One line at the `backup-volatile-filter.ts` carve-out recording that `session-delivery-queue/needs-review` is intentionally not covered because the session queue has no quarantine concept today — and that the carve-out must be extended in parallel if it gains one, or those entries would be silently filtered out of backups.

## Evidence

| Gate | Result |
|---|---|
| `pnpm check` — oxfmt, tsgo, oxlint type-aware, 5 lint gates | PASS |
| `check-rebrand-leakage.sh`, `check-no-zombie-imports`, `check-stub-debt`, `check-throwing-stub-callers`, `check-attestations` (+ `--self-test`), `check-obsolescence-audit` | PASS |
| docs CI job — `npm ci && astro build` in `docs/` | PASS |
| Outbound suites (`delivery-queue`, `deliver`, `send-outcome`) | 140/140, all 20 new tests verified present in verbose output |

`pnpm check:docs` is not a CI job; it reports 133 markdownlint errors both with and without this change — all pre-existing, none in the edited file.

LIVE smoke tests are N/A: nothing under `src/middleware/` is touched.

### Mutation check

Each guard was disabled in turn to confirm it is load-bearing and that the tests fail for the right reason:

| Mutation | Tests killed |
|---|---|
| M1 — disable the new classifier (pre-#3061 behaviour) | 2, exactly the ambiguous-quarantine pair |
| M2 — blanket `failUnknownDelivery` in the `else` (the over-quarantine mistake) | 6: 3 pre-existing replay tests + 3 new ones |
| M3 — drop `annotatePlatformSendAttempted` at the throw site | 2, exactly the propagation-contract pair |
| M4 — add an `m` flag to `QUEUE_ENTRY_ID_PATTERN` | 1, exactly the trailing-newline vector |
| M5 — skip the `landedBeforeFailure > 0` branch | 5, including the new precedence test |

## For the reviewer

**Newly-reachable state.** `recoveryState: "unknown_after_send"` gains a producer. The value itself is not new — `failPartialDelivery` already produced it on this path and `failUnknownDelivery` on the live one — so only *which failures reach it* widens, and no consumer is new. Every consumer was enumerated (`grep` over `src/ extensions/ ui/ apps/ docs/ scripts/`); all live in `delivery-queue.ts` plus the operator doc, none in `ui/`, `apps/`, `extensions/` or `scripts/`:

- `hasUnknownSendOutcome` → quarantine on the next pass (asserted by the "next startup" test);
- `describeDeliveredBeforeFailure` guards `typeof landed !== "number"`, so the deliberately-unset count renders as nothing rather than a misleading "0 confirmed";
- `formatSendStartedAt` still has a real timestamp — `markDeliveryAttemptStarted` stamps the recovery re-send and `failUnknownDelivery` does not clear it;
- `describeRetryCountResetReason` is truthful at `retryCount: 1`, which is exactly this path (#3060 fixed that);
- the reconcile runbook line and doc steps apply unchanged.

**Blast radius worth stating.** More quarantined entries means more undelivered message payloads in `delivery-queue/needs-review/`, which is deliberately carved out of the volatile-backup filter — so this puts marginally more message content into backups. That is the trade already documented in `docs/gateway/message-delivery.md` § Backups contain undelivered message content, along with the reconcile-and-prune hygiene that bounds it. Directionally it is the same trade #3060 made on the live path; flagging it explicitly rather than letting it ride.

**Known residual, deliberately out of scope.** Under `bestEffort` the sender *reports* per-payload failures and resolves instead of throwing, so per-payload transport progress never crosses that boundary — the recovery path synthesises its own error there. A `bestEffort` recovery retry where every payload fails and none lands therefore still replays, where the live path (which keeps the per-payload detail) would quarantine. #3060 encoded that recovery behaviour deliberately (`delivery-queue.test.ts` — "Nothing landed, so it stays replayable rather than becoming manual work"), and closing it needs a different channel than #3061's "propagate across the throw". It is commented at the synthesis site and documented as a residual rather than papered over — happy to open a follow-up if you want it closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
