### PR TITLE
docs(e2e): document clickclack release-user-journey exclusion; report blocked raw-fetch gate (#3055)

### DIFF
--- a/scripts/lib/docker-e2e-scenarios.mjs
+++ b/scripts/lib/docker-e2e-scenarios.mjs
@@ -349,6 +349,22 @@ export const mainLanes = [
     "REMOTECLAW_NPM_ONBOARD_CHANNEL=slack REMOTECLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:npm-onboard-channel-agent",
     { resources: ["service"], stateScenario: "empty", weight: 3 },
   ),
+  // Not runnable in the RemoteClaw fork — no ClickClack (or any-channel) e2e
+  // coverage here (#3055). The lane's runner, upstream's
+  // `scripts/e2e/lib/release-user-journey/`, was never ported, so
+  // `test:docker:release-user-journey` is not a package.json script in this
+  // repo and the lane cannot execute. `node scripts/check-docker-e2e-boundaries.mjs`
+  // reports it — it is one of 64 lanes here pointing at 39 package scripts that
+  // this fork never ported.
+  //
+  // ClickClack coverage upstream is three files, not one: `clickclack-fixture.mjs`
+  // (a standalone mock ClickClack HTTP server — it imports no plugin-sdk, so the
+  // fork's plugin-sdk decomposition is NOT what blocks it), `write-clickclack-plugin.mjs`,
+  // and `assertions.mjs configure-clickclack`. All three are spawned by that
+  // directory's `scenario.sh`. Porting any of them on its own would land an
+  // unreachable file rather than coverage, so the exclusion is deliberate:
+  // restoring ClickClack e2e here means porting the `scripts/e2e/lib/` harness,
+  // which is tracked separately from #3055.
   npmLane(
     "release-user-journey",
     "REMOTECLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:release-user-journey",


### PR DESCRIPTION
Refs #3055.

**No runtime product-code change.** One comment-only edit to a scripts file (16 added lines, all comments, 0 removed).

---

## ⚠️ Item 1 is BLOCKED — `check-no-raw-channel-fetch.mjs` FAILS on the current tree

The gate was **not** wired into CI, because it does not pass. Per the issue's own acceptance ("runs in CI **and passes on the current tree**") and the standing instruction not to neuter the gate, weaken its matcher, or pad the ledger, this is reported rather than suppressed.

```
$ node scripts/check-no-raw-channel-fetch.mjs
Found raw fetch() usage in channel/plugin runtime sources outside allowlist:
- extensions/bluebubbles/src/types.ts:161
- extensions/discord/src/monitor/gateway-plugin.ts:298
- extensions/discord/src/monitor/gateway-plugin.ts:332
- extensions/discord/src/send.outbound.ts:361
- extensions/matrix/src/directory-live.ts:41
- extensions/mattermost/src/mattermost/probe.ts:28
- extensions/msteams/src/graph.ts:39
- extensions/nextcloud-talk/src/send.ts:104
- extensions/nextcloud-talk/src/send.ts:196
- extensions/slack/src/monitor/media.ts:107
- extensions/slack/src/monitor/media.ts:63
- extensions/slack/src/monitor/media.ts:67
- extensions/slack/src/monitor/media.ts:81
- extensions/talk-voice/index.ts:31
- extensions/tlon/src/tlon-api.ts:184
- extensions/tlon/src/tlon-api.ts:234
- extensions/tlon/src/tlon-api.ts:288
- extensions/voice-call/src/providers/tts-openai.ts:126
- src/channels/telegram/api.ts:8
Use fetchWithSsrFGuard() or existing channel/plugin SDK wrappers for network calls.
EXIT=1
```

19 violations across 10 adapters. All verified real `fetch(` call expressions — not false positives.

### Root cause: the ledger is inherited from upstream and has rotted

The fork's allowlist is upstream's verbatim (plus the clickclack entry from #2861). Because the gate has **never run here**, nothing caught the drift. Most ledgered lines no longer point at a `fetch(`:

| Ledger entry | State in fork |
|---|---|
| `discord/src/monitor/gateway-plugin.ts:417`, `:483` | stale — no `fetch` at those lines; the file's 2 `fetch` calls are now at 298/332 |
| `msteams/src/graph.ts:47` | stale — the file's 1 `fetch` call is now at 39 |
| `slack/src/monitor/media.ts:106`, `:125`, `:130` | stale — `:125` matches only the identifier `fetchedContentType`, not a call |
| `matrix/src/matrix/sdk/transport.ts:112` | **file does not exist in this fork** |

### Risk triage (URL provenance at each callsite)

Severity is *not* uniform. Grouped by whether the fetched URL is attacker-influenceable:

- **Hardcoded vendor host — low risk.** `talk-voice/index.ts:31` (`https://api.elevenlabs.io/...`), `voice-call/.../tts-openai.ts:126` (`https://api.openai.com/...`), `src/channels/telegram/api.ts:8` (`https://api.telegram.org/...`), `tlon/tlon-api.ts:184` (`${MEMEX_BASE_URL}/...`), `msteams/graph.ts:39` (`${GRAPH_ROOT}...`).
- **Operator-config base URL — same class as the approved clickclack entry.** `mattermost/probe.ts:28`, `nextcloud-talk/send.ts:104,196`, `matrix/directory-live.ts:41` (`${params.homeserver}`).
- **Line-drift of an already-approved upstream callsite.** `discord/gateway-plugin.ts:298,332` (the `fetchImpl` injection point), `msteams/graph.ts:39`.
- **Server- or inbound-influenced URL — warrants actual review.** `tlon/tlon-api.ts:234` (`uploadUrl`) and `:288` (`signedUrl`), both server-supplied; `slack/monitor/media.ts:107` follows a redirect `Location` with `redirect: "follow"`; `slack/monitor/media.ts:67` fetches `url` on the branch that does *not* run `assertSlackFileUrl`; `bluebubbles/types.ts:161` is a generic caller-supplied-`url` wrapper; `discord/send.outbound.ts:361` builds from `resolveWebhookExecutionUrl(...)`.

Note `slack/monitor/media.ts:63` and `:81` do validate via `assertSlackFileUrl` first.

### Why this PR does not fix it

Remediation is available — `fetchWithSsrFGuard` exists in this fork (exported from the per-channel `src/plugin-sdk/*` barrels; already used by 22 extension files). But closing this means migrating 19 callsites across 10 adapters, each needing a URL-provenance security judgement, which is runtime product-code change well outside this issue's stated scope. **Recommend a dedicated follow-up issue**; per `CLAUDE.md` ("the allowlist is a debt ledger, not an escape hatch") any re-pinned ledger entries should reference it.

### `Refs`, not `Closes` — deliberate

The dispatch asked for `Closes #3055`, but acceptance criterion (a) is unmet. Auto-closing would drop the tracker for a live security gap. Switch to `Closes` if you'd rather split item 1 into its own issue first.

---

## ✅ Item 2 — clickclack e2e: exclusion documented

`scripts/lib/docker-e2e-scenarios.mjs` — comment at the `release-user-journey` lane (the fork's fixture-registry site).

**PORT was evaluated and rejected on evidence**, not preference:

- The fork has **no `scripts/e2e/lib/` directory at all** — the entire release-user-journey runner (`scenario.sh`, `assertions.mjs`, `write-clickclack-plugin.mjs`, `env-limits.mjs`) is absent.
- `test:docker:release-user-journey` is **not a package.json script** here — only 7 of 44 referenced `test:docker:*` scripts exist.
- The repo's own tooling confirms it: `node scripts/check-docker-e2e-boundaries.mjs` reports the lane as one of **64 lanes pointing at 39 missing package scripts**.
- Upstream's `scenario.sh:154` is what spawns the fixture. With no `scenario.sh`, a ported fixture is unreachable — a dead file, not coverage.

### Two corrections to the issue's framing (grounded against live source)

1. **The fixture needs no plugin-sdk adaptation.** `clickclack-fixture.mjs` is a standalone mock ClickClack HTTP server; its only non-`node:` import is `../env-limits.mjs`. It imports zero plugin-sdk, so the fork's plugin-sdk decomposition and the OpenClaw→RemoteClaw rebrand are *not* what block the port. The missing harness is.
2. **ClickClack coverage upstream is three files, not one** — `clickclack-fixture.mjs`, `write-clickclack-plugin.mjs`, and `assertions.mjs configure-clickclack`.

Also note the frozen local `../openclaw` reference (Apr 19) predates clickclack entirely and has no `release-user-journey`; this was verified against `openclaw/openclaw@main` via the GitHub API.

---

## Verification

- `pnpm check` — **green** (format + tsgo + type-aware lint + all `lint:*` gates); re-run green by the pre-commit hook.
- `node --check scripts/lib/docker-e2e-scenarios.mjs` — parses.
- Registry re-imported: `release-user-journey` lane object unchanged (command, `timeoutMs` 1200000, weight 4, resources).
- Diff audited mechanically: 16 added lines, **0** non-comment additions, 0 removals.

## Incidental finding (not addressed here)

`scripts/check-docker-e2e-boundaries.mjs` is also invoked nowhere — not in any workflow, not a package script. Same class of gap as item 1.
