### PR TITLE
ci(security): wire the raw-fetch gate into CI and reconcile its ledger (#3055)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,28 @@ jobs:
       - name: Check policy-doctor bounded-write boundary
         run: node scripts/check-policy-doctor-boundary.mjs
 
+  raw-channel-fetch-gate:
+    # Security lint for the fork's most-exposed surface: channel/plugin runtime
+    # code must route outbound calls through fetchWithSsrFGuard() (DNS-pinned
+    # host, redirect:"manual", per-hop re-validation) rather than raw fetch(),
+    # except for callsites on the reviewed ledger in the script. The gate
+    # existed but ran in no CI job, so it never fired and its ledger rotted
+    # unnoticed (#3055). See § Fork-integrity gates.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Check raw channel fetch callsites
+        run: node scripts/check-no-raw-channel-fetch.mjs
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -393,6 +415,7 @@ jobs:
         throwing-stub-callers-gate,
         obsolescence-audit-gate,
         policy-doctor-boundary-gate,
+        raw-channel-fetch-gate,
         lint,
         build,
         packaged-boot-smoke,
@@ -406,7 +429,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.policy-doctor-boundary-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-extensions.result }}" != "success" || "${{ needs.test-auto-reply.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.policy-doctor-boundary-gate.result }}" != "success" || "${{ needs.raw-channel-fetch-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-extensions.result }}" != "success" || "${{ needs.test-auto-reply.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,12 @@ GitHub Actions (`.github/workflows/ci.yml`):
   the `CI` rollup so adapter / auto-reply regressions block merge (#2779). See
   § Testing → Extensions & auto-reply coverage lanes
 - Jobs run on `ubuntu-latest` with Node 22 and pnpm 10.23.0
-- Branch protection requires `build`, `test`, `lint`, and `docs` to pass
+- Branch protection requires the `CI` rollup job to pass — it is the sole
+  required status check. An individual job gates merge only if it is listed in
+  **both** the rollup's `needs:` and its result-check condition. Omitting it
+  from the condition silently un-gates it (the job runs but its failure is
+  ignored); omitting it from `needs:` is worse — `needs.X.result` evaluates
+  empty, so the condition fails permanently and blocks every merge
 
 ### Fork-integrity gates
 
@@ -185,6 +190,17 @@ against regressions specific to the fork-sync lifecycle:
   detects throwing stubs with live non-test callers — see § Fork Stub
   Conventions.
 - **obsolescence-audit-gate**: retrospective audit sentinels for gut waves.
+- **raw-channel-fetch-gate** (`pnpm lint:no-raw-channel-fetch`): channel and
+  plugin runtime code under `src/channels`, `src/routing`, `src/line`, and
+  `extensions/` must route outbound calls through `fetchWithSsrFGuard()`
+  (DNS-pinned host, `redirect: "manual"`, per-hop redirect re-validation)
+  rather than raw `fetch()` / `globalThis.fetch()`. Reviewed exceptions live
+  on the inline ledger in `scripts/check-no-raw-channel-fetch.mjs`, pinned to
+  `file:line` so a moved callsite re-fails the gate and gets re-reviewed
+  instead of silently inheriting its exception. Adding a ledger entry requires
+  a comment justifying why that callsite is not an SSRF vector. Wired in
+  #3055 — the script existed from upstream but ran in no CI job, so it never
+  fired and its ledger rotted unnoticed.
 - **css-class-drift-gate** (`pnpm lint:ui:no-css-class-drift`, part of
   `pnpm check`): cross-references `class="..."` tokens in
   `ui/src/**/*.{ts,tsx,html}` against the CSS rule definitions reachable

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -3,6 +3,7 @@ import type { WebClient } from "@slack/web-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { logVerbose } from "../../../../src/globals.js";
 import * as ssrf from "../../../../src/infra/net/ssrf.js";
+import type { FetchLike } from "../../../../src/media/fetch.js";
 import * as mediaFetch from "../../../../src/media/fetch.js";
 import type { SavedMedia } from "../../../../src/media/store.js";
 import * as mediaStore from "../../../../src/media/store.js";
@@ -12,7 +13,6 @@ import {
   withFetchPreconnect,
 } from "../../../../test/helpers/extensions/fetch-mock.js";
 import {
-  fetchWithSlackAuth,
   resetSlackThreadStarterCacheForTest,
   resolveSlackAttachmentContent,
   resolveSlackMedia,
@@ -33,157 +33,6 @@ const createSavedMedia = (filePath: string, contentType: string): SavedMedia => 
   path: filePath,
   size: 128,
   contentType,
-});
-
-describe("fetchWithSlackAuth", () => {
-  beforeEach(() => {
-    // Create a new mock for each test
-    mockFetch = vi.fn<FetchMock>(
-      async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(),
-    );
-    globalThis.fetch = withFetchPreconnect(mockFetch);
-  });
-
-  afterEach(() => {
-    // Restore original fetch
-    globalThis.fetch = originalFetch;
-  });
-
-  it("sends Authorization header on initial request with manual redirect", async () => {
-    // Simulate direct 200 response (no redirect)
-    const mockResponse = new Response(Buffer.from("image data"), {
-      status: 200,
-      headers: { "content-type": "image/jpeg" },
-    });
-    mockFetch.mockResolvedValueOnce(mockResponse);
-
-    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
-
-    expect(result).toBe(mockResponse);
-
-    // Verify fetch was called with correct params
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledWith("https://files.slack.com/test.jpg", {
-      headers: { Authorization: "Bearer xoxb-test-token" },
-      redirect: "manual",
-    });
-  });
-
-  it("rejects non-Slack hosts to avoid leaking tokens", async () => {
-    await expect(
-      fetchWithSlackAuth("https://example.com/test.jpg", "xoxb-test-token"),
-    ).rejects.toThrow(/non-Slack host|non-Slack/i);
-
-    // Should fail fast without attempting a fetch.
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("follows redirects without Authorization header", async () => {
-    // First call: redirect response from Slack
-    const redirectResponse = new Response(null, {
-      status: 302,
-      headers: { location: "https://cdn.slack-edge.com/presigned-url?sig=abc123" },
-    });
-
-    // Second call: actual file content from CDN
-    const fileResponse = new Response(Buffer.from("actual image data"), {
-      status: 200,
-      headers: { "content-type": "image/jpeg" },
-    });
-
-    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
-
-    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
-
-    expect(result).toBe(fileResponse);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-
-    // First call should have Authorization header and manual redirect
-    expect(mockFetch).toHaveBeenNthCalledWith(1, "https://files.slack.com/test.jpg", {
-      headers: { Authorization: "Bearer xoxb-test-token" },
-      redirect: "manual",
-    });
-
-    // Second call should follow the redirect without Authorization
-    expect(mockFetch).toHaveBeenNthCalledWith(
-      2,
-      "https://cdn.slack-edge.com/presigned-url?sig=abc123",
-      {
-        redirect: "follow",
-      },
-    );
-  });
-
-  it("handles relative redirect URLs", async () => {
-    // Redirect with relative URL
-    const redirectResponse = new Response(null, {
-      status: 302,
-      headers: { location: "/files/redirect-target" },
-    });
-
-    const fileResponse = new Response(Buffer.from("image data"), {
-      status: 200,
-      headers: { "content-type": "image/jpeg" },
-    });
-
-    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
-
-    await fetchWithSlackAuth("https://files.slack.com/original.jpg", "xoxb-test-token");
-
-    // Second call should resolve the relative URL against the original
-    expect(mockFetch).toHaveBeenNthCalledWith(2, "https://files.slack.com/files/redirect-target", {
-      redirect: "follow",
-    });
-  });
-
-  it("returns redirect response when no location header is provided", async () => {
-    // Redirect without location header
-    const redirectResponse = new Response(null, {
-      status: 302,
-      // No location header
-    });
-
-    mockFetch.mockResolvedValueOnce(redirectResponse);
-
-    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
-
-    // Should return the redirect response directly
-    expect(result).toBe(redirectResponse);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns 4xx/5xx responses directly without following", async () => {
-    const errorResponse = new Response("Not Found", {
-      status: 404,
-    });
-
-    mockFetch.mockResolvedValueOnce(errorResponse);
-
-    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
-
-    expect(result).toBe(errorResponse);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("handles 301 permanent redirects", async () => {
-    const redirectResponse = new Response(null, {
-      status: 301,
-      headers: { location: "https://cdn.slack.com/new-url" },
-    });
-
-    const fileResponse = new Response(Buffer.from("image data"), {
-      status: 200,
-    });
-
-    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
-
-    await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
-
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch).toHaveBeenNthCalledWith(2, "https://cdn.slack.com/new-url", {
-      redirect: "follow",
-    });
-  });
 });
 
 describe("resolveSlackMedia", () => {
@@ -528,6 +377,62 @@ describe("Slack media SSRF policy", () => {
     expect(policy?.allowedHostnames).toEqual(
       expect.arrayContaining(["*.slack.com", "*.slack-edge.com", "*.slack-files.com"]),
     );
+  });
+
+  // Drives resolveSlackMedia far enough to grab the `fetchImpl` it hands to
+  // fetchRemoteMedia, then aborts. Lets a test exercise the Slack fetcher's own guards
+  // directly instead of the outer ssrfPolicy, which would normally reject first.
+  const captureSlackMediaFetchImpl = async (): Promise<FetchLike> => {
+    let captured: FetchLike | undefined;
+    vi.spyOn(mediaFetch, "fetchRemoteMedia").mockImplementation(async (params) => {
+      captured = params.fetchImpl;
+      throw new Error("stop after capturing fetchImpl");
+    });
+
+    await resolveSlackMedia({
+      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(captured).toBeDefined();
+    return captured!;
+  };
+
+  it("never attaches the Slack token when the media fetcher is handed a non-Slack host", async () => {
+    // Defense-in-depth: the fetchImpl built by createSlackMediaFetch independently
+    // refuses to send the bot token off a Slack host, so this asserts the INNER guard.
+    const slackMediaFetch = await captureSlackMediaFetchImpl();
+
+    await expect(slackMediaFetch("https://evil.example.com/test.jpg")).rejects.toThrow(
+      /non-Slack host/i,
+    );
+    // Fails closed: the token-bearing request is never issued at all.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("strips the Authorization header on redirect hops after the first", async () => {
+    // The fetchImpl attaches the bot token exactly once, on the initial Slack-host
+    // request. fetchRemoteMedia re-invokes it per redirect hop (redirect: "manual"),
+    // and those hops must carry no credential — Slack CDN URLs are pre-signed.
+    mockFetch.mockResolvedValue(new Response(Buffer.from("img"), { status: 200 }));
+    const slackMediaFetch = await captureSlackMediaFetchImpl();
+
+    // Hop 1: Slack host, token attached, redirects not auto-followed.
+    await slackMediaFetch("https://files.slack.com/test.jpg");
+    const firstInit = mockFetch.mock.calls[0]?.[1];
+    expect(new Headers(firstInit?.headers).get("authorization")).toBe("Bearer xoxb-test-token");
+    expect(firstInit?.redirect).toBe("manual");
+
+    // Hop 2: the CDN target the redirect pointed at. Hand it an init that still carries
+    // the header — the way a redirect replay would — so this asserts the fetcher actively
+    // STRIPS the credential rather than merely never having added it.
+    await slackMediaFetch("https://cdn.slack-edge.com/presigned?sig=abc123", {
+      headers: { Authorization: "Bearer xoxb-test-token" },
+    });
+    const secondInit = mockFetch.mock.calls[1]?.[1];
+    expect(new Headers(secondInit?.headers).get("authorization")).toBeNull();
+    expect(secondInit?.redirect).toBe("manual");
   });
 
   it("passes ssrfPolicy to forwarded attachment image downloads", async () => {

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -68,45 +68,6 @@ function createSlackMediaFetch(token: string): FetchLike {
   };
 }
 
-/**
- * Fetches a URL with Authorization header, handling cross-origin redirects.
- * Node.js fetch strips Authorization headers on cross-origin redirects for security.
- * Slack's file URLs redirect to CDN domains with pre-signed URLs that don't need the
- * Authorization header, so we handle the initial auth request manually.
- */
-export async function fetchWithSlackAuth(url: string, token: string): Promise<Response> {
-  const parsed = assertSlackFileUrl(url);
-
-  // Initial request with auth and manual redirect handling
-  const initialRes = await fetch(parsed.href, {
-    headers: { Authorization: `Bearer ${token}` },
-    redirect: "manual",
-  });
-
-  // If not a redirect, return the response directly
-  if (initialRes.status < 300 || initialRes.status >= 400) {
-    return initialRes;
-  }
-
-  // Handle redirect - the redirected URL should be pre-signed and not need auth
-  const redirectUrl = initialRes.headers.get("location");
-  if (!redirectUrl) {
-    return initialRes;
-  }
-
-  // Resolve relative URLs against the original
-  const resolvedUrl = new URL(redirectUrl, parsed.href);
-
-  // Only follow safe protocols (we do NOT include Authorization on redirects).
-  if (resolvedUrl.protocol !== "https:") {
-    return initialRes;
-  }
-
-  // Follow the redirect without the Authorization header
-  // (Slack's CDN URLs are pre-signed and don't need it)
-  return fetch(resolvedUrl.toString(), { redirect: "follow" });
-}
-
 const SLACK_MEDIA_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
   allowRfc2544BenchmarkRange: true,

--- a/package.json
+++ b/package.json
@@ -331,6 +331,7 @@
     "lint:no-clawd-discord": "node scripts/check-no-clawd-discord.mjs",
     "lint:no-lobster-leak": "node scripts/check-no-lobster-leak.mjs",
     "lint:no-models-write": "node scripts/check-no-models-write-config.mjs",
+    "lint:no-raw-channel-fetch": "node scripts/check-no-raw-channel-fetch.mjs",
     "lint:no-remoteclaw-ai": "node scripts/check-no-remoteclaw-ai.mjs",
     "lint:plugins:no-monolithic-plugin-sdk-entry-imports": "node --import tsx scripts/check-no-monolithic-plugin-sdk-entry-imports.ts",
     "lint:swift": "swiftlint lint --config .swiftlint.yml && (cd apps/ios && swiftlint lint --config .swiftlint.yml)",

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -12,60 +12,105 @@ import {
 
 const sourceRoots = ["src/channels", "src/routing", "src/line", "extensions"];
 
-// Temporary allowlist for legacy callsites. New raw fetch callsites in channel/plugin runtime
-// code should be rejected and migrated to fetchWithSsrFGuard/shared channel helpers.
+// Allowlist ("ledger") of reviewed raw-fetch callsites in channel/plugin runtime code.
+// New raw fetch callsites should be rejected and migrated to fetchWithSsrFGuard/shared
+// channel helpers. Every entry carries a justification for WHY that specific callsite is
+// not an SSRF vector — an entry without one is not reviewable and should not be added.
+//
+// Entries are pinned to `file:line` on purpose: when a callsite moves, the gate fails and
+// the exception is re-reviewed rather than silently inherited. Fix drift by re-confirming
+// the call is the same one and bumping the line — never by relaxing the matcher.
+//
+// Reconciled in #3055 against the live violation set. The gate had never been wired into
+// CI, so the upstream-inherited ledger had rotted: 44 of 49 entries no longer matched any
+// live call — 34 pointed at files gutted from the fork (28 distinct files), and 10 were
+// stale line pins in 5 files that still exist (calls since migrated to fetchWithSsrFGuard,
+// or moved). Those were removed: a line-pinned entry that matches nothing is a latent
+// false-allow, since a future edit landing a raw fetch on that exact line would be admitted
+// unreviewed. The safe/unsafe verdict for the entries this reconciliation added comes from
+// an independent security-architect triage of all 19 then-current violations (0
+// production-exploitable); the pre-existing entries it kept are the ones that still matched
+// a live call.
+//
+// When writing a justification, name the control that actually restricts the request. Note
+// that in SsrFPolicy (src/infra/net/ssrf.ts) `allowedHostnames` is NOT a restrictive
+// allowlist — it EXEMPTS those hosts from the private-IP check
+// (shouldSkipPrivateNetworkChecks), by exact match only. The restrictive field is
+// `hostnameAllowlist`, and it alone interprets `*.` wildcard patterns.
 const allowedRawFetchCallsites = new Set([
-  bundledPluginCallsite("browser", "src/browser/cdp.helpers.ts", 268),
-  bundledPluginCallsite("browser", "src/browser/client-fetch.ts", 192),
-  bundledPluginCallsite("chutes", "models.ts", 536),
-  bundledPluginCallsite("chutes", "models.ts", 543),
-  // Self-hosted ClickClack deployment: `baseUrl` is operator-supplied local
+  // Shared `blueBubblesFetchWithTimeout` helper. Most callers
+  // (chat/history/probe/reactions/send) pass a URL built by buildBlueBubblesApiUrl()
+  // from the operator-supplied `baseUrl` of a self-hosted BlueBubbles server, and
+  // multipart.ts forwards a URL its own callers supply. The one caller reachable by a
+  // remote server is attachments.ts, which passes this helper as the `fetchImpl` to
+  // fetchRemoteMedia() — so redirect targets chosen by the remote server also reach
+  // this line. That path is protected by fetchWithSsrFGuard, which fetchRemoteMedia
+  // always applies: DNS pinning, redirect:"manual" with per-hop re-validation, and
+  // private-IP blocking. The `ssrfPolicy` attachments.ts passes only RELAXES that base
+  // guard — `allowedHostnames: [trustedHostname]` exempts the operator's own host from
+  // the private-IP check, `allowPrivateNetwork` is an explicit operator opt-in for a
+  // LAN server, and a third branch passes no policy at all when the baseUrl has no
+  // extractable hostname.
+  bundledPluginCallsite("bluebubbles", "src/types.ts", 161),
+  // Operator-supplied `baseUrl` for a self-hosted ClickClack deployment — local
   // config, never a value taken from inbound traffic (#2861).
   bundledPluginCallsite("clickclack", "src/http-client.ts", 52),
-  bundledPluginCallsite("discord", "src/monitor/gateway-plugin.ts", 417),
-  bundledPluginCallsite("discord", "src/monitor/gateway-plugin.ts", 483),
-  bundledPluginCallsite("discord", "src/voice-message.ts", 298),
-  bundledPluginCallsite("discord", "src/voice-message.ts", 333),
-  bundledPluginCallsite("elevenlabs", "speech-provider.ts", 295),
-  bundledPluginCallsite("elevenlabs", "tts.ts", 74),
-  bundledPluginCallsite("feishu", "src/monitor.webhook.test-helpers.ts", 25),
-  bundledPluginCallsite("github-copilot", "login.ts", 80),
-  bundledPluginCallsite("github-copilot", "login.ts", 112),
+  // Discord gateway `fetchImpl`, used by @buape/carbon to reach the fixed Discord API
+  // for gateway metadata. Two callsites: the no-proxy path and the invalid-proxy
+  // fallback. No caller-controlled URL.
+  bundledPluginCallsite("discord", "src/monitor/gateway-plugin.ts", 298),
+  bundledPluginCallsite("discord", "src/monitor/gateway-plugin.ts", 332),
+  // Fixed `https://discord.com/api/v10/webhooks/...` execution URL built by
+  // resolveWebhookExecutionUrl(); id and token are encodeURIComponent'd into the path,
+  // so neither can redirect the request to another host.
+  bundledPluginCallsite("discord", "src/send.outbound.ts", 361),
+  // Fixed CHAT_CERTS_URL constant on googleapis.com (Google Chat signing certs).
   bundledPluginCallsite("googlechat", "src/auth.ts", 83),
-  bundledPluginCallsite("huggingface", "models.ts", 143),
-  bundledPluginCallsite("kilocode", "provider-models.ts", 130),
-  bundledPluginCallsite("matrix", "src/matrix/sdk/transport.ts", 112),
-  bundledPluginCallsite("microsoft-foundry", "onboard.ts", 479),
-  bundledPluginCallsite("microsoft", "speech-provider.ts", 140),
-  bundledPluginCallsite("minimax", "oauth.ts", 82),
-  bundledPluginCallsite("minimax", "oauth.ts", 123),
-  bundledPluginCallsite("minimax", "tts.ts", 52),
-  bundledPluginCallsite("msteams", "src/graph.ts", 47),
-  bundledPluginCallsite("msteams", "src/sdk.ts", 400),
-  bundledPluginCallsite("msteams", "src/sdk.ts", 441),
-  bundledPluginCallsite("ollama", "src/stream.ts", 649),
-  bundledPluginCallsite("openai", "tts.ts", 149),
+  // Operator-supplied `homeserver` from Matrix account config.
+  bundledPluginCallsite("matrix", "src/directory-live.ts", 41),
+  // Operator-supplied `baseUrl` for a self-hosted Mattermost server.
+  bundledPluginCallsite("mattermost", "src/mattermost/probe.ts", 28),
+  // Fixed Microsoft Graph root (`https://graph.microsoft.com/v1.0`); only the path
+  // segment varies.
+  bundledPluginCallsite("msteams", "src/graph.ts", 39),
+  // Operator-supplied `baseUrl` for a self-hosted Nextcloud instance (message send and
+  // reaction send).
+  bundledPluginCallsite("nextcloud-talk", "src/send.ts", 104),
+  bundledPluginCallsite("nextcloud-talk", "src/send.ts", 196),
+  // QA test-harness bus; `baseUrl` is the local harness endpoint, not production input.
   bundledPluginCallsite("qa-channel", "src/bus-client.ts", 41),
   bundledPluginCallsite("qa-channel", "src/bus-client.ts", 221),
-  bundledPluginCallsite("qa-lab", "src/docker-up.runtime.ts", 274),
-  bundledPluginCallsite("qa-lab", "src/gateway-child.ts", 489),
-  bundledPluginCallsite("qa-lab", "src/suite.ts", 330),
-  bundledPluginCallsite("qa-lab", "src/suite.ts", 341),
-  bundledPluginCallsite("qa-lab", "web/src/app.ts", 22),
-  bundledPluginCallsite("qa-lab", "web/src/app.ts", 30),
-  bundledPluginCallsite("qa-lab", "web/src/app.ts", 38),
-  bundledPluginCallsite("qqbot", "src/engine/api/api-client.ts", 124),
-  bundledPluginCallsite("qqbot", "src/engine/api/media-chunked.ts", 554),
-  bundledPluginCallsite("qqbot", "src/engine/api/token.ts", 211),
-  bundledPluginCallsite("qqbot", "src/engine/tools/channel-api.ts", 178),
-  bundledPluginCallsite("qqbot", "src/engine/utils/stt.ts", 87),
-  bundledPluginCallsite("signal", "src/install-signal-cli.ts", 224),
-  bundledPluginCallsite("slack", "src/monitor/media.ts", 106),
-  bundledPluginCallsite("slack", "src/monitor/media.ts", 125),
-  bundledPluginCallsite("slack", "src/monitor/media.ts", 130),
-  bundledPluginCallsite("venice", "models.ts", 552),
-  bundledPluginCallsite("vercel-ai-gateway", "models.ts", 181),
+  // Inbound Slack media URL, but these two run *inside* the fetchImpl that
+  // fetchRemoteMedia drives through fetchWithSsrFGuard — DNS pinning,
+  // redirect:"manual" with per-hop re-validation, and private-IP blocking all apply.
+  // The host restriction is assertSlackFileUrl(), which gates the FIRST hop (:63)
+  // before the bot token is attached; hop 2+ (:67) deletes the Authorization header,
+  // so a redirect target never receives the token. SLACK_MEDIA_SSRF_POLICY's
+  // `allowedHostnames` is not the restriction — it is the private-IP-check exemption
+  // described in the header note, and an inert one here, since that check is
+  // exact-match while the policy supplies wildcards.
+  bundledPluginCallsite("slack", "src/monitor/media.ts", 63),
+  bundledPluginCallsite("slack", "src/monitor/media.ts", 67),
+  // Fixed `https://api.elevenlabs.io/v1/voices`.
+  bundledPluginCallsite("talk-voice", "index.ts", 31),
+  // Fixed `https://memex.tlon.network` upload endpoint.
+  bundledPluginCallsite("tlon", "src/tlon-api.ts", 184),
+  // Blob PUT to the upload URL that the first-party Memex endpoint above just returned;
+  // reached only on hosted ships that opted in, and the request carries no secret.
+  bundledPluginCallsite("tlon", "src/tlon-api.ts", 234),
+  // Blob PUT to a presigned URL derived from the operator's own configured S3 endpoint.
+  bundledPluginCallsite("tlon", "src/tlon-api.ts", 288),
+  // Fixed `https://api.openai.com/v1/audio/speech`.
+  bundledPluginCallsite("voice-call", "src/providers/tts-openai.ts", 126),
+  // Operator/provider-configured `baseUrl` for the Twilio REST API.
   bundledPluginCallsite("voice-call", "src/providers/twilio/api.ts", 23),
+
+  // --- Non-bundled-plugin callsites (outside `extensions/`) ---
+  // bundledPluginCallsite() only emits `extensions/…` keys, so repo-root channel
+  // sources are spelled as raw `relPath:line` strings.
+  // Fixed `https://api.telegram.org/bot<token>/getChat`; chatId is encodeURIComponent'd
+  // into the query string.
+  "src/channels/telegram/api.ts:8",
 ]);
 
 function isRawFetchCall(expression) {


### PR DESCRIPTION
Closes #3055. (Item 2 — the clickclack e2e fixture exclusion — already landed via #3064; this completes Item 1.)

## The gap

`scripts/check-no-raw-channel-fetch.mjs` enforces that channel/plugin runtime code routes outbound calls through `fetchWithSsrFGuard()` instead of raw `fetch()`, against an inline allowlist ("ledger"). Every sibling `check-*.mjs` gate runs from `ci.yml`; this one **ran nowhere** — no CI job, no package script, no other script, no git hook. So it never fired, and the ledger it inherited verbatim from upstream rotted unnoticed.

On the tree before this PR it exits 1 with **19 violations**.

**This is a control-gap fix, not a live-vulnerability fix.** An independent security-architect triage of all 19 callsites found **0 of 19 production-exploitable SSRF**: 4 stale line pins plus 15 unledgered-but-safe callsites (fixed vendor hosts, operator-supplied self-hosted `baseUrl`s, and calls already running under an outer SSRF guard). The gate's value is catching a *future* raw fetch on the fork's most-exposed surface — the defect is that it silently never ran.

## What changed

**1. Dead-code deletion (removes 2 violations).** `fetchWithSlackAuth` in `extensions/slack/src/monitor/media.ts` had no production caller — only its own tests referenced it. Deleted, along with its 7 now-dead tests. Its `redirect: "follow"` branch with no host/IP re-validation was the only latent-SSRF *shape* in the set, so removing it beats ledgering it.

**2. Ledger reconcile.** Against the live violation set (re-derived from gate output, not transcribed):

- **44 of 49 entries were rot** — 34 pointed at files gutted from the fork (28 distinct files), 10 were stale line pins in 5 files that still exist (calls since migrated to `fetchWithSsrFGuard`, or moved). Removed. A line-pinned entry matching nothing is a **latent false-allow**: a future edit landing a raw fetch on that exact line would be admitted unreviewed. `extensions/discord/src/voice-message.ts:298`/`:333` was exactly this — the file migrated to the guard, but the pins stayed.
- **17 entries added**, each with a provenance comment; **5 pre-existing entries retained** (the ones still matching a live call).
- Result: **22 ledger entries ↔ 22 live callsites, 1:1, zero rot, zero missing.**

**3. Restored two lost test pins.** Deleting the dead tests removed the only coverage of two *still-shipping* Slack guards. Both are back, and both are **mutation-verified** (removing the guard makes exactly that test fail, and only that one):
- `assertSlackFileUrl`'s non-Slack-host rejection — the bot token never leaves a Slack host.
- `createSlackMediaFetch`'s `headers.delete("Authorization")` on redirect hops 2+.

**4. Wiring (last, deliberately).** `lint:no-raw-channel-fetch` package script, a `raw-channel-fetch-gate` CI job mirroring `zombie-import-gate` step-for-step, and **both** rollup surfaces — `needs:` *and* the result-check condition. Green-before-armed: wiring a red gate would turn CI red on its first ever run.

**5. Docs.** Documented in `CLAUDE.md` § Fork-integrity gates. Also corrected the adjacent branch-protection line: it claimed `build`, `test`, `lint`, `docs` are required, but the live setting is a single required `CI` rollup context (and there is no `docs` job in `ci.yml` at all).

## Gate is green

```
$ node scripts/check-no-raw-channel-fetch.mjs
$ echo $?
0
```

`pnpm check` exit 0 (also enforced by the pre-commit hook). Slack media suite 24/24. `extensions/slack/src/monitor/media.test.ts` is not quarantined, so the `test-extensions` lane really runs it.

## What was NOT changed

The gate's **matcher and guard requirement are untouched** — `isRawFetchCall`, `findRawFetchCallLines`, `sourceRoots`, `skipRelativePath`, `extraTestSuffixes`, and the `runCallsiteGuard` call are byte-identical, and `scripts/lib/` is unmodified. Only `allowedRawFetchCallsites` and its comments differ.

Line pinning was deliberately kept despite its brittleness: a moved callsite re-failing the gate and forcing re-review is the feature, not a bug.

## Review notes

Three adversarial validation rounds ran on this diff and were not decorative — round 2 caught that a round-1 fix was *itself* wrong, and round 3 caught a residual imprecision. Worth knowing what they corrected, since ledger comments are the artifact this gate exists to produce:

> In `SsrFPolicy`, `allowedHostnames` is **not** a restrictive allowlist — it *exempts* hosts from the private-IP check (`shouldSkipPrivateNetworkChecks`), by exact match. The restrictive field is `hostnameAllowlist`, and it alone interprets `*.` wildcards.

Two justifications initially credited `allowedHostnames` as the control. Both were rewritten to name the real one (the base `fetchWithSsrFGuard`: DNS pinning, `redirect:"manual"` + per-hop re-validation, private-IP blocking), and the correction is recorded in the ledger header so the next author doesn't repeat it. Note `SLACK_MEDIA_SSRF_POLICY`'s `allowedHostnames` is in fact **inert** — it supplies wildcards to an exact-match check.

## Deferred (pre-existing, surfaced not caused)

Filed separately rather than expanded into this PR:

- `attestation-gate` is a real job in `ci.yml` but appears in **neither** the rollup's `needs:` nor its condition — by the rule this PR documents, it currently gates nothing. Same defect class, different gate. `CONTRIBUTING.md` asserts it is "enforced universally", which is therefore wrong.
- A broader audit of other `check-*.mjs` scripts' invocation status is warranted — a spot-check found some invoked indirectly (`check-plugin-sdk-exports.mjs` via `build-all.mjs`) and some genuinely orphaned (`check-package-patches.mjs`, `check-import-cycles.ts`, `check-webhook-auth-body-order.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
