### PR TITLE
feat(mattermost): bound error-response body reads (#3070)

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -4,6 +4,7 @@ import {
   createMattermostClient,
   createMattermostPost,
   normalizeMattermostBaseUrl,
+  readMattermostError,
   updateMattermostPost,
 } from "./client.js";
 
@@ -163,6 +164,101 @@ describe("createMattermostClient", () => {
     });
     const result = await client.request<unknown>("/anything", { method: "DELETE" });
     expect(result).toBeUndefined();
+  });
+});
+
+// ── readMattermostError ──────────────────────────────────────────────
+
+describe("readMattermostError", () => {
+  it("extracts the message field from a JSON error body", async () => {
+    const res = new Response(JSON.stringify({ message: "Not Found", id: "api.404" }), {
+      headers: { "content-type": "application/json" },
+    });
+    await expect(readMattermostError(res)).resolves.toBe("Not Found");
+  });
+
+  it("stringifies a JSON error body that carries no message field", async () => {
+    const res = new Response(JSON.stringify({ id: "api.404" }), {
+      headers: { "content-type": "application/json" },
+    });
+    await expect(readMattermostError(res)).resolves.toBe('{"id":"api.404"}');
+  });
+
+  it("returns raw text for a non-JSON error body", async () => {
+    const res = new Response("upstream exploded", {
+      headers: { "content-type": "text/plain" },
+    });
+    await expect(readMattermostError(res)).resolves.toBe("upstream exploded");
+  });
+
+  it("falls back to raw text when a JSON-typed body does not parse", async () => {
+    const res = new Response("<html>502 Bad Gateway</html>", {
+      headers: { "content-type": "application/json" },
+    });
+    await expect(readMattermostError(res)).resolves.toBe("<html>502 Bad Gateway</html>");
+  });
+
+  it("handles a bodyless response", async () => {
+    const res = new Response(null, { status: 204, headers: { "content-type": "text/plain" } });
+    await expect(readMattermostError(res)).resolves.toBe("");
+  });
+
+  it("keeps the pre-existing throw on a bodyless response typed as JSON", async () => {
+    // Pins the no-body fast path. `res.json()` on an absent body rejects, exactly as it did before
+    // the bounded read landed — routing this case through the bounded branch instead would swallow
+    // it into "" via the JSON-parse fallback, which would be a silent behaviour change.
+    const res = new Response(null, {
+      status: 304,
+      headers: { "content-type": "application/json" },
+    });
+    await expect(readMattermostError(res)).rejects.toThrow(SyntaxError);
+  });
+
+  it("caps an oversized error body at 8 KiB", async () => {
+    const res = new Response("x".repeat(64 * 1024), {
+      headers: { "content-type": "text/plain" },
+    });
+    const detail = await readMattermostError(res);
+    expect(detail).toHaveLength(8 * 1024);
+  });
+
+  it("caps an oversized JSON error body and surfaces the truncated text", async () => {
+    // A hostile server can pad a JSON body past the cap; the truncated remainder no longer parses,
+    // so the raw-text fallback carries the (bounded) detail instead of buffering the whole body.
+    const res = new Response(JSON.stringify({ message: "x".repeat(64 * 1024) }), {
+      headers: { "content-type": "application/json" },
+    });
+    const detail = await readMattermostError(res);
+    expect(detail).toHaveLength(8 * 1024);
+  });
+
+  it("stops reading an unbounded error body instead of draining it", async () => {
+    let pulls = 0;
+    let cancelled = false;
+    const chunk = new TextEncoder().encode("x".repeat(4 * 1024));
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        if (pulls > 1000) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const res = new Response(stream, { headers: { "content-type": "text/plain" } });
+
+    const detail = await readMattermostError(res);
+
+    expect(detail).toHaveLength(8 * 1024);
+    // A handful of 4 KiB pulls to fill the 8 KiB budget — not the endless stream the server
+    // offered. Bounded rather than exact: stream queue pre-fill can add one pull depending on
+    // microtask timing, and pinning that would test scheduling instead of the read.
+    expect(pulls).toBeLessThanOrEqual(4);
+    expect(cancelled).toBe(true);
   });
 });
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -5,6 +5,10 @@ import {
 } from "remoteclaw/plugin-sdk/text-runtime";
 import { z } from "zod";
 import { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
+import { readResponseTextLimited } from "../../../../src/plugin-sdk/response-text-limit.js";
+
+/** Diagnostic budget for an error body; a configured server should never need more. */
+const MATTERMOST_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
 export type MattermostFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -77,14 +81,33 @@ function buildMattermostApiUrl(baseUrl: string, path: string): string {
 
 export async function readMattermostError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
-  if (contentType.includes("application/json")) {
-    const data = (await res.json()) as { message?: string } | undefined;
-    if (data?.message) {
-      return data.message;
+  // No readable body (204/304, or a synthesized bodyless Response): the stream reader has nothing
+  // to bound, so keep the original unbounded calls — they resolve immediately on an absent body.
+  if (!res.body) {
+    if (contentType.includes("application/json")) {
+      const data = (await res.json()) as { message?: string } | undefined;
+      if (data?.message) {
+        return data.message;
+      }
+      return JSON.stringify(data);
     }
-    return JSON.stringify(data);
+    return await res.text();
   }
-  return await res.text();
+  const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
+  if (contentType.includes("application/json")) {
+    try {
+      const data = JSON.parse(text) as { message?: string } | undefined;
+      if (data?.message) {
+        return data.message;
+      }
+      return JSON.stringify(data);
+    } catch {
+      // A truncated or non-conforming JSON error body still carries useful detail — surface it raw
+      // rather than losing the diagnostic.
+      return text;
+    }
+  }
+  return text;
 }
 
 export function createMattermostClient(params: {

--- a/src/plugin-sdk/response-text-limit.test.ts
+++ b/src/plugin-sdk/response-text-limit.test.ts
@@ -1,0 +1,105 @@
+// Plugin SDK tests cover bounded response-body text reads.
+import { describe, expect, it, vi } from "vitest";
+import { readResponseTextLimited } from "./response-text-limit.js";
+
+function streamingResponse(
+  chunks: Uint8Array[],
+  hooks?: { onPull?: (index: number) => void; onCancel?: () => void },
+): Response {
+  let index = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      hooks?.onPull?.(index);
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(chunks[index]);
+      index += 1;
+    },
+    cancel() {
+      hooks?.onCancel?.();
+    },
+  });
+  return new Response(stream);
+}
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+describe("readResponseTextLimited", () => {
+  it("returns the whole body when it fits under the limit", async () => {
+    const response = new Response("short error detail");
+    await expect(readResponseTextLimited(response, 1024)).resolves.toBe("short error detail");
+  });
+
+  it("truncates a body that exceeds the limit", async () => {
+    const response = new Response("a".repeat(5000));
+    const text = await readResponseTextLimited(response, 100);
+    expect(text).toBe("a".repeat(100));
+  });
+
+  it("stops reading once the limit is reached instead of draining the body", async () => {
+    const onPull = vi.fn();
+    const onCancel = vi.fn();
+    // 4 chunks of 64 bytes; a 100-byte budget is spent partway through the second.
+    const chunks = [
+      bytes("a".repeat(64)),
+      bytes("b".repeat(64)),
+      bytes("c".repeat(64)),
+      bytes("d".repeat(64)),
+    ];
+    const response = streamingResponse(chunks, { onPull, onCancel });
+
+    const text = await readResponseTextLimited(response, 100);
+
+    expect(text).toBe(`${"a".repeat(64)}${"b".repeat(36)}`);
+    expect(text).toHaveLength(100);
+    // The body was left undrained. Asserted as a bound, not an exact count: a ReadableStream may
+    // eagerly pre-fill its queue by one chunk depending on microtask timing, so an exact count
+    // would pin scheduling rather than the read behaviour under test.
+    expect(onPull.mock.calls.length).toBeLessThan(chunks.length);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty string for a non-positive limit and leaves the body unconsumed", async () => {
+    const response = new Response("payload");
+    await expect(readResponseTextLimited(response, 0)).resolves.toBe("");
+    await expect(readResponseTextLimited(new Response("payload"), -1)).resolves.toBe("");
+    // The reader was never acquired, so the body is still intact for another consumer.
+    expect(response.bodyUsed).toBe(false);
+    await expect(response.text()).resolves.toBe("payload");
+  });
+
+  it("returns an empty string when the response has no body", async () => {
+    const response = new Response(null, { status: 204 });
+    await expect(readResponseTextLimited(response, 1024)).resolves.toBe("");
+  });
+
+  it("skips empty chunks without spending budget", async () => {
+    const response = streamingResponse([bytes(""), bytes("detail"), bytes("")]);
+    await expect(readResponseTextLimited(response, 1024)).resolves.toBe("detail");
+  });
+
+  it("decodes multi-byte characters split across chunks", async () => {
+    // "é" is 2 bytes in UTF-8; split it so each chunk holds half.
+    const encoded = bytes("é");
+    const response = streamingResponse([encoded.subarray(0, 1), encoded.subarray(1)]);
+    await expect(readResponseTextLimited(response, 1024)).resolves.toBe("é");
+  });
+
+  it("flushes a multi-byte character truncated by the limit", async () => {
+    // "ab é" is 5 UTF-8 bytes; a 4-byte budget cuts "é" in half, and the decoder flush emits a
+    // replacement char rather than dropping the partial sequence.
+    const response = new Response("ab é");
+    const text = await readResponseTextLimited(response, 4);
+    expect(text).toBe("ab �");
+  });
+
+  it("defaults to a 16 KiB budget", async () => {
+    const response = new Response("a".repeat(32 * 1024));
+    const text = await readResponseTextLimited(response);
+    expect(text).toHaveLength(16 * 1024);
+  });
+});

--- a/src/plugin-sdk/response-text-limit.ts
+++ b/src/plugin-sdk/response-text-limit.ts
@@ -1,0 +1,82 @@
+// Bounded response-body text reader for adapters that surface HTTP error details.
+//
+// This duplicates `readResponseTextLimited` in `src/agents/provider-http-errors.ts` — deliberately.
+// That module still exists in the fork, but it sits in the `src/agents/` execution-engine layer
+// RemoteClaw is replacing, its only importer is its own test, and it pulls in @remoteclaw/media-core,
+// packages/normalization-core, and src/logging/redact. Channel adapters are a kept surface and must
+// not take a dependency on a layer scheduled for removal, so the kept plugin-sdk layer carries its
+// own copy. The logic is pure Web API (Response / ReadableStream / TextDecoder) and has no imports
+// at all, which is what makes the duplication cheap.
+//
+// Keep the two in sync until `src/agents/provider-http-errors.ts` is gutted, at which point this
+// becomes the sole definition. No gate enforces that today.
+//
+// Import this from extensions by relative path, as extensions/mattermost does. There is no
+// `./plugin-sdk/response-text-limit` key in package.json exports (57 explicit keys, no wildcard),
+// so a bare `remoteclaw/plugin-sdk/response-text-limit` specifier would resolve under vitest — which
+// auto-aliases local subpaths — and then fail at runtime with ERR_PACKAGE_PATH_NOT_EXPORTED.
+
+/**
+ * Reads at most `limitBytes` from a response body instead of buffering the whole thing.
+ *
+ * Adapters call this on error paths, where the body is influenced by a remote endpoint the
+ * operator configured but the fork does not control: `res.text()` / `res.json()` would read an
+ * arbitrarily large error body straight into memory. Once the budget is spent the stream is
+ * cancelled so the upstream producer stops sending rather than idling on a full buffer.
+ *
+ * Returns `""` when the budget is non-positive or the response carries no readable body — callers
+ * that need to distinguish "empty body" from "no body" should check `response.body` themselves.
+ */
+export async function readResponseTextLimited(
+  response: Response,
+  limitBytes = 16 * 1024,
+): Promise<string> {
+  if (limitBytes <= 0) {
+    return "";
+  }
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return "";
+  }
+
+  const decoder = new TextDecoder();
+  let total = 0;
+  let text = "";
+  let reachedLimit = false;
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value || value.byteLength === 0) {
+        continue;
+      }
+      const remaining = limitBytes - total;
+      if (remaining <= 0) {
+        reachedLimit = true;
+        break;
+      }
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      total += chunk.byteLength;
+      text += decoder.decode(chunk, { stream: true });
+      if (total >= limitBytes) {
+        reachedLimit = true;
+        break;
+      }
+    }
+    // Flush any trailing partial multi-byte sequence left by a truncated chunk.
+    text += decoder.decode();
+  } finally {
+    if (reachedLimit) {
+      // Stop the upstream body once the diagnostic budget is full.
+      await reader.cancel().catch(() => undefined);
+    }
+    try {
+      reader.releaseLock();
+    } catch {}
+  }
+
+  return text;
+}


### PR DESCRIPTION
Closes #3070

**This touches the Mattermost channel-adapter error path (a kept fork surface) and needs independent security review before merge.**

## What

Ports upstream OpenClaw's `readResponseTextLimited` hardening (`v2026.6.9`) into the fork:

1. **New** `src/plugin-sdk/response-text-limit.ts` — fork-native `readResponseTextLimited(response, limitBytes = 16 * 1024)`. Pure Web API (`Response` / `ReadableStream` / `TextDecoder`), **zero imports**, so no dependency on the gutted `src/agents/*` layer or any excluded package.
2. **Adopted** in `extensions/mattermost/src/mattermost/client.ts` `readMattermostError` with an 8 KiB cap, preserving message-extraction semantics (JSON `message` → stringified JSON → raw-text fallback) and the no-body fast path.

The SSRF-guarded `fetchWithSsrFGuard` path is unchanged, per the issue's proposed approach.

## Two issue premises were wrong — corrected against live sources

Grounded against the genuine upstream (`openclaw/openclaw` at tag `v2026.6.9`), not the issue text:

- **The issue's inline helper snippet is a lossy paraphrase.** Real upstream tracks `reachedLimit`, calls `await reader.cancel()` when the budget is spent, and flushes the decoder (`text += decoder.decode()`). The snippet omits both. The `cancel()` is the part that actually stops the producer rather than merely abandoning the stream — this PR ports the real implementation.
- **`src/agents/provider-http-errors.ts` is NOT absent from the fork.** It exists (12.6 KB) and is attested `readResponseTextLimited: "live"`. The issue's stated rationale ("the upstream definition site is not present either") is false. The fork-native copy is still the right call — that layer is being replaced, its only importer is its own test, and it pulls in `@remoteclaw/media-core`, `packages/normalization-core`, and `src/logging/redact` — but the file header now documents the real reason and the sync obligation, rather than the false one.

## ⚠️ Known limitation — the cap is inert on the production path

Surfaced by an independent security review and confirmed from source. `createMattermostClient`'s `guardedFetchImpl` buffers the **entire** body before `readMattermostError` ever runs:

```ts
const bodyBytes = NULL_BODY_STATUSES.has(response.status)
  ? null
  : await response.arrayBuffer();   // unbounded, every response
```

All 10 non-test `createMattermostClient` call sites use this guarded path, so:

- **What this PR does buy:** the propagated error *string* is bounded, and the second/third unbounded allocations (`res.text()`'s full-size string, `res.json()`'s parsed object graph) are removed — roughly a 2–4× constant-factor reduction in peak allocation.
- **What it does not:** allocation still scales linearly and without bound in the attacker-controlled body size, which is the threat #3070 states.

Bounding `response.arrayBuffer()` means changing the SSRF-guarded fetch path, which #3070 explicitly scopes as unchanged and which warrants its own change plus security review. **Recommend a follow-up issue.** Flagging rather than silently closing #3070 on a partial fix — reviewer's call whether to retitle/re-scope the issue instead.

## Behaviour change worth noting

A *valid* JSON error body larger than 8 KiB previously yielded a clean `message`; it now fails `JSON.parse` on the truncated text and returns 8 KiB of raw JSON, interpolated into the thrown `Error`. Strictly better than the prior unbounded read, but error messages can now reach 8 KiB — there is no display-side `truncateErrorDetail` on this path.

## Testing

- `src/plugin-sdk/response-text-limit.test.ts` — 9 tests (unit lane, `pnpm test`): limit truncation, early-stop + cancel, non-positive limit leaves body unconsumed, no-body, empty chunks, multi-byte UTF-8 split across chunks, truncated multi-byte flush, 16 KiB default.
- `extensions/mattermost/src/mattermost/client.test.ts` — 8 new tests (`test-extensions` lane; not quarantined): all four message-extraction branches, the no-body fast path, the 8 KiB cap for text and JSON bodies, and early-stop against an endless stream.
- Both suites were **mutation-checked**: the no-body fast path is now genuinely gated (removing it turns the suite red), and two originally timing-coupled pull-count assertions were loosened to bounds so they test the read rather than `ReadableStream` scheduling.

**Verification:** `pnpm check` ✅ (0 warnings, 0 errors) · `pnpm build` ✅ · unit 9/9 ✅ · full Mattermost suite 24 files / 229 tests ✅ · fork-integrity gates ✅ (zombie-imports, stub-debt, throwing-stub-callers, attestations, obsolescence-audit, policy-doctor-boundary, raw-channel-fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)