### PR TITLE
fix(outbound): quarantine ambiguous bestEffort failures on the recovery path (#3063)

### DIFF
--- a/docs/gateway/message-delivery.md
+++ b/docs/gateway/message-delivery.md
@@ -40,23 +40,18 @@ Practical consequences:
   connection was refused, the name did not resolve, the platform rejected the
   chat outright, or the send never started) still retry normally.
 
-  This applies to **both** senders: the live send, and the retry the recovery
-  pass makes on its own at startup. They classify a failure with the same
-  predicate, so an ambiguous one is quarantined whichever of the two hit it —
-  a recovery retry that times out after reaching the wire is held for review
-  rather than replayed on the next restart.
+  This applies to **both** senders — the live send, and the retry the recovery
+  pass makes on its own at startup — and to **both** ways a send can fail:
+  raising an error, or, under `bestEffort`, reporting each payload's failure and
+  returning. All four combinations classify with the same predicate, so an
+  ambiguous failure is quarantined whichever one hit it. A recovery retry that
+  times out after reaching the wire is held for review rather than replayed on
+  the next restart, and so is a `bestEffort` recovery retry whose payloads
+  failed that way with nothing landed.
 
-  Residual windows remain:
-  - the in-flight marker is written with an atomic rename but is not flushed to
-    stable storage, so a power loss can take the marker with it and a
-    post-reboot recovery pass has nothing left to refuse;
-  - under `bestEffort` a sender reports per-payload failures instead of
-    throwing, and that report does not carry how far each payload got. When a
-    **recovery retry** fails that way with nothing landed, the entry is retried
-    rather than held — so a payload that did reach the recipient can arrive
-    twice. A retry that landed part of the message is still quarantined, and the
-    live send, which keeps the per-payload detail, still quarantines the
-    ambiguous case.
+  One residual window remains: the in-flight marker is written with an atomic
+  rename but is not flushed to stable storage, so a power loss can take the
+  marker with it and a post-reboot recovery pass has nothing left to refuse.
 
 ## The `needs-review` reconciliation queue
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -943,6 +943,27 @@ describe("deliverOutboundPayloads", () => {
     expect(onError).toHaveBeenCalledWith(expect.any(Error), expect.anything());
   });
 
+  it("tells a bestEffort onError caller whether the payload reached the transport (#3063)", async () => {
+    // bestEffort resolves, so the annotated throw below never fires and a caller
+    // that re-classifies the failure — the queue's recovery pass does, to choose
+    // between replaying and quarantining — has only this channel. Without it
+    // every reported failure reads as "no send was ever made" and gets replayed.
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("socket hang up"));
+    const onError = vi.fn();
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "a" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+      onError,
+    });
+
+    expect(readPlatformSendAttempted(onError.mock.calls[0]?.[0])).toBe(true);
+  });
+
   it("annotates the rethrown error with how many payloads landed", async () => {
     // Crash recovery calls this function with skipQueue set, so it does its own
     // queue bookkeeping and the error is its only channel for "how far did the
@@ -1310,6 +1331,40 @@ describe("deliverOutboundPayloads", () => {
     expect(sendText).not.toHaveBeenCalled();
     expect(queueMocks.failUnknownDelivery).not.toHaveBeenCalled();
     expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+  });
+
+  it("reports a pre-send failure to a bestEffort onError caller as not attempted (#3063)", async () => {
+    // The other half of the annotation the recovery pass reads. The same
+    // pre-send failure as the test above, reported instead of thrown: the flag
+    // has to say false rather than simply be absent, or a caller cannot tell
+    // "the send never started" (replayable) from "the sender said nothing".
+    const sendText = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+    const onError = vi.fn();
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "   ", mediaUrl: "https://example.com/file.png" }],
+      bestEffort: true,
+      onError,
+    });
+
+    expect(sendText).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(readPlatformSendAttempted(onError.mock.calls[0]?.[0])).toBe(false);
   });
 
   it("acks the queue entry when delivery is aborted", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -551,7 +551,19 @@ export async function deliverOutboundPayloads(
       // Keep the cause: "partial delivery failure (bestEffort)" alone tells an
       // operator triaging the entry nothing about why it failed.
       firstPayloadError ??= described;
-      params.onError?.(err, payload);
+      // The only channel that carries how far THIS payload got out of a
+      // bestEffort send. The annotated `throw` below cannot: under bestEffort
+      // the core catches per-payload and this function RESOLVES, so there is no
+      // throw for a caller to read — which is why #3061 fixed the throwing path
+      // and left this one replaying (#3063). A caller that re-classifies the
+      // failure (the queue's recovery pass does, to choose between replaying and
+      // quarantining) otherwise sees a bare error and has to assume no send ever
+      // started. Annotated at the same statement as the classification above, so
+      // the two cannot disagree about one payload.
+      params.onError?.(
+        annotatePlatformSendAttempted(err, sendProgress.platformSendAttempted),
+        payload,
+      );
     },
   };
 

--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -961,6 +961,205 @@ describe("recoverPendingDeliveries", () => {
     expect(entry.deliveredBeforeFailure).toBe(1);
   });
 
+  // #3063: the bestEffort half of the #3061 symmetry above. This sender REPORTS
+  // per-payload failures and RESOLVES, so the annotated throw those tests rely
+  // on never happens — the sender annotates each per-payload error on its way
+  // into onError instead. Same classifier, same three arms, same partial-first
+  // ordering, so recovery and the live send dispose of an identical bestEffort
+  // failure identically.
+  it("quarantines a bestEffort retry that failed ambiguously with nothing landed (#3063)", async () => {
+    // The bug this closes: every payload failed after reaching the transport and
+    // none was observed to land. Before this the entry was replayed on the next
+    // restart while the live send quarantined the very same failure.
+    const id = await enqueueTestDelivery();
+    const ambiguous = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("socket hang up"), true),
+        params.payloads[0],
+      );
+      return [];
+    });
+
+    const { summary } = await runRecovery(ambiguous);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+    // Unknowable, not zero: `0` reads to an operator as "confirmed nothing
+    // arrived", which is exactly what this outcome cannot confirm.
+    expect(entry.deliveredBeforeFailure).toBeUndefined();
+  });
+
+  it("does not replay an ambiguously-failed bestEffort retry on the next startup (#3063)", async () => {
+    // The disposition only matters if it survives the restart — the duplicate
+    // this closes is delivered by the NEXT recovery pass, not this one.
+    const id = await enqueueTestDelivery();
+    await runRecovery(
+      vi.fn<DeliverFn>(async (params) => {
+        params.onError?.(
+          annotatePlatformSendAttempted(new Error("socket hang up"), true),
+          params.payloads[0],
+        );
+        return [];
+      }),
+    );
+
+    const replay = vi.fn<DeliverFn>(async () => undefined);
+    const { summary } = await runRecovery(replay);
+
+    expect(replay).not.toHaveBeenCalled();
+    expect(summary.needsReview).toBe(1);
+    expect(fs.existsSync(path.join(resolveNeedsReviewDir(stateDir), `${id}.json`))).toBe(true);
+  });
+
+  it("still replays a bestEffort retry that failed before reaching the transport (#3063)", async () => {
+    // The blanket-quarantine mistake, guarded on this path too: a payload that
+    // failed normalization or a hook never reached the wire, so it must stay
+    // replayable exactly as the live send treats it. Quarantining it would route
+    // routine validation errors into the operator's manual queue.
+    const id = await enqueueTestDelivery();
+    const preSend = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("no text fallback is available"), false),
+        params.payloads[0],
+      );
+      return [];
+    });
+
+    const { summary } = await runRecovery(preSend);
+
+    expect(summary.failed).toBe(1);
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+    expect(entry.retryCount).toBe(1);
+  });
+
+  it("still replays a bestEffort retry whose connection was never established (#3063)", async () => {
+    // A send WAS attempted, so the flag alone would quarantine this. The errno
+    // arm is what keeps routine transient outages out of the reconciliation
+    // queue — recovery runs the whole predicate here, not just the new flag.
+    const id = await enqueueTestDelivery();
+    const refused = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(
+          Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:443"), {
+            code: "ECONNREFUSED",
+          }),
+          true,
+        ),
+        params.payloads[0],
+      );
+      return [];
+    });
+
+    await runRecovery(refused);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBeUndefined();
+    expect(hasUnknownSendOutcome(entry)).toBe(false);
+  });
+
+  it("quarantines when ANY bestEffort payload failed ambiguously (#3063)", async () => {
+    // Classifying from the first error alone lets a clean ECONNREFUSED on
+    // payload 1 mask an ambiguous post-transmission failure on payload 2 —
+    // replaying the payload that may have arrived. The live path OR-accumulates
+    // for this reason; so does this one.
+    const id = await enqueueTestDelivery();
+    const mixed = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(
+          Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
+          true,
+        ),
+        params.payloads[0],
+      );
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("socket hang up"), true),
+        params.payloads[0],
+      );
+      return [];
+    });
+
+    await runRecovery(mixed);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+    // The FIRST error is the one quoted to the operator, and it is the clean
+    // one — so the disposition cannot have been read off the message.
+    expect(entry.lastError).toContain("ECONNREFUSED");
+  });
+
+  it("keeps the partial-delivery disposition ahead of the bestEffort ambiguity check (#3063)", async () => {
+    // Both properties hold at once (a payload failed ambiguously AND one
+    // landed), and the landed count still has to win: it is the only record of
+    // which part arrived, and quarantining without it tells the operator less.
+    const id = await enqueueTestDelivery();
+    const partial = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("socket hang up"), true),
+        params.payloads[0],
+      );
+      return [{ messageId: "m1" }];
+    });
+
+    await runRecovery(partial);
+
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(entry.deliveredBeforeFailure).toBe(1);
+  });
+
+  it("keeps an all-permanent bestEffort failure on failed/ (#3063)", async () => {
+    // The third arm. Every payload was rejected outright, so nothing arrived and
+    // nothing can be retried — needs-review is for undetermined outcomes, and
+    // burying a known one among them costs the operator a pointless check.
+    const id = await enqueueTestDelivery();
+    const permanent = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("Bad Request: chat not found"), true),
+        params.payloads[0],
+      );
+      return [];
+    });
+
+    const { summary } = await runRecovery(permanent);
+
+    expect(summary.failed).toBe(1);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", "failed", `${id}.json`))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", `${id}.json`))).toBe(false);
+  });
+
+  it("quarantines a bestEffort failure mixing a permanent rejection with an ambiguous payload (#3063)", async () => {
+    // The synthesized error quotes the FIRST payload's message, so a permanent
+    // one there would file the whole entry under failed/ — asserting
+    // "never arrived" about a later payload that may be on the recipient's
+    // device. The live path has no permanent branch and quarantines this mix.
+    const id = await enqueueTestDelivery();
+    const mixed = vi.fn<DeliverFn>(async (params) => {
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("Bad Request: chat not found"), true),
+        params.payloads[0],
+      );
+      params.onError?.(
+        annotatePlatformSendAttempted(new Error("socket hang up"), true),
+        params.payloads[0],
+      );
+      return [];
+    });
+
+    await runRecovery(mixed);
+
+    expect(fs.existsSync(path.join(stateDir, "delivery-queue", "failed", `${id}.json`))).toBe(
+      false,
+    );
+    const entry = await readEntry(id);
+    expect(entry.recoveryState).toBe("unknown_after_send");
+    expect(hasUnknownSendOutcome(entry)).toBe(true);
+  });
+
   it("quarantines a partly-delivered entry even when the error is permanent", async () => {
     // "Permanent" answers whether retrying can work, not whether part of the
     // message is already on the recipient's device. Filing it under failed/

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -931,6 +931,16 @@ export async function recoverPendingDeliveries(opts: {
       // an entry whose payloads all failed and the message is silently dropped.
       let sawPayloadFailure = false;
       let firstPayloadError: string | undefined;
+      // Whether ANY payload failed in a way that might have landed. The live
+      // path's accumulator verbatim (`deliver.ts`), and OR-accumulated for the
+      // same reason: taking the verdict from the first error alone lets a clean
+      // ECONNREFUSED on payload 1 mask an ambiguous post-transmission timeout on
+      // payload 2, replaying the payload that may have arrived.
+      let sawAmbiguousPayloadFailure = false;
+      // The aggregate verdict for the synthesized bestEffort failure below, and
+      // only for it: a real throw out of the sender still classifies from its
+      // own annotations in the catch.
+      let bestEffortOutcome: { definitelyDidNotLand: boolean } | undefined;
       try {
         const sent = await opts.deliver({
           cfg: opts.cfg,
@@ -947,23 +957,40 @@ export async function recoverPendingDeliveries(opts: {
           skipQueue: true, // Prevent re-enqueueing during recovery
           onError: (err) => {
             sawPayloadFailure = true;
-            firstPayloadError ??= describeDeliveryError(err);
+            const described = describeDeliveryError(err);
+            // The live path's predicate on the live path's facts. Under
+            // `bestEffort` the sender REPORTS per-payload errors and resolves
+            // instead of throwing, so the annotated `throw` #3061 reads never
+            // fires here; the sender annotates each per-payload error on its way
+            // into this callback instead, and that is what crosses the resolve
+            // boundary (#3063).
+            //
+            // Unreported means the DeliverFn is not the outbound sender and
+            // cannot tell us — keep the historical replay-whole reading, the
+            // same default the landed count and the thrown-error branch below
+            // take. See § the `platformSendAttempted` default there.
+            sawAmbiguousPayloadFailure ||= !didSendDefinitelyNotLand({
+              platformSendAttempted: readPlatformSendAttempted(err) ?? false,
+              error: err,
+              describedError: described,
+            });
+            firstPayloadError ??= described;
           },
         });
         if (sawPayloadFailure) {
           // Route it exactly as a thrown failure would be: what already landed
-          // decides between "retry it whole" and "a human has to reconcile it".
+          // decides between "retry it whole" and "a human has to reconcile it",
+          // and among the nothing-landed ones the ambiguity verdict decides.
           //
-          // Deliberately NOT annotated with `platformSendAttempted`: under
-          // `bestEffort` the sender REPORTS per-payload errors and resolves
-          // instead of throwing, and how far each payload got does not cross
-          // that resolve boundary — this error is synthesized here, not caught
-          // from the sender. So with nothing landed the entry replays, where the
-          // live path (which still holds the per-payload detail) would quarantine
-          // an ambiguous one. Narrow, deliberate, and documented as a residual in
-          // `docs/gateway/message-delivery.md` § Delivery guarantee rather than
-          // papered over with a guess (#3060, #3061).
+          // The verdict travels BESIDE the synthesized error, not on it. This
+          // error is constructed here, so it carries none of the evidence
+          // `didSendDefinitelyNotLand` reads: no errno to inspect, and no
+          // permanent-rejection pattern (the branch below already filed that
+          // case under failed/). Re-deriving the verdict from it downstream
+          // would therefore answer "definitely did not land" for every
+          // bestEffort failure — the replay this exists to prevent.
           const landed = Array.isArray(sent) ? sent.length : 0;
+          bestEffortOutcome = { definitelyDidNotLand: !sawAmbiguousPayloadFailure };
           throw annotateDeliveredBeforeFailure(
             new Error(
               `bestEffort delivery reported a per-payload failure: ${firstPayloadError ?? "unknown error"}`,
@@ -1002,7 +1029,21 @@ export async function recoverPendingDeliveries(opts: {
           return;
         }
 
-        if (isPermanentDeliveryError(errMsg)) {
+        // A permanent rejection is the platform stating it did not accept the
+        // message, so failed/ ("never arrived") is an honest file for it — but
+        // only about the payload that was rejected. Under bestEffort the
+        // synthesized message above carries the FIRST payload's error while a
+        // LATER one may have failed ambiguously, and failed/ would then assert
+        // non-delivery for a payload that might already be on the recipient's
+        // device. The live path has no permanent branch at all and quarantines
+        // that mix; this keeps the two agreeing (#3063).
+        //
+        // A no-op for a thrown failure, deliberately: an error whose message
+        // matches a permanent pattern already answers `didSendDefinitelyNotLand`
+        // through that predicate's own third arm, so this only ever narrows the
+        // synthesized bestEffort case.
+        const permanentErrorCoversEveryPayload = bestEffortOutcome?.definitelyDidNotLand ?? true;
+        if (isPermanentDeliveryError(errMsg) && permanentErrorCoversEveryPayload) {
           opts.log.warn(
             `Delivery ${current.id} hit permanent error — moving to failed/: ${errMsg}`,
           );
@@ -1033,20 +1074,42 @@ export async function recoverPendingDeliveries(opts: {
         // was never established both still retry, so only the genuinely
         // undetermined subset is quarantined. Its third arm — an outright
         // platform rejection — is unreachable from here, since the permanent
-        // branch above already filed that case under failed/; it is kept anyway,
-        // because diverging from the shared predicate is how these two paths
-        // came to disagree in the first place.
+        // branch above already filed that case under failed/; the one failure
+        // that branch declines is a bestEffort one, which takes its verdict from
+        // the line below and never reaches this predicate. The arm is kept
+        // anyway, because diverging from the shared predicate is how these two
+        // paths came to disagree in the first place.
+        //
+        // A `bestEffort` failure was already classified where the evidence
+        // still existed, above; its verdict is used as-is rather than re-derived
+        // from an error that no longer carries any.
+        //
+        // ## The `platformSendAttempted` default
         //
         // Unreported flag means the DeliverFn is not the outbound sender and
         // cannot tell us, so keep the historical replay-whole behaviour — the
         // same default the landed count takes above. The real sender always
         // reports it: every throw out of `deliverOutboundPayloads` passes the
         // annotating site, including its pre-send failures.
-        const definitelyDidNotLand = didSendDefinitelyNotLand({
-          platformSendAttempted: readPlatformSendAttempted(err) ?? false,
-          error: err,
-          describedError: errMsg,
-        });
+        //
+        // Deliberately NOT fail-closed. Quarantine-on-absent reads as the safer
+        // default, but it is only safe for a sender that reaches a chat
+        // platform, and absent is exactly the case where we know the DeliverFn
+        // is NOT that sender. Every other DeliverFn — and every failure it
+        // raises — would be routed to an operator's manual queue and never sent,
+        // turning a routine transient error into permanent undelivered mail. The
+        // narrow risk it would buy against (a future non-outbound DeliverFn put
+        // on a chat-send path, throwing post-send-ambiguously without
+        // annotating) is instead held closed by there being exactly one
+        // production wiring of this function, pinned by
+        // `delivery-recovery-wiring.guard.test.ts` (#3063).
+        const definitelyDidNotLand =
+          bestEffortOutcome?.definitelyDidNotLand ??
+          didSendDefinitelyNotLand({
+            platformSendAttempted: readPlatformSendAttempted(err) ?? false,
+            error: err,
+            describedError: errMsg,
+          });
 
         if (!definitelyDidNotLand) {
           try {

--- a/src/infra/outbound/delivery-recovery-wiring.guard.test.ts
+++ b/src/infra/outbound/delivery-recovery-wiring.guard.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Why the recovery pass may default an unreported send outcome to "replay".
+ *
+ * `recoverPendingDeliveries` classifies failures it did not raise, so it depends
+ * on the `DeliverFn` it is handed annotating its errors
+ * (`delivered-before-failure.ts`). An unannotated failure is read as "definitely
+ * did not land" and replayed — correct for the non-outbound DeliverFns that
+ * default exists for, and a potential duplicate for a sender that actually
+ * reaches a chat platform.
+ *
+ * Failing closed instead (quarantine-on-absent) would strand every
+ * non-annotating DeliverFn's mail in the operator's manual queue and never send
+ * it — see § The `platformSendAttempted` default in `delivery-queue.ts`. What
+ * keeps the open default safe is therefore not the default itself: it is that
+ * production wires the recovery pass to exactly one DeliverFn, and that one
+ * always annotates.
+ *
+ * This pins that invariant (#3063). A second production wiring, or a different
+ * sender on the existing one, fails here — so the next author has to reason
+ * about the default rather than silently inherit one chosen for a different
+ * caller.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(thisDir, "../../..");
+
+/** The module that declares it — its own definition and doc-comments are not wirings. */
+const DECLARING_FILE = "src/infra/outbound/delivery-queue.ts";
+const SCAN_ROOTS = ["src", "extensions"];
+const SKIP_DIRS = new Set(["node_modules", "dist", "coverage", ".git", "__snapshots__"]);
+
+function toPosix(relativePath: string): string {
+  return relativePath.split(path.sep).join("/");
+}
+
+function listSourceFiles(root: string): string[] {
+  const files: string[] = [];
+  const walk = (absolute: string) => {
+    for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) {
+          walk(path.join(absolute, entry.name));
+        }
+        continue;
+      }
+      if (!entry.name.endsWith(".ts") || entry.name.endsWith(".d.ts")) {
+        continue;
+      }
+      // Test files may wire any DeliverFn they like — that is the point of them.
+      if (entry.name.includes(".test.")) {
+        continue;
+      }
+      files.push(toPosix(path.relative(repoRoot, path.join(absolute, entry.name))));
+    }
+  };
+  walk(path.join(repoRoot, root));
+  return files;
+}
+
+function findProductionCallSites(): string[] {
+  return SCAN_ROOTS.flatMap(listSourceFiles)
+    .filter((file) => file !== DECLARING_FILE)
+    .filter((file) => /\brecoverPendingDeliveries\s*\(/.test(readRepoFile(file)))
+    .toSorted();
+}
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("delivery recovery wiring", () => {
+  it("has exactly one production caller of recoverPendingDeliveries", () => {
+    // Adding a second one is not forbidden — it just cannot be done silently.
+    // Whoever adds it owns the question this file exists to keep asked: does the
+    // DeliverFn behind it annotate how far a failed send got?
+    expect(findProductionCallSites()).toEqual(["src/gateway/server.impl.ts"]);
+  });
+
+  it("wires that caller to the annotating outbound sender", () => {
+    // `deliverOutboundPayloads` reports both facts the recovery classifier needs
+    // — the landed count and whether a platform send was entered — on the thrown
+    // error and, under bestEffort where nothing is thrown, on each per-payload
+    // error it hands to onError. Swapping in a sender that reports neither
+    // re-opens the replay-an-ambiguous-failure window on the recovery path.
+    const [callSite] = findProductionCallSites();
+    expect(callSite).toBeDefined();
+    const source = readRepoFile(callSite);
+    expect(source).toMatch(
+      /recoverPendingDeliveries\s*\(\s*\{[^}]*deliver:\s*deliverOutboundPayloads/,
+    );
+  });
+
+  it("keeps that sender annotating both of its failure channels", () => {
+    // The throwing channel (#3061) and the bestEffort resolve channel (#3063).
+    // Losing either one silently downgrades the recovery pass to "assume nothing
+    // landed" for the failures it covered, which is how the duplicate returns.
+    const sender = readRepoFile("src/infra/outbound/deliver.ts");
+    const annotations = sender.match(/annotatePlatformSendAttempted\s*\(/g) ?? [];
+    expect(annotations.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #3063.

> ⚠️ **Runtime delivery-path change — requires independent review.** Item 1 changes
> how the crash-recovery pass disposes of a failed re-send on the kept
> delivery-recovery surface. The failure mode on the wrong side of this decision is
> a recipient receiving a message twice; on the other side, mail parked in an
> operator's manual queue instead of being sent.

## The gap

#3062 made the recovery re-send path symmetric with the live path for **throwing**
send failures: an ambiguous full-failure (platform send attempted, nothing landed,
non-permanent) quarantines on both paths, via a `platformSendAttempted` flag
propagated across the throw.

Under **`bestEffort`** the sender *reports* per-payload errors and *resolves*
rather than throwing, so that throw-annotation channel never fires. A `bestEffort`
recovery re-send with nothing landed was therefore replayed on the next restart —
a potential duplicate — while the live path already quarantined the identical
failure. Pre-existing and deliberate (#3060), documented as a residual window.
Severity LOW.

## Item 1 — mirror the live path's per-payload ambiguity accounting

The fix carries the fact across the **resolve** boundary, since there is no throw
to hang it on:

- **`deliver.ts`** — the wrapped `onError` now annotates each per-payload error
  with `sendProgress.platformSendAttempted` before forwarding it, at the same
  statement where it classifies that payload for its own accumulator, so the two
  cannot disagree.
- **`delivery-queue.ts`** — `recoverPendingDeliveries`' `bestEffort` branch
  OR-accumulates `!didSendDefinitelyNotLand({...})` over those per-payload errors:
  the live path's predicate, verbatim, on the same inputs. Not a new heuristic.

Only the **maybe-landed** subset quarantines. Every other disposition is unchanged:

| `bestEffort` recovery failure | Disposition |
|---|---|
| ≥1 payload ambiguous, nothing landed | `failUnknownDelivery` (quarantine) — **changed** |
| all payloads pre-send / connection never established | `failDelivery` (retry) — unchanged |
| ≥1 payload landed | `failPartialDelivery` — unchanged |
| all payloads permanently rejected | `moveToFailed` — unchanged |
| error unannotated (non-outbound `DeliverFn`) | `failDelivery` (retry) — unchanged |

The verdict travels **beside** the synthesized error rather than on it: that error
is constructed in the recovery pass and carries none of the evidence
`didSendDefinitelyNotLand` reads (no errno, and no permanent pattern — that branch
already returned), so re-deriving it downstream would answer "definitely did not
land" for every `bestEffort` failure.

### One extra symmetry item, beyond the issue's enumeration

Implementing the above surfaced a second live-vs-recovery divergence of the same
family, so it is fixed here and called out for review: the recovery **permanent-error
branch** matches against the synthesized message, which quotes the **first**
payload's error. A `bestEffort` failure whose first payload was rejected
permanently and whose *later* payload failed ambiguously was filed under `failed/`
— asserting "never arrived" about a payload that may be on the recipient's device.
The live path has no permanent branch at all and quarantines that mix. The branch
is now gated on the aggregate verdict; **a no-op for every thrown failure**, because
an error whose message matches a permanent pattern already satisfies
`didSendDefinitelyNotLand`'s own third arm.

### Blast radius

`deliver.ts`'s per-payload annotation is non-enumerable (so it stays out of
`JSON.stringify`). Exactly one production caller of `deliverOutboundPayloads`
passes an `onError` — `src/commands/agent/delivery.ts:238`, which only `String(err)`s
it — so no existing consumer's behaviour changes. The other consumer is the
recovery pass this PR wires up.

## Item 2 — the absent-`platformSendAttempted` default: **kept open, tripwired**

**Decision: leave `?? false` (→ retry) as-is; add a wiring tripwire + rationale
comment.** Not fail-closed.

**Why.** Quarantine-on-absent reads as the safer default, but it is only safe for a
sender that reaches a chat platform — and *absent is precisely the case where we
know the `DeliverFn` is not that sender*. Flipping it would route every failure
raised by every non-outbound `DeliverFn` into the operator's manual queue and never
send it, turning a routine transient error into permanent undelivered mail. It
would also break a deliberately-locked current caller: `delivery-queue.test.ts`
§ "treats an unannotated failure as replay-whole (#3061)". So the issue's third
option applies.

**What holds the risk closed instead.** Not the default — the fact that production
wires the recovery pass to exactly **one** `DeliverFn`, and that one always
annotates. That was an unpinned invariant; it now has a guard test
(`delivery-recovery-wiring.guard.test.ts`) asserting there is exactly one
production caller of `recoverPendingDeliveries`, that it is wired to
`deliverOutboundPayloads`, and that that sender still annotates **both** of its
failure channels (the #3061 throw and the #3063 resolve). Adding a second wiring
is not forbidden — it just can no longer be done silently. The rationale lives in
the source at `delivery-queue.ts` § The `platformSendAttempted` default.

## Item 3 — docs

`docs/gateway/message-delivery.md` no longer carries the `bestEffort` carve-out.
It now states the unified behaviour (both senders × both failure shapes, all four
combinations classifying with the same predicate). The genuine power-loss residual
— the in-flight marker is atomically renamed but not fsynced — is kept, and is now
the only one.

## Verification

- New recovery tests cover (a) ambiguous full-failure → quarantine, incl. that it
  is not replayed on the next startup, (b) pre-send and connection-never-established
  → retry, (c) partial-land → `failPartialDelivery`, (d) all-permanent → `failed/`,
  plus the OR-accumulation guard (a clean `ECONNREFUSED` on payload 1 must not mask
  an ambiguous timeout on payload 2) and the permanent+ambiguous mix.
- New `deliver.ts` tests pin both directions of the per-payload annotation
  (attempted, and a real pre-send failure reporting *not* attempted).
- **Mutation-checked** — each guard, disabled in turn, fails exactly its own tests
  and nothing else:

  | Mutation | Failing tests |
  |---|---|
  | drop the `deliver.ts` per-payload annotation | 3 (both annotation tests + the wiring guard) |
  | force `definitelyDidNotLand: true` (never quarantine) | the 4 quarantine tests only |
  | force `definitelyDidNotLand: false` (blanket-quarantine) | the 4 retry/`failed/` tests only |
  | remove the permanent-branch gate | the permanent+ambiguous mix test only |

- `pnpm check` green (format, tsgo, oxlint type-aware, and the `lint`-job gates).
- Standalone fork-integrity gates green: rebrand, zombie-import, stub-debt,
  throwing-stub-callers, attestation, obsolescence-audit.
- Full unit lane green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
