### PR TITLE
security(windows): pin system-binary spawns to %SystemRoot% (#3077)

### DIFF
--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -3,6 +3,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { resolveDateTimestampMs } from "@remoteclaw/normalization-core/number-coercion";
+import { resolveWindowsPowerShellPath } from "../infra/windows-system-paths.js";
 
 export const MODULE_ATTESTATIONS = {
   resolveUserTimezone: "live",
@@ -165,7 +166,7 @@ function detectSystemTimeFormat(): boolean {
   if (process.platform === "win32") {
     try {
       const result = execFileSync(
-        "powershell",
+        resolveWindowsPowerShellPath(),
         ["-Command", "(Get-Culture).DateTimeFormat.ShortTimePattern"],
         { encoding: "utf8", timeout: 1000 },
       ).trim();

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:net";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveLsofCommandSync } from "../infra/ports-lsof.js";
 import { tryListenOnPort } from "../infra/ports-probe.js";
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import { resolvePositiveTimerTimeoutMs, resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { sleep } from "../utils.js";
 
@@ -165,7 +166,9 @@ export function parseLsofOutput(output: string): PortProcess[] {
 export function listPortListeners(port: number): PortProcess[] {
   if (process.platform === "win32") {
     try {
-      const out = execFileSync("netstat", ["-ano", "-p", "TCP"], { encoding: "utf-8" });
+      const out = execFileSync(resolveWindowsSystem32Path("netstat.exe"), ["-ano", "-p", "TCP"], {
+        encoding: "utf-8",
+      });
       const lines = out.split(/\r?\n/).filter(Boolean);
       const results: PortProcess[] = [];
       for (const line of lines) {

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolveWindowsCmdExePath } from "../../infra/windows-system-paths.js";
 import { prepareRestartScript, runRestartScript } from "./restart-helper.js";
 
 vi.mock("node:child_process", async () => {
@@ -559,11 +560,15 @@ exit 0
 
       await runRestartScript(scriptPath);
 
-      expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", scriptPath], {
-        detached: true,
-        stdio: "ignore",
-        windowsHide: true,
-      });
+      expect(spawn).toHaveBeenCalledWith(
+        resolveWindowsCmdExePath(),
+        ["/d", "/s", "/c", scriptPath],
+        {
+          detached: true,
+          stdio: "ignore",
+          windowsHide: true,
+        },
+      );
       expect(mockChild.on).toHaveBeenCalledWith("error", expect.any(Function));
       expect(mockChild.unref).toHaveBeenCalledTimes(1);
     });
@@ -576,11 +581,15 @@ exit 0
 
       await runRestartScript(scriptPath);
 
-      expect(spawn).toHaveBeenCalledWith("cmd.exe", ["/d", "/s", "/c", `"${scriptPath}"`], {
-        detached: true,
-        stdio: "ignore",
-        windowsHide: true,
-      });
+      expect(spawn).toHaveBeenCalledWith(
+        resolveWindowsCmdExePath(),
+        ["/d", "/s", "/c", `"${scriptPath}"`],
+        {
+          detached: true,
+          stdio: "ignore",
+          windowsHide: true,
+        },
+      );
     });
 
     it("does not throw when spawn fails synchronously", async () => {

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -16,6 +16,7 @@ import {
   resolveGatewayRestartLogPath,
   shellEscapeRestartLogValue,
 } from "../../daemon/restart-logs.js";
+import { resolveWindowsCmdExePath } from "../../infra/windows-system-paths.js";
 
 /**
  * Shell-escape a string for embedding in single-quoted shell arguments.
@@ -393,7 +394,7 @@ exit $status
  */
 export async function runRestartScript(scriptPath: string): Promise<void> {
   const isWindows = process.platform === "win32";
-  const file = isWindows ? "cmd.exe" : "/bin/sh";
+  const file = isWindows ? resolveWindowsCmdExePath() : "/bin/sh";
   const args = isWindows ? ["/d", "/s", "/c", quoteCmdScriptArg(scriptPath)] : [scriptPath];
 
   try {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -13,6 +13,7 @@ import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { pickPrimaryLanIPv4, isValidIPv4 } from "../gateway/net.js";
 import { isSafeExecutableValue } from "../infra/safe-executable-value.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import { isWSL } from "../infra/wsl.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -340,7 +341,10 @@ export async function detectBinary(name: string): Promise<boolean> {
     }
   }
 
-  const command = process.platform === "win32" ? ["where", name] : ["/usr/bin/env", "which", name];
+  const command =
+    process.platform === "win32"
+      ? [resolveWindowsSystem32Path("where.exe"), name]
+      : ["/usr/bin/env", "which", name];
   try {
     const result = await runCommandWithTimeout(command, { timeoutMs: 2000 });
     return result.code === 0 && result.stdout.trim().length > 0;

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
+import { resolveWindowsCmdExePath } from "../infra/windows-system-paths.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
 import {
@@ -105,7 +106,9 @@ async function execLaunchctl(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const isWindows = process.platform === "win32";
-  const file = isWindows ? (process.env.ComSpec ?? "cmd.exe") : "launchctl";
+  // ComSpec stays the primary override; the fallback is pinned so an unset
+  // ComSpec cannot fall through to a %PATH% lookup (CWE-426).
+  const file = isWindows ? (process.env.ComSpec ?? resolveWindowsCmdExePath()) : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
   return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
 }

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import {
   buildGatewayDistEntrypointCandidates,
   findFirstAccessibleGatewayEntrypoint,
@@ -165,7 +166,7 @@ async function resolveNodePath(): Promise<string> {
 }
 
 async function resolveBinaryPath(binary: string): Promise<string> {
-  const cmd = process.platform === "win32" ? "where" : "which";
+  const cmd = process.platform === "win32" ? resolveWindowsSystem32Path("where.exe") : "which";
   try {
     const output = execFileSync(cmd, [binary], { encoding: "utf8" }).trim();
     const resolved = output.split(/\r?\n/)[0]?.trim();

--- a/src/daemon/schtasks-exec.ts
+++ b/src/daemon/schtasks-exec.ts
@@ -1,4 +1,5 @@
 /** Executes Windows Task Scheduler commands with daemon-friendly timeouts. */
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 
 const SCHTASKS_TIMEOUT_MS = 15_000;
@@ -8,10 +9,13 @@ const SCHTASKS_NO_OUTPUT_TIMEOUT_MS = 30_000;
 export async function execSchtasks(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  const result = await runCommandWithTimeout(["schtasks", ...args], {
-    timeoutMs: SCHTASKS_TIMEOUT_MS,
-    noOutputTimeoutMs: SCHTASKS_NO_OUTPUT_TIMEOUT_MS,
-  });
+  const result = await runCommandWithTimeout(
+    [resolveWindowsSystem32Path("schtasks.exe"), ...args],
+    {
+      timeoutMs: SCHTASKS_TIMEOUT_MS,
+      noOutputTimeoutMs: SCHTASKS_NO_OUTPUT_TIMEOUT_MS,
+    },
+  );
   const timeoutDetail =
     result.termination === "timeout"
       ? `schtasks timed out after ${SCHTASKS_TIMEOUT_MS}ms`

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { isGatewayArgv } from "../infra/gateway-process-argv.js";
 import { findVerifiedGatewayListenerPidsOnPortSync } from "../infra/gateway-processes.js";
 import { inspectPortUsage } from "../infra/ports.js";
+import {
+  resolveWindowsCmdExePath,
+  resolveWindowsSystem32Path,
+} from "../infra/windows-system-paths.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { sleep } from "../utils.js";
@@ -426,7 +430,7 @@ async function launchFallbackTaskScript(env: GatewayServiceEnv): Promise<void> {
     return;
   }
 
-  const child = spawn("cmd.exe", ["/d", "/c", scriptPath], {
+  const child = spawn(resolveWindowsCmdExePath(), ["/d", "/c", scriptPath], {
     detached: true,
     stdio: "ignore",
     windowsHide: true,
@@ -559,11 +563,7 @@ async function terminateGatewayProcessTree(pid: number, graceMs: number): Promis
     killProcessTree(pid, { graceMs });
     return;
   }
-  const taskkillPath = path.join(
-    process.env.SystemRoot ?? "C:\\Windows",
-    "System32",
-    "taskkill.exe",
-  );
+  const taskkillPath = resolveWindowsSystem32Path("taskkill.exe");
   spawnSync(taskkillPath, ["/T", "/PID", String(pid)], {
     stdio: "ignore",
     timeout: 5_000,

--- a/src/infra/clipboard.ts
+++ b/src/infra/clipboard.ts
@@ -1,5 +1,9 @@
 // Reads and writes clipboard text through platform command helpers.
 import { runCommandWithTimeout } from "../process/exec.js";
+import {
+  resolveWindowsPowerShellPath,
+  resolveWindowsSystem32Path,
+} from "./windows-system-paths.js";
 import { isWSL2Sync } from "./wsl.js";
 
 // WSL interop needs a shell to launch Windows PE binaries; exec keeps the
@@ -7,13 +11,25 @@ import { isWSL2Sync } from "./wsl.js";
 const WSL_CLIPBOARD_ARGV = ["/bin/sh", "-c", "exec /mnt/c/Windows/System32/clip.exe"];
 
 export async function copyToClipboard(value: string): Promise<boolean> {
+  // On Windows, pin the system binaries so %PATH% cannot decide which
+  // clip.exe/powershell.exe runs (CWE-426). Off Windows these entries are
+  // WSL-interop fallbacks reached through the Linux PATH, where an absolute
+  // C:\ path would not resolve — so the bare names stay there.
+  const isWindows = process.platform === "win32";
   const attempts: Array<{ argv: string[] }> = [
     ...(isWSL2Sync() ? [{ argv: WSL_CLIPBOARD_ARGV }] : []),
     { argv: ["pbcopy"] },
     { argv: ["xclip", "-selection", "clipboard"] },
     { argv: ["wl-copy"] },
-    { argv: ["clip.exe"] },
-    { argv: ["powershell", "-NoProfile", "-Command", "Set-Clipboard"] },
+    { argv: [isWindows ? resolveWindowsSystem32Path("clip.exe") : "clip.exe"] },
+    {
+      argv: [
+        isWindows ? resolveWindowsPowerShellPath() : "powershell",
+        "-NoProfile",
+        "-Command",
+        "Set-Clipboard",
+      ],
+    },
   ];
   for (const attempt of attempts) {
     try {

--- a/src/infra/node-shell.test.ts
+++ b/src/infra/node-shell.test.ts
@@ -1,25 +1,28 @@
 // Covers platform shell argv construction.
 import { describe, expect, it } from "vitest";
 import { buildNodeShellCommand } from "./node-shell.js";
+import { resolveWindowsCmdExePath } from "./windows-system-paths.js";
 
 describe("buildNodeShellCommand", () => {
-  it("uses cmd.exe for win-prefixed platform labels", () => {
+  it("uses a %SystemRoot%-pinned cmd.exe for win-prefixed platform labels", () => {
+    const cmdExe = resolveWindowsCmdExePath();
+    expect(cmdExe).toMatch(/^[A-Za-z]:\\.*\\System32\\cmd\.exe$/);
     expect(buildNodeShellCommand("echo hi", "win32")).toEqual([
-      "cmd.exe",
+      cmdExe,
       "/d",
       "/s",
       "/c",
       "echo hi",
     ]);
     expect(buildNodeShellCommand("echo hi", "windows")).toEqual([
-      "cmd.exe",
+      cmdExe,
       "/d",
       "/s",
       "/c",
       "echo hi",
     ]);
     expect(buildNodeShellCommand("echo hi", " Windows 11 ")).toEqual([
-      "cmd.exe",
+      cmdExe,
       "/d",
       "/s",
       "/c",

--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -1,5 +1,6 @@
 // Builds platform shell argv for Node-driven command execution.
 import { normalizeLowercaseStringOrEmpty } from "@remoteclaw/normalization-core/string-coerce";
+import { resolveWindowsCmdExePath } from "./windows-system-paths.js";
 
 // Node shell command construction keeps platform shell flags centralized for
 // system.run and related command execution paths.
@@ -7,7 +8,7 @@ import { normalizeLowercaseStringOrEmpty } from "@remoteclaw/normalization-core/
 export function buildNodeShellCommand(command: string, platform?: string | null) {
   const normalized = normalizeLowercaseStringOrEmpty((platform ?? "").trim());
   if (normalized.startsWith("win")) {
-    return ["cmd.exe", "/d", "/s", "/c", command];
+    return [resolveWindowsCmdExePath(), "/d", "/s", "/c", command];
   }
   return ["/bin/sh", "-lc", command];
 }

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -15,6 +15,11 @@ import type {
   PortUsage,
   PortUsageStatus,
 } from "./ports-types.js";
+import {
+  resolveWindowsPowerShellPath,
+  resolveWindowsSystem32Path,
+  resolveWindowsWmicPath,
+} from "./windows-system-paths.js";
 
 type CommandResult = {
   stdout: string;
@@ -495,7 +500,13 @@ function parseNetstatConnections(output: string, port: number): PortConnection[]
 }
 
 async function resolveWindowsImageName(pid: number): Promise<string | undefined> {
-  const res = await runCommandSafe(["tasklist", "/FI", `PID eq ${pid}`, "/FO", "LIST"]);
+  const res = await runCommandSafe([
+    resolveWindowsSystem32Path("tasklist.exe"),
+    "/FI",
+    `PID eq ${pid}`,
+    "/FO",
+    "LIST",
+  ]);
   if (res.code !== 0) {
     return undefined;
   }
@@ -512,7 +523,7 @@ async function resolveWindowsImageName(pid: number): Promise<string | undefined>
 
 async function resolveWindowsCommandLine(pid: number): Promise<string | undefined> {
   const powershell = await runCommandSafe([
-    "powershell",
+    resolveWindowsPowerShellPath(),
     "-NoProfile",
     "-Command",
     `(Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" | Select-Object -ExpandProperty CommandLine)`,
@@ -525,7 +536,7 @@ async function resolveWindowsCommandLine(pid: number): Promise<string | undefine
   }
 
   const wmic = await runCommandSafe([
-    "wmic",
+    resolveWindowsWmicPath(),
     "process",
     "where",
     `ProcessId=${pid}`,
@@ -551,7 +562,12 @@ async function readWindowsListeners(
   port: number,
 ): Promise<{ listeners: PortListener[]; detail?: string; errors: string[] }> {
   const errors: string[] = [];
-  const res = await runCommandSafe(["netstat", "-ano", "-p", "tcp"]);
+  const res = await runCommandSafe([
+    resolveWindowsSystem32Path("netstat.exe"),
+    "-ano",
+    "-p",
+    "tcp",
+  ]);
   if (res.code !== 0) {
     if (res.error) {
       errors.push(res.error);
@@ -587,7 +603,12 @@ async function readWindowsEstablishedConnections(
   port: number,
 ): Promise<{ connections: PortConnection[]; detail?: string; errors: string[] }> {
   const errors: string[] = [];
-  const res = await runCommandSafe(["netstat", "-ano", "-p", "tcp"]);
+  const res = await runCommandSafe([
+    resolveWindowsSystem32Path("netstat.exe"),
+    "-ano",
+    "-p",
+    "tcp",
+  ]);
   if (res.code !== 0) {
     if (res.error) {
       errors.push(res.error);

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -1,5 +1,6 @@
 // Covers gateway port availability and diagnostics behavior.
 import net from "node:net";
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
@@ -17,6 +18,11 @@ let handlePortError: typeof import("./ports.js").handlePortError;
 let PortInUseError: typeof import("./ports.js").PortInUseError;
 
 const describeUnix = process.platform === "win32" ? describe.skip : describe;
+// argv[0] is now an absolute %SystemRoot% path (src/infra/windows-system-paths.ts);
+// these tests assert which binary ran, not where it lives.
+function windowsBinaryName(argv: string[]): string {
+  return path.win32.basename(argv[0] ?? "").toLowerCase();
+}
 
 function setPlatform(platform: NodeJS.Platform): void {
   mockProcessPlatform(platform);
@@ -419,8 +425,8 @@ describe("inspectPortUsage on Windows", () => {
   it("reports established gateway client connections from netstat", async () => {
     setPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
-      const [command] = argv;
-      if (command === "netstat") {
+      const command = windowsBinaryName(argv);
+      if (command === "netstat.exe") {
         return {
           stdout:
             "  TCP    127.0.0.1:50123    127.0.0.1:18789    ESTABLISHED    4242\r\n" +
@@ -429,10 +435,10 @@ describe("inspectPortUsage on Windows", () => {
           code: 0,
         };
       }
-      if (command === "tasklist") {
+      if (command === "tasklist.exe") {
         return { stdout: "Image Name: node.exe\r\n", stderr: "", code: 0 };
       }
-      if (command === "powershell") {
+      if (command === "powershell.exe") {
         return {
           stdout:
             '"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\remoteclaw\\dist\\index.js logs --follow\r\n',
@@ -457,18 +463,18 @@ describe("inspectPortUsage on Windows", () => {
   it("uses PowerShell process command lines to classify RemoteClaw listeners", async () => {
     setPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
-      const [command] = argv;
-      if (command === "netstat") {
+      const command = windowsBinaryName(argv);
+      if (command === "netstat.exe") {
         return {
           stdout: "  TCP    127.0.0.1:18789    0.0.0.0:0    LISTENING    4242\r\n",
           stderr: "",
           code: 0,
         };
       }
-      if (command === "tasklist") {
+      if (command === "tasklist.exe") {
         return { stdout: "Image Name: node.exe\r\n", stderr: "", code: 0 };
       }
-      if (command === "powershell") {
+      if (command === "powershell.exe") {
         return {
           stdout:
             '"C:\\Program Files\\nodejs\\node.exe" C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\remoteclaw\\dist\\index.js gateway run\r\n',
@@ -493,8 +499,8 @@ describe("inspectPortUsage on Windows", () => {
   it("does not match Windows listener ports by substring", async () => {
     setPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
-      const [command] = argv;
-      if (command === "netstat") {
+      const command = windowsBinaryName(argv);
+      if (command === "netstat.exe") {
         return {
           stdout:
             "  TCP    127.0.0.1:187890    0.0.0.0:0    LISTENING    9000\r\n" +
@@ -514,21 +520,21 @@ describe("inspectPortUsage on Windows", () => {
   it("falls back to wmic when PowerShell cannot read the command line", async () => {
     setPlatform("win32");
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
-      const [command] = argv;
-      if (command === "netstat") {
+      const command = windowsBinaryName(argv);
+      if (command === "netstat.exe") {
         return {
           stdout: "  TCP    127.0.0.1:18789    0.0.0.0:0    LISTENING    4242\r\n",
           stderr: "",
           code: 0,
         };
       }
-      if (command === "tasklist") {
+      if (command === "tasklist.exe") {
         return { stdout: "Image Name: node.exe\r\n", stderr: "", code: 0 };
       }
-      if (command === "powershell") {
+      if (command === "powershell.exe") {
         return { stdout: "", stderr: "access denied", code: 1 };
       }
-      if (command === "wmic") {
+      if (command === "wmic.exe") {
         return {
           stdout: "CommandLine=node.exe C:\\remoteclaw\\dist\\index.js gateway run\r\n",
           stderr: "",
@@ -541,7 +547,9 @@ describe("inspectPortUsage on Windows", () => {
     const result = await inspectPortUsage(18789);
 
     expect(result.listeners[0]?.commandLine).toContain("remoteclaw");
-    const commandNames = runCommandWithTimeoutMock.mock.calls.map(([argv]) => argv[0]);
-    expect(commandNames).toContain("wmic");
+    const commandNames = runCommandWithTimeoutMock.mock.calls.map(([argv]) =>
+      windowsBinaryName(argv as string[]),
+    );
+    expect(commandNames).toContain("wmic.exe");
   });
 });

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -1,6 +1,7 @@
 // Detects and decodes Windows console output encodings.
 import { spawnSync } from "node:child_process";
 import { normalizeLowercaseStringOrEmpty } from "@remoteclaw/normalization-core/string-coerce";
+import { resolveWindowsCmdExePath, resolveWindowsPowerShellPath } from "./windows-system-paths.js";
 
 const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
   65001: "utf-8",
@@ -49,7 +50,7 @@ export function resolveWindowsConsoleEncoding(): string | null {
     return cachedWindowsConsoleEncoding;
   }
   try {
-    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
+    const result = spawnSync(resolveWindowsCmdExePath(), ["/d", "/s", "/c", "chcp"], {
       windowsHide: true,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
@@ -74,7 +75,7 @@ export function resolveWindowsSystemEncoding(): string | null {
   }
   try {
     const result = spawnSync(
-      "powershell.exe",
+      resolveWindowsPowerShellPath(),
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "[Text.Encoding]::Default.CodePage"],
       {
         windowsHide: true,

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -4,6 +4,11 @@ import { normalizeLowercaseStringOrEmpty } from "@remoteclaw/normalization-core/
 import { normalizeStringEntries } from "@remoteclaw/normalization-core/string-normalization";
 import { parseCmdScriptCommandLine } from "../daemon/cmd-argv.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
+import {
+  resolveWindowsPowerShellPath,
+  resolveWindowsSystem32Path,
+  resolveWindowsWmicPath,
+} from "./windows-system-paths.js";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 
@@ -21,7 +26,7 @@ export type WindowsProcessArgsResult =
 
 function readListeningPidsViaPowerShell(port: number, timeoutMs: number): number[] | null {
   const ps = spawnSync(
-    "powershell",
+    resolveWindowsPowerShellPath(),
     [
       "-NoProfile",
       "-Command",
@@ -71,7 +76,7 @@ export function readWindowsListeningPidsResultSync(
   if (powershellPids != null) {
     return { ok: true, pids: powershellPids };
   }
-  const netstat = spawnSync("netstat", ["-ano", "-p", "tcp"], {
+  const netstat = spawnSync(resolveWindowsSystem32Path("netstat.exe"), ["-ano", "-p", "tcp"], {
     encoding: "utf8",
     timeout: timeoutMs,
     windowsHide: true,
@@ -115,7 +120,7 @@ export function readWindowsProcessArgsResultSync(
   timeoutMs = DEFAULT_TIMEOUT_MS,
 ): WindowsProcessArgsResult {
   const powershell = spawnSync(
-    "powershell",
+    resolveWindowsPowerShellPath(),
     [
       "-NoProfile",
       "-Command",
@@ -132,7 +137,7 @@ export function readWindowsProcessArgsResultSync(
     return { ok: true, args: command ? parseCmdScriptCommandLine(command) : null };
   }
   const wmic = spawnSync(
-    "wmic",
+    resolveWindowsWmicPath(),
     ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/value"],
     {
       encoding: "utf8",

--- a/src/infra/windows-system-paths.test.ts
+++ b/src/infra/windows-system-paths.test.ts
@@ -1,0 +1,118 @@
+// Covers %SystemRoot% resolution hardening for pinned Windows system binaries.
+import { describe, expect, it } from "vitest";
+import {
+  resolveWindowsCmdExePath,
+  resolveWindowsPowerShellPath,
+  resolveWindowsSystem32Path,
+  resolveWindowsSystemRoot,
+  resolveWindowsWmicPath,
+} from "./windows-system-paths.js";
+
+const DEFAULT_ROOT = "C:\\Windows";
+
+// Every test injects its own env object, so the suite is host-platform agnostic.
+function env(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values;
+}
+
+describe("resolveWindowsSystemRoot", () => {
+  it("accepts a well-formed SystemRoot", () => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: "D:\\WinNT" }))).toBe("D:\\WinNT");
+  });
+
+  it("reads SystemRoot case-insensitively", () => {
+    expect(resolveWindowsSystemRoot(env({ SYSTEMROOT: "D:\\WinNT" }))).toBe("D:\\WinNT");
+    expect(resolveWindowsSystemRoot(env({ systemroot: "D:\\WinNT" }))).toBe("D:\\WinNT");
+  });
+
+  it("falls back to WINDIR, then to the default root", () => {
+    expect(resolveWindowsSystemRoot(env({ WINDIR: "E:\\Windows" }))).toBe("E:\\Windows");
+    expect(resolveWindowsSystemRoot(env({}))).toBe(DEFAULT_ROOT);
+  });
+
+  it("strips trailing separators", () => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: "D:\\WinNT\\\\" }))).toBe("D:\\WinNT");
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: "D:\\WinNT/" }))).toBe("D:\\WinNT");
+  });
+
+  // Each rejection branch must fall through to the safe default rather than
+  // letting an attacker-shaped value reach a spawn.
+  it.each([
+    ["NUL byte", "C:\\Win\0dows"],
+    ["carriage return", "C:\\Windows\r"],
+    ["line feed", "C:\\Windows\n"],
+    ["semicolon (PATH separator injection)", "C:\\Windows;C:\\Evil"],
+    ["relative path", "Windows"],
+    ["dot-relative path", ".\\Windows"],
+    ["UNC path", "\\\\attacker\\share\\Windows"],
+    ["bare drive root with no subdirectory", "C:\\"],
+    ["POSIX absolute path (no drive letter)", "/usr/share/windows"],
+    ["empty string", ""],
+    ["whitespace only", "   "],
+  ])("rejects %s and falls back to the default root", (_label, raw) => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(DEFAULT_ROOT);
+  });
+
+  it("falls through a rejected SystemRoot to a valid WINDIR", () => {
+    expect(
+      resolveWindowsSystemRoot(env({ SystemRoot: "\\\\evil\\share", WINDIR: "D:\\WinNT" })),
+    ).toBe("D:\\WinNT");
+  });
+});
+
+describe("resolveWindowsSystem32Path", () => {
+  it("joins onto System32 with win32 separators", () => {
+    expect(resolveWindowsSystem32Path("netstat.exe", env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\netstat.exe",
+    );
+    expect(resolveWindowsSystem32Path("taskkill.exe", env({}))).toBe(
+      "C:\\Windows\\System32\\taskkill.exe",
+    );
+  });
+
+  it.each([
+    ["path traversal", "..\\..\\evil.exe"],
+    ["forward-slash traversal", "../evil.exe"],
+    ["absolute path", "C:\\evil\\payload.exe"],
+    ["nested directory", "wbem\\wmic.exe"],
+    ["missing .exe suffix", "netstat"],
+    ["wrong suffix", "payload.com"],
+    ["space in name", "my program.exe"],
+    ["empty name", ""],
+  ])("rejects %s", (_label, name) => {
+    expect(() => resolveWindowsSystem32Path(name, env({}))).toThrow(
+      /Invalid Windows System32 executable name/,
+    );
+  });
+});
+
+describe("named binary resolvers", () => {
+  it("pins cmd.exe into System32", () => {
+    expect(resolveWindowsCmdExePath(env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\cmd.exe",
+    );
+  });
+
+  // PowerShell and WMIC are NOT in System32 directly — a plain System32 join
+  // would produce a path that does not exist on any Windows install.
+  it("pins powershell.exe under WindowsPowerShell\\v1.0", () => {
+    expect(resolveWindowsPowerShellPath(env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+  });
+
+  it("pins WMIC.exe under the wbem subdirectory", () => {
+    expect(resolveWindowsWmicPath(env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\wbem\\WMIC.exe",
+    );
+  });
+
+  it("keeps a hostile SystemRoot out of every resolved binary path", () => {
+    const hostile = env({ SystemRoot: "\\\\attacker\\share" });
+    expect(resolveWindowsCmdExePath(hostile)).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(resolveWindowsPowerShellPath(hostile)).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(resolveWindowsWmicPath(hostile)).toBe("C:\\Windows\\System32\\wbem\\WMIC.exe");
+  });
+});

--- a/src/infra/windows-system-paths.ts
+++ b/src/infra/windows-system-paths.ts
@@ -1,0 +1,100 @@
+// Resolves Windows system binaries to absolute %SystemRoot% paths.
+//
+// Spawning a Windows system binary by bare name ("netstat", "cmd.exe", …) lets
+// %PATH% — and, under some configurations, the current working directory —
+// decide which executable actually runs. Pinning to %SystemRoot% removes that
+// search entirely (CWE-426, Untrusted Search Path).
+//
+// This is a deliberate twin of `scripts/windows-cmd-helpers.mjs`, which carries
+// the same resolution and hardening semantics for the build-tooling side. The
+// two cannot share code: the scripts copy is `.mjs`, loaded by plain `node`
+// (so it cannot import TypeScript), it lives outside the tsconfig `include`,
+// and `scripts/lib/docker-e2e-package.sh` bind-mounts it into a container as a
+// single standalone file. Keep the two in sync by hand when either changes.
+import path from "node:path";
+
+const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
+const WINDOWS_SYSTEM32_EXE_NAME_RE = /^[A-Za-z0-9_.-]+\.exe$/u;
+
+function getEnvValueCaseInsensitive(
+  env: NodeJS.ProcessEnv,
+  expectedKey: string,
+): string | undefined {
+  const direct = env[expectedKey];
+  if (direct !== undefined) {
+    return direct;
+  }
+  // Windows env keys are case-insensitive; a caller-supplied object may not be.
+  const expected = expectedKey.toUpperCase();
+  const actualKey = Object.keys(env).find((key) => key.toUpperCase() === expected);
+  return actualKey ? env[actualKey] : undefined;
+}
+
+function normalizeWindowsSystemRoot(raw: string | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (
+    !trimmed ||
+    trimmed.includes("\0") ||
+    trimmed.includes("\r") ||
+    trimmed.includes("\n") ||
+    trimmed.includes(";")
+  ) {
+    return null;
+  }
+  const normalized = path.win32.normalize(trimmed);
+  // Reject relative roots and UNC paths — a remote share must never win here.
+  if (!path.win32.isAbsolute(normalized) || normalized.startsWith("\\\\")) {
+    return null;
+  }
+  const parsed = path.win32.parse(normalized);
+  if (!/^[A-Za-z]:\\$/.test(parsed.root) || normalized.length <= parsed.root.length) {
+    return null;
+  }
+  return normalized.replace(/[\\/]+$/, "");
+}
+
+/** Resolve the Windows install root, falling back to `C:\Windows` when unusable. */
+export function resolveWindowsSystemRoot(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    normalizeWindowsSystemRoot(getEnvValueCaseInsensitive(env, "SystemRoot")) ??
+    normalizeWindowsSystemRoot(getEnvValueCaseInsensitive(env, "WINDIR")) ??
+    DEFAULT_WINDOWS_SYSTEM_ROOT
+  );
+}
+
+/** Resolve an absolute `%SystemRoot%\System32\<name>.exe` path. */
+export function resolveWindowsSystem32Path(
+  executableName: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (
+    path.win32.basename(executableName) !== executableName ||
+    !WINDOWS_SYSTEM32_EXE_NAME_RE.test(executableName)
+  ) {
+    throw new Error(`Invalid Windows System32 executable name: ${executableName}`);
+  }
+  // Always win32 joins: the result is a Windows path even when this code runs
+  // on a POSIX host (tests, cross-platform tooling).
+  return path.win32.join(resolveWindowsSystemRoot(env), "System32", executableName);
+}
+
+/** Resolve the absolute path to `cmd.exe`. */
+export function resolveWindowsCmdExePath(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveWindowsSystem32Path("cmd.exe", env);
+}
+
+/** Resolve the absolute path to Windows PowerShell (not in System32 directly). */
+export function resolveWindowsPowerShellPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.win32.join(
+    resolveWindowsSystemRoot(env),
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+/** Resolve the absolute path to `wmic.exe`, which lives under System32\wbem. */
+export function resolveWindowsWmicPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.win32.join(resolveWindowsSystemRoot(env), "System32", "wbem", "WMIC.exe");
+}

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureFullEnv } from "../test-utils/env.js";
+import { resolveWindowsCmdExePath } from "./windows-system-paths.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const resolvePreferredRemoteClawTmpDirMock = vi.hoisted(() => vi.fn(() => os.tmpdir()));
@@ -106,7 +107,7 @@ describe("relaunchGatewayScheduledTask", () => {
     expect(result.tried).toContain('schtasks /Run /TN "RemoteClaw Gateway (work)"');
     expect(result.tried).toContain(`cmd.exe /d /s /c ${seenCommandArg}`);
     const spawnCall = requireFirstMockCall(spawnMock, "restart helper spawn");
-    expect(spawnCall[0]).toBe("cmd.exe");
+    expect(spawnCall[0]).toBe(resolveWindowsCmdExePath());
     expect(spawnCall[1]).toStrictEqual(["/d", "/s", "/c", seenCommandArg]);
     expect(spawnCall[2]).toStrictEqual({
       detached: true,
@@ -200,7 +201,7 @@ describe("relaunchGatewayScheduledTask", () => {
     if (typeof commandArg !== "string") {
       throw new Error("expected quoted restart helper path");
     }
-    expect(spawnCall[0]).toBe("cmd.exe");
+    expect(spawnCall[0]).toBe(resolveWindowsCmdExePath());
     expect(commandArgs).toStrictEqual(["/d", "/s", "/c", commandArg]);
     expect(commandArg.startsWith('"')).toBe(true);
     expect(commandArg.endsWith('"')).toBe(true);

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -10,6 +10,7 @@ import { resolveTaskScriptPath } from "../daemon/schtasks.js";
 import { formatErrorMessage } from "./errors.js";
 import type { RestartAttempt } from "./restart.types.js";
 import { resolvePreferredRemoteClawTmpDir } from "./tmp-remoteclaw-dir.js";
+import { resolveWindowsCmdExePath } from "./windows-system-paths.js";
 
 const TASK_RESTART_RETRY_LIMIT = 12;
 const TASK_RESTART_RETRY_DELAY_SEC = 1;
@@ -91,7 +92,7 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
       })}\r\n`,
       "utf8",
     );
-    const child = spawn("cmd.exe", ["/d", "/s", "/c", quotedScriptPath], {
+    const child = spawn(resolveWindowsCmdExePath(), ["/d", "/s", "/c", quotedScriptPath], {
       detached: true,
       stdio: "ignore",
       windowsHide: true,

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import type { GatewayClient } from "../gateway/client.js";
 import { sanitizeSystemRunEnvOverrides } from "../infra/host-env-security.js";
+import { resolveWindowsCmdExePath } from "../infra/windows-system-paths.js";
 import type {
   ExecEventPayload,
   ExecFinishedEventParams,
@@ -21,7 +22,8 @@ function resolveSystemRunCommand(opts: {
     return { ok: true, argv, shellCommand: null, cmdText: argv.join(" ") };
   }
   if (typeof raw === "string" && raw.trim()) {
-    const shell = process.platform === "win32" ? ["cmd.exe", "/c", raw] : ["sh", "-lc", raw];
+    const shell =
+      process.platform === "win32" ? [resolveWindowsCmdExePath(), "/c", raw] : ["sh", "-lc", raw];
     return { ok: true, argv: shell, shellCommand: raw, cmdText: raw };
   }
   return { ok: false, message: "command required" };

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -9,6 +9,7 @@ import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
+import { resolveWindowsCmdExePath } from "../infra/windows-system-paths.js";
 import { logDebug, logError } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
@@ -107,7 +108,10 @@ function resolveChildProcessInvocation(params: {
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
 
   return {
-    command: useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
+    // ComSpec stays the primary (it is the documented Windows override), but the
+    // fallback is pinned rather than a bare name so an unset ComSpec cannot fall
+    // through to a %PATH% lookup (CWE-426).
+    command: useCmdWrapper ? (process.env.ComSpec ?? resolveWindowsCmdExePath()) : resolvedCommand,
     args: useCmdWrapper
       ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
       : finalArgv.slice(1),

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveWindowsCmdExePath } from "../infra/windows-system-paths.js";
 
 const { spawnMock, spawnSyncMock, execFileMock, execFilePromisifyMock } = vi.hoisted(() => {
   const execFilePromisifyMockLocal = vi.fn();
@@ -171,7 +172,7 @@ describe("windows command wrapper behavior", () => {
 
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = process.env.ComSpec ?? resolveWindowsCmdExePath();
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -189,7 +190,7 @@ describe("windows command wrapper behavior", () => {
 
   it("wraps corepack.cmd via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = process.env.ComSpec ?? resolveWindowsCmdExePath();
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -251,7 +252,7 @@ describe("windows command wrapper behavior", () => {
   it("falls back to npm.cmd when npm-cli.js is unavailable", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = process.env.ComSpec ?? resolveWindowsCmdExePath();
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -302,7 +303,7 @@ describe("windows command wrapper behavior", () => {
 
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = process.env.ComSpec ?? resolveWindowsCmdExePath();
 
     execFileMock.mockImplementation(
       (

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -1,5 +1,6 @@
 // Kill tree tests cover process tree termination and platform-specific fallbacks.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
 const { spawnMock } = vi.hoisted(() => ({
@@ -21,7 +22,8 @@ let signalProcessTree: typeof import("./kill-tree.js").signalProcessTree;
 
 function expectTaskkillCall(index: number, args: string[]) {
   expect(spawnMock.mock.calls[index]).toStrictEqual([
-    "taskkill",
+    // Pinned to %SystemRoot%\System32 so %PATH% cannot hijack it (CWE-426).
+    resolveWindowsSystem32Path("taskkill.exe"),
     args,
     {
       detached: true,

--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 
 const DEFAULT_GRACE_MS = 3000;
 const MAX_GRACE_MS = 60_000;
@@ -104,7 +105,7 @@ function signalProcessTreeUnix(
 
 function runTaskkill(args: string[]): void {
   try {
-    spawn("taskkill", args, {
+    spawn(resolveWindowsSystem32Path("taskkill.exe"), args, {
       stdio: "ignore",
       detached: true,
       windowsHide: true,


### PR DESCRIPTION
Closes #3077.

On Windows, `spawn("netstat", …)` resolves via `%PATH%` — and under some
configurations the current working directory. A planted `netstat.exe` /
`cmd.exe` / `powershell.exe` / `taskkill.exe` / `wmic.exe` executes in the
Gateway's process context. CWE-426, Untrusted Search Path.

## The resolver

New `src/infra/windows-system-paths.ts` carries the same resolution and
hardening semantics as the fork's existing `scripts/windows-cmd-helpers.mjs`:
rejects NUL/CR/LF/`;`, requires a `path.win32` absolute path, rejects UNC,
requires a drive-letter root, strips trailing separators, reads `SystemRoot`
case-insensitively with a `WINDIR` fallback and a `C:\Windows` default.
No check was softened.

**Duplicate, not re-export.** The scripts helper is `.mjs` loaded by plain
`node` (so it cannot import TypeScript), `scripts/` is outside the tsconfig
`include`, and `scripts/lib/docker-e2e-package.sh:258` bind-mounts the file
into a container as a single standalone path — any `../src/` import would be
unresolvable there. The module header documents the twin relationship.

Upstream fixed this class via `getWindowsSystem32ExePath()` in
`src/infra/windows-install-roots.ts`, which is `EXCLUDE-GUT` tombstoned in this
fork and deliberately **not** revived (`git grep windows-install-roots` → no
matches).

`powershell.exe` and `wmic.exe` get dedicated resolvers: they live under
`System32\WindowsPowerShell\v1.0` and `System32\wbem`, so a plain System32
join would produce paths that exist on no Windows install.

## Sites: 24, not 10

Re-deriving the enumeration found 14 sites beyond the 10 in the issue's
corrected table. All 10 confirmed; none removed.

| Cluster | Verdict |
|---|---|
| `ports-inspect.ts` ×5 | **Exposed.** `runCommandSafe` → `runCommandWithTimeout` → `resolveChildProcessInvocation` → `resolveWindowsCommandShim`, which only appends `.cmd` for corepack/pnpm/yarn. `shouldSpawnWithShell` always returns `false`, so argv[0] reaches `spawn` unchanged. (Line 530 `"where"` is a `wmic` argument — excluded.) |
| `ComSpec`-guarded ×5 | **Only 2 actually are.** `restart-helper.ts:396`, `node-shell.ts:10`, `invoke-system-run.ts:24` carry a bare `cmd.exe` with no ComSpec read → full sites. `launchd.ts:108` and `exec.ts:110` do read ComSpec; those keep it as the documented override and pin only the bare-name fallback. |
| `date-time.ts:168` | **Live, not dead.** `MODULE_ATTESTATIONS` marks `resolveUserTimeFormat: "live"`; reached from `agents/current-time.ts` and `agents/tools/session-status-tool.ts` into cron / auto-reply / heartbeat. |

Plus four the enumeration grep pattern could not reach: bare `where` in
`onboard-helpers.ts:343` and `program-args.ts:168`, `clip.exe` + `powershell`
in the clipboard chain, and **bare `schtasks` in `schtasks-exec.ts:11`** — the
single funnel for every Task Scheduler call in the daemon install/restart path.

Also consolidates the inline `path.join` at `schtasks.ts:562` onto the resolver.

## Behaviour

Non-Windows is unchanged. Every pinned site sits inside an existing platform
guard (verified per site, not assumed); the clipboard chain pins only when
`process.platform === "win32"` so WSL interop keeps its PATH lookup.

## Tests

`windows-system-paths.test.ts` — 29 tests, env injected so nothing depends on
running on Windows. Two fault injections confirmed the guards are load-bearing:
removing the `;` rejection failed the semicolon test; removing the
drive-letter-root check failed the POSIX-absolute test. UNC survived both
independently — it is covered by the UNC guard *and* the drive-root check.

`pnpm check` (format + tsgo + oxlint + 6 lint gates), unit lane
(1050 files / 10235 tests), gateway lane (185 files / 1973 tests), and the
standalone fork-integrity gates (rebrand, zombie-import, stub-debt,
throwing-stub-callers, attestations, obsolescence, raw-channel-fetch,
policy-doctor) all pass locally.

⚠️ Windows-only code that CI does not exercise on a Windows runner — wants a
manual smoke on Windows before release.

Noticed but **not** changed: `src/middleware/runtime-factory.ts:29` calls
`execFileSync("which", …)` unguarded, which cannot work on Windows at all
(different bug, different threat model); `src/infra/node-shell.ts`'s
`buildNodeShellCommand` has no production callers (pinned anyway so a future
caller does not inherit the bug); `scripts/check-stub-debt.mjs` reports the
fork-boundary-mock baseline could tighten from 139 to 129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)