### PR TITLE
test(config): pin Slack relay mode/validation coupling (#3078)

### DIFF
--- a/src/config/slack-relay-mode-coupling.test.ts
+++ b/src/config/slack-relay-mode-coupling.test.ts
@@ -1,0 +1,139 @@
+// Coupling tripwire for remoteclaw#3078 — Slack relay transport vs. its config validation.
+//
+// The v2026.6.11 sync landed the Slack relay TRANSPORT
+// (extensions/slack/src/monitor/relay-source.ts) but not the relay CONFIG SCHEMA
+// upstream uses to validate it (SlackRelaySchema + requireRelayConfig).
+//
+// Today that split is fail-closed and correct: the Slack `mode` enum excludes
+// "relay" and the schema is .strict(), so the transport is unreachable from
+// config and nothing needs fixing. This file exists to keep it that way.
+//
+// THE INVARIANT PINNED HERE:
+//
+//   Either `mode` excludes "relay", OR the schema defines relay validation
+//   (SlackRelaySchema + requireRelayConfig enforced on BOTH the top-level and
+//   the per-account path). Never one without the other.
+//
+// Why the second half matters: relay-source.ts feeds config straight into
+// `new URL(config.url)` and an `Authorization: Bearer ${authToken}` header with
+// no local validation. Upstream's requireRelayConfig is what rejects a blank
+// relay.url / missing relay.authToken, and its SlackRelaySchema is what marks
+// authToken as a sensitive SecretInputSchema so secret redaction covers it.
+// Widening the enum without porting those turns config into an unvalidated
+// outbound-credential path.
+//
+// IF YOU ARE HERE BECAUSE THIS FILE WENT RED: you most likely widened the Slack
+// `mode` enum. That is allowed — but only together with the validation. Port
+// SlackRelaySchema and requireRelayConfig from upstream, enforce requireRelayConfig
+// at BOTH the top-level and per-account paths, then update the expectations below
+// to the new intended shape. Please do not simply delete this file: the coupling
+// assertion at the bottom is the only thing standing between a widened enum and
+// an unvalidated credential-bearing connection path.
+//
+// Ref: https://github.com/remoteclaw/remoteclaw/issues/3078
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const SCHEMA_RELATIVE_PATH = "src/config/zod-schema.providers-core.ts";
+
+const WHY = [
+  "remoteclaw#3078: the Slack relay transport (extensions/slack/src/monitor/relay-source.ts)",
+  "is present in this fork, but the relay config validation (SlackRelaySchema +",
+  "requireRelayConfig) is not. The narrow `mode` enum is what keeps the transport",
+  "unreachable. Widening it without porting the validation exposes an unvalidated",
+  "relay.url / relay.authToken path. See the header comment in this file.",
+].join(" ");
+
+function issuesFor(raw: unknown) {
+  const res = validateConfigObject(raw);
+  return res.ok ? undefined : res.issues;
+}
+
+describe("Slack relay mode/validation coupling (remoteclaw#3078)", () => {
+  it("accepts mode=socket — control for the rejections below", () => {
+    // Without this control, the two rejection tests could pass for an unrelated
+    // reason (some other required Slack field) and silently stop guarding relay.
+    const res = validateConfigObject({ channels: { slack: { mode: "socket" } } });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects channels.slack.mode="relay" (top-level enum)', () => {
+    const issues = issuesFor({ channels: { slack: { mode: "relay" } } });
+    expect(issues, WHY).toBeDefined();
+
+    const modeIssue = issues?.find((issue) => issue.path === "channels.slack.mode");
+    expect(modeIssue, WHY).toBeDefined();
+    expect(modeIssue?.allowedValues, WHY).toBeDefined();
+    expect(modeIssue?.allowedValues, WHY).not.toContain("relay");
+  });
+
+  it('rejects channels.slack.accounts.*.mode="relay" (per-account enum)', () => {
+    const issues = issuesFor({ channels: { slack: { accounts: { ops: { mode: "relay" } } } } });
+    expect(issues, WHY).toBeDefined();
+
+    const modeIssue = issues?.find((issue) => issue.path === "channels.slack.accounts.ops.mode");
+    expect(modeIssue, WHY).toBeDefined();
+    expect(modeIssue?.allowedValues, WHY).toBeDefined();
+    expect(modeIssue?.allowedValues, WHY).not.toContain("relay");
+  });
+
+  it("rejects an unknown channels.slack.relay config block (strict schema)", () => {
+    // The second independent gate documented in #3078: even with a widened enum,
+    // .strict() rejects the `relay` object the transport would read.
+    const issues = issuesFor({
+      channels: {
+        slack: { relay: { url: "wss://relay.example", authToken: "t", gatewayId: "g" } },
+      },
+    });
+    expect(issues, WHY).toBeDefined();
+    expect(
+      issues?.some((issue) => issue.message.includes("relay")),
+      WHY,
+    ).toBe(true);
+  });
+
+  it("never lets a relay-mode config through without relay validation", () => {
+    // The tripwire proper. Unlike the cases above, this assertion stays correct
+    // across a legitimate future widening: it fails ONLY for the dangerous
+    // combination (relay mode accepted, relay validation absent).
+    const relayModeAccepted = validateConfigObject({
+      channels: { slack: { mode: "relay" } },
+    }).ok;
+
+    const schemaSource = fs.readFileSync(path.join(repoRoot, SCHEMA_RELATIVE_PATH), "utf8");
+    const definesRelaySchema = /\bSlackRelaySchema\b/.test(schemaSource);
+    // Call sites only — the lookbehind drops the `function requireRelayConfig(`
+    // declaration so this counts enforcement, not definition. Upstream enforces
+    // it twice: once top-level, once per-account.
+    const relayEnforcementCallSites = (
+      schemaSource.match(/(?<!\bfunction\s)\brequireRelayConfig\s*\(/g) ?? []
+    ).length;
+
+    const relayValidationPresent = definesRelaySchema && relayEnforcementCallSites >= 2;
+    const invariantHolds = !relayModeAccepted || relayValidationPresent;
+
+    expect(
+      invariantHolds,
+      [
+        `Slack relay coupling broken in ${SCHEMA_RELATIVE_PATH}.`,
+        `relayModeAccepted=${relayModeAccepted}`,
+        `definesSlackRelaySchema=${definesRelaySchema}`,
+        `requireRelayConfigCallSites=${relayEnforcementCallSites} (need >= 2)`,
+        "",
+        "A relay-mode Slack config now validates, but the schema does not validate",
+        "the relay block itself. relay.url reaches new URL() and relay.authToken",
+        "reaches an Authorization: Bearer header unchecked, and authToken is not",
+        "registered as sensitive so secret redaction does not cover it.",
+        "",
+        "Fix by porting SlackRelaySchema + requireRelayConfig from upstream and",
+        "enforcing requireRelayConfig on both the top-level and per-account paths.",
+        "",
+        WHY,
+      ].join("\n"),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #3078 by making the Slack relay config/code coupling explicit and enforced.

## Approach: tripwire, not adoption

#3078 offered two options — port upstream's `SlackRelaySchema` + `requireRelayConfig` (A), or delete the dormant transport (B). This PR takes neither, deliberately:

- **Not A.** This fork is subtractive. Relay is not a supported transport here, so importing an unused validator adds exactly the dormant surface the fork's posture exists to avoid.
- **Not B.** Removing the transport is a separate gutting decision for the maintainer (see reachability evidence below). Out of scope here.

Instead this encodes the invariant so the two halves cannot drift apart silently:

> Either `mode` excludes `"relay"`, **or** the schema defines relay validation (`SlackRelaySchema` + `requireRelayConfig` enforced on both the top-level and per-account paths). Never one without the other.

**No production code changes.** `src/config/zod-schema.providers-core.ts` is byte-identical to base.

## What the test does

`src/config/slack-relay-mode-coupling.test.ts` (new, 139 lines), sitting alongside `slack-http-config.test.ts` and `slack-token-validation.test.ts`.

Four assertions pin today's fail-closed shape:

1. `mode: "socket"` is **accepted** — a control, so the rejections below cannot pass vacuously for some unrelated missing-field reason.
2. `channels.slack.mode: "relay"` is rejected, asserted via the issue's machine-readable `allowedValues` not containing `"relay"` (not a message regex).
3. `channels.slack.accounts.*.mode: "relay"` is rejected the same way — both enum sites are pinned independently.
4. An unknown `channels.slack.relay` block is rejected by `.strict()` — the second independent gate #3078 documents.

The fifth is the tripwire proper: it derives `relayModeAccepted` from a real parse and `relayValidationPresent` from the schema source, then asserts the implication. Unlike 1–4 it stays correct across a *legitimate* future widening, failing only for the dangerous combination.

The header comment and every assertion message explain the coupling and point at #3078, so a maintainer hitting red understands the constraint rather than seeing a broken expectation. It explicitly tells them porting the validation is allowed, and asks them not to just delete the file.

## Proof the tripwire bites

Widening **both** enums to `["socket", "http", "relay"]` and nothing else — the exact half-sync this guards against — fails 3 of 5:

```
 FAIL  ... > never lets a relay-mode config through without relay validation
AssertionError: Slack relay coupling broken in src/config/zod-schema.providers-core.ts.
relayModeAccepted=true
definesSlackRelaySchema=false
requireRelayConfigCallSites=0 (need >= 2)
```

Reverted → 5/5 green.

Crucially, a **second** injection — the same enum widening *plus* a real `SlackRelaySchema` and two `requireRelayConfig` call sites — leaves the coupling assertion **green** (only the shape-pinning tests 2–4 fail, which is by design: the porter updates them). So the assertion discriminates the dangerous half-port from a legitimate one rather than firing on any change to the enum. Both injections were fully reverted; the schema file hash matches base.

## Reachability of the relay transport (reported, not changed)

The transport is **provably dead** in this fork — three independent gates, one more than #3078 identified:

1. **No production importer.** `grep -rn "RelaySource\|relay-source"` across `src/` and `extensions/` returns only definitions in `relay-source.ts` and usage in `relay-source.test.ts`. Nothing else imports `monitorSlackRelaySource`.
2. **No dispatch branch.** `provider.ts:204` computes `slackMode`, then compares it only against `"http"` and `"socket"` (lines 212, 214, 219, 263, 271, 285, 310, 387, 498, 505). There is no `slackMode === "relay"` branch anywhere in the repo.
3. **Config rejects it** — the enum and `.strict()`, now pinned by this PR.

So widening the enum alone would *not* activate relay; a dispatch branch would also have to land. That refines #3078's risk model but does not weaken the case for the tripwire — a sync bringing the enum would plausibly bring the dispatch with it.

Only 3 of the 6 files listed in #3078 are genuinely relay-transport. `provider-support.ts` is a **substring false positive** (`relayAbort` is a local abort-listener variable, unrelated to relay). `message-handler.ts:20` and `message-handler/types.ts:13` carry an optional `relayIdentity` field written only by `relay-source.ts` — dead in practice, but they are not relay-transport files. A gutting decision would cover `relay-source.ts`, `relay-source.test.ts`, and the `"relay"` arm of the `mode` union in `monitor/types.ts:9`.

## Also noticed, not changed

- `src/config/zod-schema.secret-input-validation.ts:73` — `resolveMode` already tolerates `mode === "relay"`, a *third* half-landed relay-aware fragment in the config layer. Inert today: the enum rejects `mode: "relay"` before this tolerance can matter, and a `"relay"` baseMode would in any case just skip the http-signing-secret check.
- Same file, line 93 — the per-account mode resolution inlines `account.mode === "http" || account.mode === "socket"` and omits `"relay"`, so it is asymmetric with `resolveMode` above it. Harmless now; worth knowing if relay is ever enabled.
- `extensions/slack/src/monitor/types.ts:9` types `mode` as `"socket" | "http" | "relay"` — the type union is already wider than the runtime schema.

## Verification

All run on this branch; outputs quoted in full in the task report.

- Invariant test: **5 passed** (unmodified tree)
- Deliberately-widened run: **3 failed | 2 passed**, then **5 passed** after revert
- `git diff src/config/zod-schema.providers-core.ts`: **empty**; SHA-256 matches pre-injection baseline
- `./node_modules/.bin/tsgo --noEmit`: exit 0, zero diagnostics
- `oxlint --type-aware` on the new file: `Found 0 warnings and 0 errors.`
- `oxfmt --check`: `All matched files use the correct format.`
- Full `src/config` suite: **134 files / 1055 tests passed**, 12 skipped, 0 failed
- Confirmed the new file is enumerated by `vitest.unit.config.ts` (the required `test` CI job), so it actually gates merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
