### PR TITLE
test(gateway): pin plugin-subagent session-messages limit clamp

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PluginRegistry } from "../plugins/registry.js";
-import type { PluginRuntime } from "../plugins/runtime/types.js";
+import type { PluginRuntime, SubagentGetSessionMessagesParams } from "../plugins/runtime/types.js";
 import type { PluginDiagnostic } from "../plugins/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
 
@@ -46,6 +46,20 @@ function getLastDispatchedContext(): GatewayRequestContext | undefined {
   return call?.context;
 }
 
+function getLastDispatchedParams(method: string): Record<string, unknown> {
+  const call = handleGatewayRequest.mock.calls.at(-1)?.[0];
+  if (call?.req.method !== method) {
+    throw new Error(
+      `Expected the last gateway dispatch to be ${method}, got ${String(call?.req.method)}`,
+    );
+  }
+  const params = call.req.params;
+  if (!params || typeof params !== "object") {
+    throw new Error(`Expected the ${method} dispatch to carry params`);
+  }
+  return params as Record<string, unknown>;
+}
+
 async function importServerPluginsModule(): Promise<ServerPluginsModule> {
   return import("./server-plugins.js");
 }
@@ -72,6 +86,13 @@ function createSubagentRuntime(serverPlugins: ServerPluginsModule): PluginRuntim
     throw new Error("Expected loadGatewayPlugins to provide subagent runtime");
   }
   return call.runtimeOptions.subagent;
+}
+
+async function createSubagentRuntimeWithFallbackContext(): Promise<PluginRuntime["subagent"]> {
+  const serverPlugins = await importServerPluginsModule();
+  const runtime = createSubagentRuntime(serverPlugins);
+  serverPlugins.setFallbackGatewayContext(createTestContext("subagent-limit-clamp"));
+  return runtime;
 }
 
 beforeEach(() => {
@@ -208,5 +229,78 @@ describe("loadGatewayPlugins", () => {
       | (GatewayRequestContext & { marker: string })
       | undefined;
     expect(dispatched?.marker).toBe("after-mutation");
+  });
+
+  // The clamp is reachable only through loadGatewayPlugins —
+  // createGatewaySubagentRuntime is deliberately private — so these cases assert
+  // on the params the mocked server-methods dispatch receives for "sessions.get".
+  describe("subagent getSessionMessages limit clamp", () => {
+    test.each([
+      {
+        name: "clamps an over-max limit down to the 1000 maximum",
+        limit: 5_000,
+        expected: 1_000,
+      },
+      {
+        name: "floors a zero limit up to 1",
+        limit: 0,
+        expected: 1,
+      },
+      {
+        name: "floors a negative limit up to 1",
+        limit: -10,
+        expected: 1,
+      },
+      {
+        name: "truncates a fractional limit toward zero",
+        limit: 10.7,
+        expected: 10,
+      },
+      {
+        name: "passes an in-range limit through unchanged",
+        limit: 50,
+        expected: 50,
+      },
+    ])("$name", async ({ limit, expected }) => {
+      const runtime = await createSubagentRuntimeWithFallbackContext();
+
+      await runtime.getSessionMessages({ sessionKey: "s-limit", limit });
+
+      const params = getLastDispatchedParams("sessions.get");
+      expect(params.key).toBe("s-limit");
+      expect(params.limit).toBe(expected);
+    });
+
+    test.each([
+      {
+        name: "omits the limit key when limit is explicitly undefined",
+        params: { sessionKey: "s-limit", limit: undefined },
+      },
+      {
+        name: "omits the limit key when limit is absent",
+        params: { sessionKey: "s-limit" },
+      },
+      {
+        name: "omits the limit key when limit is NaN",
+        params: { sessionKey: "s-limit", limit: Number.NaN },
+      },
+      {
+        name: "omits the limit key when limit is Infinity",
+        params: { sessionKey: "s-limit", limit: Number.POSITIVE_INFINITY },
+      },
+    ] satisfies { name: string; params: SubagentGetSessionMessagesParams }[])(
+      "$name",
+      async ({ params }) => {
+        const runtime = await createSubagentRuntimeWithFallbackContext();
+
+        await runtime.getSessionMessages(params);
+
+        const dispatched = getLastDispatchedParams("sessions.get");
+        expect(dispatched.key).toBe("s-limit");
+        // Key absence, not `undefined`: `toBeUndefined()` would also pass for a
+        // forwarded `limit: undefined`, which is what the clamp avoids emitting.
+        expect("limit" in dispatched).toBe(false);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Why

The v2026.6.11 sync (#3074) security Polish found that the plugin-subagent
`getSessionMessages` limit was passed through to `sessions.get` unclamped, and
fixed it as a MUST-PORT. **The fix shipped without a test**, so nothing prevents
a future content-only sync from silently reverting it.

This adds only the test. **No implementation change** —
`src/gateway/server-plugins.ts` is byte-identical to `main`.

## What it pins

`createGatewaySubagentRuntime` is deliberately private, so the test reaches the
clamp the way production does — through the exported `loadGatewayPlugins` — and
asserts on the params the mocked `server-methods` dispatch receives for
`"sessions.get"`. No production symbol was exported to make this testable.

| input `limit` | dispatched |
|---|---|
| `5000` | `1000` (clamped to max) |
| `0`, `-10` | `1` (`Math.max(1, …)`) |
| `10.7` | `10` (`Math.floor`) |
| `50` | `50` (in-range passthrough) |
| `undefined` / omitted | no `limit` key |
| `NaN`, `Infinity` | no `limit` key |

Two details worth noting:

- The omit cases assert **key absence** (`expect("limit" in params).toBe(false)`),
  not `toBeUndefined()` — the latter passes for both absent and
  present-but-`undefined`, and forwarding `limit: undefined` is exactly what the
  guard avoids.
- The `5000 → 1000` case pins the constant's **value** through observable
  behavior rather than importing or re-declaring the private
  `PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT`.

## Verification

`pnpm test:gateway` scope (`src/gateway/server-plugins.test.ts`): **14 passed**
(5 pre-existing + 9 new). `pnpm check` green via the pre-commit hook.

Mutation-checked — the test was proven to fail against a broken implementation,
then the implementation reverted:

1. Removing the `Math.min(...)` clamp entirely (the exact shape of a silent sync
   revert) → `clamps an over-max limit down to the 1000 maximum` FAILS with
   `expected 5000 to be 1000`; the other 13 pass, confirming the remaining cases
   exercise orthogonal branches rather than echoing the clamp.
2. Widening the constant to `1_000_000` → same single failure, confirming the
   constant's value is pinned and not merely "some clamp exists".

Both injections were reverted; `git diff src/gateway/server-plugins.ts` is empty
and the blob hash matches the base (`6622c9b79254852e07d2374f9d3a691347d5c484`).

## Lane note

`src/gateway/**` is excluded from `vitest.unit.config.ts`, so this file runs in
the required `test-gateway` CI lane (which is a hard gate — the quarantine
ledger covers only the extensions and auto-reply lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)