### PR TITLE
fix: gate probe SSH fallback on --port + drop unsatisfiable host peerDeps (#3083, #3079)

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -14,14 +14,6 @@
   "devDependencies": {
     "remoteclaw": "workspace:*"
   },
-  "peerDependencies": {
-    "remoteclaw": ">=2026.6.11"
-  },
-  "peerDependenciesMeta": {
-    "remoteclaw": {
-      "optional": true
-    }
-  },
   "remoteclaw": {
     "bundle": {
       "stageRuntimeDependencies": true

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -10,14 +10,6 @@
   "devDependencies": {
     "remoteclaw": "workspace:*"
   },
-  "peerDependencies": {
-    "remoteclaw": ">=2026.6.11"
-  },
-  "peerDependenciesMeta": {
-    "remoteclaw": {
-      "optional": true
-    }
-  },
   "remoteclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -10,14 +10,6 @@
   "devDependencies": {
     "remoteclaw": "workspace:*"
   },
-  "peerDependencies": {
-    "remoteclaw": ">=2026.6.5"
-  },
-  "peerDependenciesMeta": {
-    "remoteclaw": {
-      "optional": true
-    }
-  },
   "remoteclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -10,14 +10,6 @@
   "devDependencies": {
     "remoteclaw": "workspace:*"
   },
-  "peerDependencies": {
-    "remoteclaw": ">=2026.4.4"
-  },
-  "peerDependenciesMeta": {
-    "remoteclaw": {
-      "optional": true
-    }
-  },
   "remoteclaw": {
     "channel": {
       "id": "qa-channel",

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -300,6 +300,7 @@ async function runGatewayStatus(
   opts: {
     timeout: string;
     json?: boolean;
+    url?: string;
     port?: unknown;
     ssh?: string;
     sshAuto?: boolean;
@@ -1121,5 +1122,133 @@ describe("gateway-status command", () => {
 
     const call = requireSshForwardCall();
     expect(call.identity).toBe("/tmp/explicit_id");
+  });
+});
+
+// `gateway probe --port <N>` is an explicit *local* port check, so it must not reach for the
+// configured remote. These pin the gate's truth table across all three configured fallbacks:
+// gateway.remote.sshTarget, gateway.remote.sshIdentity, and the
+// inferSshTargetFromRemoteUrl(gateway.remote.url) inference.
+describe("gateway-status --port gates configured remote SSH fallbacks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Config carrying an explicit configured SSH target + identity (fallbacks 1 and 2). */
+  function makeConfiguredSshConfig() {
+    return {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://configured.example:18789",
+          token: "rtok",
+          sshTarget: "ops@configured.example",
+          sshIdentity: "/tmp/id_configured",
+        },
+        auth: { token: "ltok" },
+      },
+    };
+  }
+
+  /** Config carrying only remote.url, so the SSH target can come only from inference (fallback 3). */
+  function makeInferenceOnlyConfig() {
+    return makeRemoteGatewayConfig("wss://inferred.example:18789");
+  }
+
+  it("suppresses configured sshTarget and sshIdentity when --port is given", async () => {
+    const { runtime, runtimeErrors } = createRuntimeCapture();
+    readBestEffortConfig.mockResolvedValueOnce(makeConfiguredSshConfig() as never);
+
+    await runGatewayStatus(runtime, { timeout: "1000", json: true, port: "19080" });
+
+    expect(runtimeErrors).toHaveLength(0);
+    expect(startSshPortForward).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the remote-url SSH inference when --port is given", async () => {
+    const { runtime } = createRuntimeCapture();
+    await withEnvAsync({ USER: "tester" }, async () => {
+      readBestEffortConfig.mockResolvedValueOnce(makeInferenceOnlyConfig() as never);
+
+      await runGatewayStatus(runtime, { timeout: "1000", json: true, port: "19080" });
+
+      expect(startSshPortForward).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps the configured fallbacks active when --port is paired with an explicit --url", async () => {
+    const { runtime } = createRuntimeCapture();
+    readBestEffortConfig.mockResolvedValueOnce(makeConfiguredSshConfig() as never);
+
+    await runGatewayStatus(runtime, {
+      timeout: "1000",
+      json: true,
+      port: "19080",
+      url: "ws://explicit.example:18789",
+    });
+
+    expect(startSshPortForward).toHaveBeenCalledTimes(1);
+    const call = requireSshForwardCall();
+    expect(call.target).toBe("ops@configured.example");
+    expect(call.identity).toBe("/tmp/id_configured");
+  });
+
+  it("lets an explicit --ssh win over the --port gate", async () => {
+    const { runtime } = createRuntimeCapture();
+    readBestEffortConfig.mockResolvedValueOnce(makeConfiguredSshConfig() as never);
+
+    await runGatewayStatus(runtime, {
+      timeout: "1000",
+      json: true,
+      port: "19080",
+      ssh: "me@explicit-host.example",
+    });
+
+    expect(startSshPortForward).toHaveBeenCalledTimes(1);
+    const call = requireSshForwardCall();
+    expect(call.target).toBe("me@explicit-host.example");
+    // The gate still suppressed the *configured* identity; only the target was explicit.
+    expect(call.identity).toBeUndefined();
+  });
+
+  it("keeps an explicit --ssh-identity alongside an explicit --ssh under --port", async () => {
+    const { runtime } = createRuntimeCapture();
+    readBestEffortConfig.mockResolvedValueOnce(makeConfiguredSshConfig() as never);
+
+    await runGatewayStatus(runtime, {
+      timeout: "1000",
+      json: true,
+      port: "19080",
+      ssh: "me@explicit-host.example",
+      sshIdentity: "/tmp/id_explicit",
+    });
+
+    const call = requireSshForwardCall();
+    expect(call.target).toBe("me@explicit-host.example");
+    expect(call.identity).toBe("/tmp/id_explicit");
+  });
+
+  it("leaves configured sshTarget and sshIdentity untouched when --port is absent", async () => {
+    const { runtime } = createRuntimeCapture();
+    readBestEffortConfig.mockResolvedValueOnce(makeConfiguredSshConfig() as never);
+
+    await runGatewayStatus(runtime, { timeout: "1000", json: true });
+
+    expect(startSshPortForward).toHaveBeenCalledTimes(1);
+    const call = requireSshForwardCall();
+    expect(call.target).toBe("ops@configured.example");
+    expect(call.identity).toBe("/tmp/id_configured");
+  });
+
+  it("leaves the remote-url SSH inference untouched when --port is absent", async () => {
+    const { runtime } = createRuntimeCapture();
+    await withEnvAsync({ USER: "tester" }, async () => {
+      readBestEffortConfig.mockResolvedValueOnce(makeInferenceOnlyConfig() as never);
+
+      await runGatewayStatus(runtime, { timeout: "1000", json: true });
+
+      expect(startSshPortForward).toHaveBeenCalledTimes(1);
+      expect(requireSshForwardCall().target).toBe("tester@inferred.example");
+    });
   });
 });

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -1,3 +1,4 @@
+import { parseGatewayPortOption } from "../cli/gateway-port-option.js";
 import { withProgress } from "../cli/progress.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../config/config.js";
 import { probeGateway } from "../gateway/probe.js";
@@ -26,6 +27,7 @@ import {
 export async function gatewayStatusCommand(
   opts: {
     url?: string;
+    port?: unknown;
     token?: string;
     password?: string;
     timeout?: unknown;
@@ -54,15 +56,24 @@ export async function gatewayStatusCommand(
     wideAreaDomain,
   });
 
-  let sshTarget = sanitizeSshTarget(opts.ssh) ?? sanitizeSshTarget(cfg.gateway?.remote?.sshTarget);
+  // An explicit --port is a local probe: it must not reach for the configured remote. Only an
+  // explicit --url re-enables the configured fallbacks; an explicit --ssh always wins regardless.
+  const portOverride = parseGatewayPortOption(opts.port);
+  const hasExplicitUrl = typeof opts.url === "string" && opts.url.trim().length > 0;
+  const useConfiguredRemoteTargets = portOverride === undefined || hasExplicitUrl;
+
+  let sshTarget =
+    sanitizeSshTarget(opts.ssh) ??
+    (useConfiguredRemoteTargets ? sanitizeSshTarget(cfg.gateway?.remote?.sshTarget) : null);
   let sshIdentity =
-    sanitizeSshTarget(opts.sshIdentity) ?? sanitizeSshTarget(cfg.gateway?.remote?.sshIdentity);
+    sanitizeSshTarget(opts.sshIdentity) ??
+    (useConfiguredRemoteTargets ? sanitizeSshTarget(cfg.gateway?.remote?.sshIdentity) : null);
   const remotePort = resolveGatewayPort(cfg);
 
   let sshTunnelError: string | null = null;
   let sshTunnelStarted = false;
 
-  if (!sshTarget) {
+  if (!sshTarget && useConfiguredRemoteTargets) {
     sshTarget = inferSshTargetFromRemoteUrl(cfg.gateway?.remote?.url);
   }
 


### PR DESCRIPTION
Two unrelated fork-residue fixes in disjoint files. Fixes #3079, fixes #3083.

## #3083 — `gateway probe --port` still tunnelled to the configured remote

`remoteclaw gateway probe --port <N>` asks for an explicit **local** port check, but
`gatewayStatusCommand` never read `opts.port` when resolving SSH, so it still opened a
tunnel to `gateway.remote.sshTarget`.

The gate suppresses all **three** configured fallbacks when `--port` is given and `--url` is not:

| fallback | site |
|---|---|
| `cfg.gateway.remote.sshTarget` | `gateway-status.ts` ssh target resolution |
| `cfg.gateway.remote.sshIdentity` | ssh identity resolution |
| `inferSshTargetFromRemoteUrl(cfg.gateway.remote.url)` | url-inference branch |

An explicit `--ssh` always wins; an explicit `--url` re-enables the configured fallbacks.

Ports upstream's **semantic** (`8e4213b1c41`), not its diff — upstream also threads
`portOverride` through `resolveTargets` / `buildNetworkHints` / `remotePort` and uses a
params-object `resolveSshTarget`, all of which diverge in this fork. Reuses the fork's
existing `parseGatewayPortOption`. The `opts` type omitted `port` even though commander
passes it through `resolveGatewayRpcOptions`' spread — widened.

Note: the command is `gateway probe`, not `gateway status` (per the correction comment on
 #3083). `gateway status` registers no `--port`/`--ssh` and routes to `runDaemonStatus`.

### Truth table, pinned by 7 new tests

| invocation | configured fallbacks |
|---|---|
| `--port` alone | suppressed (target, identity, url-inference) |
| `--port` + `--url` | active |
| `--port` + `--ssh` | explicit target wins; configured identity still suppressed |
| no `--port` | unchanged |

3 of the 7 fail against the un-gated code (`expected "vi.fn()" to not be called at all, but
actually been called 1 times`; `expected '/tmp/id_configured' to be undefined`) and pass with
the gate.

## #3079 — four unsatisfiable `peerDependencies.remoteclaw`

Four extensions declared a host peer dep using upstream **calendar** versions against a fork
root version of `0.8.0`, so the host-compatibility gate could never match — it did not fail
loudly, it simply never fired.

| extension | declared | `private` |
|---|---|---|
| `googlechat` | `>=2026.6.11` | true |
| `nostr` | `>=2026.6.11` | **false — publishes** |
| `policy` | `>=2026.6.5` | true |
| `qa-channel` | `>=2026.4.4` | true |

Removal (not re-versioning) matches the fork's own convention: **25 of 29** extensions declare
no host peer dep at all, and all 4 outliers carry upstream calendar values — sync residue, not
a fork decision. None had any other peer dep, so the empty objects are removed too.

**The published manifest is unaffected in shape, and the range is repaired.**
`resolvePluginNpmRuntimePackagePeerMetadata` re-derives the range from a 5-level fallback chain
and re-injects the meta at build time, so for `nostr` the published value goes from an
unsatisfiable `>=2026.6.11` to a satisfiable `>=0.8.0`:

```
nostr       private=false
   BEFORE published peerDeps: {"remoteclaw":">=2026.6.11"} meta: {"remoteclaw":{"optional":true}}
   AFTER  published peerDeps: {"remoteclaw":">=0.8.0"}     meta: {"remoteclaw":{"optional":true}}
```

The orphaned `peerDependenciesMeta` blocks are removed alongside, since they modified a key
that no longer exists (published output is byte-identical either way).

## Verification

- `./node_modules/.bin/tsgo --noEmit` — exit 0, no output
- `pnpm check` — green (also ran as a pre-commit hook)
- `oxlint --type-aware` on touched files — 0 warnings, 0 errors
- CI fork-integrity gates — zombie-import, stub-debt, throwing-stub-callers, attestations,
  obsolescence-audit, policy-doctor-boundary, no-raw-channel-fetch: all exit 0
- CI-covered `src/cli/**` gateway tests — 15 passed, 1 skipped
- All 4 manifests re-validated with `JSON.parse`

## Noticed, not changed

- **`--port` is still not threaded into the probe *target*.** `resolveTargets(cfg, opts.url)`
  and `buildNetworkHints(cfg)` take no port, so `--port` only gates SSH — it does not move the
  loopback probe URL. Two pre-existing tests assert it should
  (`uses --port for the local loopback probe target`, `lets --port select the local probe…`)
  and fail at `main`. Out of scope here; worth its own issue.
- **`src/commands/**` is excluded from every vitest lane**, so `gateway-status.test.ts` runs in
  no CI job. It has **15 pre-existing failures at `main`** — the failure set is byte-identical
  before and after this change (verified against a clean worktree at `f5a7c43d8e3`).
- `extensions/qa-channel` also carries `remoteclaw.install.minHostVersion: ">=2026.4.4"` — the
  same unsatisfiable calendar shape under a different key. Left alone (different key, out of
  #3079's scope).
- `pnpm release:check` fails with `dist/plugin-sdk/index.js not found (build missing?)` both
  with and without this change — a build precondition, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)