### PR TITLE
security(windows): reject SystemRoot '..' traversal in both resolver twins (#3091)

### DIFF
--- a/scripts/windows-cmd-helpers.mjs
+++ b/scripts/windows-cmd-helpers.mjs
@@ -1,4 +1,8 @@
 // Windows cmd.exe quoting helpers for npm/pnpm command shims.
+//
+// The %SystemRoot% resolution below is a hand-synced twin of
+// `src/infra/windows-system-paths.ts`, which carries the rationale for the
+// hardening and for why the two cannot share code. Change one, change the other.
 import path from "node:path";
 
 const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>%\r\n]/;
@@ -14,6 +18,12 @@ function getEnvValueCaseInsensitive(env, expectedKey) {
   return actualKey ? env[actualKey] : undefined;
 }
 
+// Segment-exact, not a substring test: dots are legal inside a Windows directory
+// name (`C:\Win..dows`).
+function hasParentTraversalSegment(rawPath) {
+  return rawPath.split(/[\\/]/u).includes("..");
+}
+
 function normalizeWindowsSystemRoot(raw) {
   const trimmed = raw?.trim();
   if (
@@ -21,10 +31,13 @@ function normalizeWindowsSystemRoot(raw) {
     trimmed.includes("\0") ||
     trimmed.includes("\r") ||
     trimmed.includes("\n") ||
-    trimmed.includes(";")
+    trimmed.includes(";") ||
+    hasParentTraversalSegment(trimmed)
   ) {
     return null;
   }
+  // `normalize` collapses `..` — that is why the traversal check runs above it,
+  // against the raw value.
   const normalized = path.win32.normalize(trimmed);
   if (!path.win32.isAbsolute(normalized) || normalized.startsWith("\\\\")) {
     return null;

--- a/src/infra/windows-system-paths.test.ts
+++ b/src/infra/windows-system-paths.test.ts
@@ -49,13 +49,54 @@ describe("resolveWindowsSystemRoot", () => {
     ["POSIX absolute path (no drive letter)", "/usr/share/windows"],
     ["empty string", ""],
     ["whitespace only", "   "],
+    // `path.win32.normalize` collapses `..` BEFORE the shape checks run, so a
+    // traversal emerges as a clean absolute drive-rooted non-UNC path that
+    // satisfies every other guard. These must be rejected on the raw value.
+    ["parent-segment traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
+    ["forward-slash traversal", "C:/Windows/../Users/pub/evil"],
+    ["mixed-separator traversal", "C:\\Windows/../Users\\pub\\evil"],
+    ["traversal landing beside the drive root", "C:\\Windows\\..\\evil"],
+    ["traversal clamped at the drive root", "C:\\Windows\\..\\..\\..\\..\\Users"],
+    ["traversal with a trailing separator", "C:\\Windows\\..\\Users\\pub\\evil\\"],
+    // Not raw-value cases: these two collapse to shapes the pre-existing checks
+    // already reject (bare drive root, relative path). They pin that overlap, and
+    // would still pass with the raw-value guard removed.
+    ["traversal collapsing to the bare drive root", "C:\\Windows\\.."],
+    ["leading traversal, which stays relative", "..\\Windows"],
   ])("rejects %s and falls back to the default root", (_label, raw) => {
     expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(DEFAULT_ROOT);
+  });
+
+  // The traversal guard matches whole `..` segments, not the substring — dots are
+  // legal inside a Windows directory name. The `...` row documents segment-exactness
+  // rather than a real-world root: `path.win32.normalize` treats `...` as a literal
+  // segment, though Windows itself strips trailing dots so such a directory cannot
+  // normally be created.
+  it.each([
+    ["a directory name containing dots", "C:\\Win..dows", "C:\\Win..dows"],
+    ["a trailing-dots directory name", "D:\\WinNT..", "D:\\WinNT.."],
+    ["a literal three-dot segment", "C:\\Windows\\...", "C:\\Windows\\..."],
+  ])("accepts %s", (_label, raw, expected) => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(expected);
   });
 
   it("falls through a rejected SystemRoot to a valid WINDIR", () => {
     expect(
       resolveWindowsSystemRoot(env({ SystemRoot: "\\\\evil\\share", WINDIR: "D:\\WinNT" })),
+    ).toBe("D:\\WinNT");
+  });
+
+  it("rejects a traversal in WINDIR too, not just SystemRoot", () => {
+    expect(resolveWindowsSystemRoot(env({ WINDIR: "C:\\Windows\\..\\Users\\pub\\evil" }))).toBe(
+      DEFAULT_ROOT,
+    );
+  });
+
+  it("falls through a traversal SystemRoot to a valid WINDIR", () => {
+    expect(
+      resolveWindowsSystemRoot(
+        env({ SystemRoot: "C:\\Windows\\..\\Users\\pub\\evil", WINDIR: "D:\\WinNT" }),
+      ),
     ).toBe("D:\\WinNT");
   });
 });
@@ -107,8 +148,16 @@ describe("named binary resolvers", () => {
     );
   });
 
-  it("keeps a hostile SystemRoot out of every resolved binary path", () => {
-    const hostile = env({ SystemRoot: "\\\\attacker\\share" });
+  // Every pinned binary is joined onto the one resolved root, so a single bad
+  // root redirects all of them at once.
+  it.each([
+    ["UNC", "\\\\attacker\\share"],
+    ["traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
+  ])("keeps a hostile %s SystemRoot out of every resolved binary path", (_label, raw) => {
+    const hostile = env({ SystemRoot: raw });
+    expect(resolveWindowsSystem32Path("netstat.exe", hostile)).toBe(
+      "C:\\Windows\\System32\\netstat.exe",
+    );
     expect(resolveWindowsCmdExePath(hostile)).toBe("C:\\Windows\\System32\\cmd.exe");
     expect(resolveWindowsPowerShellPath(hostile)).toBe(
       "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",

--- a/src/infra/windows-system-paths.ts
+++ b/src/infra/windows-system-paths.ts
@@ -30,6 +30,13 @@ function getEnvValueCaseInsensitive(
   return actualKey ? env[actualKey] : undefined;
 }
 
+// Segment-exact, not a substring test: dots are legal inside a Windows directory
+// name (`C:\Win..dows`), and `...` is a literal segment to `path.win32.normalize`,
+// not a parent reference.
+function hasParentTraversalSegment(rawPath: string): boolean {
+  return rawPath.split(/[\\/]/u).includes("..");
+}
+
 function normalizeWindowsSystemRoot(raw: string | undefined): string | null {
   const trimmed = raw?.trim();
   if (
@@ -37,10 +44,15 @@ function normalizeWindowsSystemRoot(raw: string | undefined): string | null {
     trimmed.includes("\0") ||
     trimmed.includes("\r") ||
     trimmed.includes("\n") ||
-    trimmed.includes(";")
+    trimmed.includes(";") ||
+    hasParentTraversalSegment(trimmed)
   ) {
     return null;
   }
+  // The traversal check above deliberately precedes this: `normalize` collapses
+  // `..`, so `C:\Windows\..\Users\pub\evil` would reach the checks below as
+  // `C:\Users\pub\evil` — absolute, drive-rooted and non-UNC — and satisfy every
+  // one of them, redirecting every pinned spawn at once.
   const normalized = path.win32.normalize(trimmed);
   // Reject relative roots and UNC paths — a remote share must never win here.
   if (!path.win32.isAbsolute(normalized) || normalized.startsWith("\\\\")) {

--- a/test/scripts/windows-cmd-helpers.test.ts
+++ b/test/scripts/windows-cmd-helpers.test.ts
@@ -1,0 +1,223 @@
+// Covers the %SystemRoot% resolution surface of `scripts/windows-cmd-helpers.mjs`,
+// the build-tooling twin of `src/infra/windows-system-paths.ts`.
+//
+// The two modules cannot share code — this one is `.mjs` loaded by plain `node`,
+// it lives outside the tsconfig `include`, and `scripts/lib/docker-e2e-package.sh`
+// bind-mounts it into a container as a single standalone file. They are kept in
+// sync by hand, so the last describe block is a mechanical parity gate rather
+// than another prose reminder to keep them aligned.
+import { describe, expect, it } from "vitest";
+import {
+  resolveWindowsCmdExePath,
+  resolveWindowsPowerShellPath,
+  resolveWindowsSystem32Path,
+  resolveWindowsSystemRoot,
+} from "../../scripts/windows-cmd-helpers.mjs";
+import * as srcTwin from "../../src/infra/windows-system-paths.js";
+
+const DEFAULT_ROOT = "C:\\Windows";
+
+// Every test injects its own env object, so the suite is host-platform agnostic.
+function env(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values;
+}
+
+// Named rather than inlined into `it.each` so the parity gate at the bottom can
+// derive its corpus from them — a row added here widens parity coverage too.
+const REJECTED_ROOTS: [label: string, raw: string][] = [
+  ["NUL byte", "C:\\Win\0dows"],
+  ["carriage return", "C:\\Windows\r"],
+  ["line feed", "C:\\Windows\n"],
+  ["semicolon (PATH separator injection)", "C:\\Windows;C:\\Evil"],
+  ["relative path", "Windows"],
+  ["dot-relative path", ".\\Windows"],
+  ["UNC path", "\\\\attacker\\share\\Windows"],
+  ["bare drive root with no subdirectory", "C:\\"],
+  ["POSIX absolute path (no drive letter)", "/usr/share/windows"],
+  ["empty string", ""],
+  ["whitespace only", "   "],
+  // `path.win32.normalize` collapses `..` BEFORE the shape checks run, so a
+  // traversal emerges as a clean absolute drive-rooted non-UNC path that
+  // satisfies every other guard. These must be rejected on the raw value.
+  ["parent-segment traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
+  ["forward-slash traversal", "C:/Windows/../Users/pub/evil"],
+  ["mixed-separator traversal", "C:\\Windows/../Users\\pub\\evil"],
+  ["traversal landing beside the drive root", "C:\\Windows\\..\\evil"],
+  ["traversal clamped at the drive root", "C:\\Windows\\..\\..\\..\\..\\Users"],
+  ["traversal with a trailing separator", "C:\\Windows\\..\\Users\\pub\\evil\\"],
+  // Not raw-value cases: these two collapse to shapes the pre-existing checks
+  // already reject (bare drive root, relative path). They pin that overlap, and
+  // would still pass with the raw-value guard removed.
+  ["traversal collapsing to the bare drive root", "C:\\Windows\\.."],
+  ["leading traversal, which stays relative", "..\\Windows"],
+];
+
+// The traversal guard matches whole `..` segments, not the substring — dots are
+// legal inside a Windows directory name. The `...` row documents segment-exactness
+// rather than a real-world root: `path.win32.normalize` treats `...` as a literal
+// segment, though Windows itself strips trailing dots so such a directory cannot
+// normally be created.
+const ACCEPTED_ROOTS: [label: string, raw: string, expected: string][] = [
+  ["a directory name containing dots", "C:\\Win..dows", "C:\\Win..dows"],
+  ["a trailing-dots directory name", "D:\\WinNT..", "D:\\WinNT.."],
+  ["a literal three-dot segment", "C:\\Windows\\...", "C:\\Windows\\..."],
+];
+
+describe("resolveWindowsSystemRoot", () => {
+  it("accepts a well-formed SystemRoot", () => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: "D:\\WinNT" }))).toBe("D:\\WinNT");
+  });
+
+  it("reads SystemRoot case-insensitively", () => {
+    expect(resolveWindowsSystemRoot(env({ SYSTEMROOT: "D:\\WinNT" }))).toBe("D:\\WinNT");
+    expect(resolveWindowsSystemRoot(env({ systemroot: "D:\\WinNT" }))).toBe("D:\\WinNT");
+  });
+
+  it("falls back to WINDIR, then to the default root", () => {
+    expect(resolveWindowsSystemRoot(env({ WINDIR: "E:\\Windows" }))).toBe("E:\\Windows");
+    expect(resolveWindowsSystemRoot(env({}))).toBe(DEFAULT_ROOT);
+  });
+
+  it("strips trailing separators", () => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: "D:\\WinNT\\\\" }))).toBe("D:\\WinNT");
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: "D:\\WinNT/" }))).toBe("D:\\WinNT");
+  });
+
+  // Each rejection branch must fall through to the safe default rather than
+  // letting an attacker-shaped value reach a spawn.
+  it.each(REJECTED_ROOTS)("rejects %s and falls back to the default root", (_label, raw) => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(DEFAULT_ROOT);
+  });
+
+  it.each(ACCEPTED_ROOTS)("accepts %s", (_label, raw, expected) => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(expected);
+  });
+
+  it("rejects a traversal in WINDIR too, not just SystemRoot", () => {
+    expect(resolveWindowsSystemRoot(env({ WINDIR: "C:\\Windows\\..\\Users\\pub\\evil" }))).toBe(
+      DEFAULT_ROOT,
+    );
+  });
+
+  it("falls through a traversal SystemRoot to a valid WINDIR", () => {
+    expect(
+      resolveWindowsSystemRoot(
+        env({ SystemRoot: "C:\\Windows\\..\\Users\\pub\\evil", WINDIR: "D:\\WinNT" }),
+      ),
+    ).toBe("D:\\WinNT");
+  });
+});
+
+describe("resolveWindowsSystem32Path", () => {
+  it("joins onto System32 with win32 separators", () => {
+    expect(resolveWindowsSystem32Path("netstat.exe", env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\netstat.exe",
+    );
+    expect(resolveWindowsSystem32Path("taskkill.exe", env({}))).toBe(
+      "C:\\Windows\\System32\\taskkill.exe",
+    );
+  });
+
+  it.each([
+    ["path traversal", "..\\..\\evil.exe"],
+    ["forward-slash traversal", "../evil.exe"],
+    ["absolute path", "C:\\evil\\payload.exe"],
+    ["nested directory", "wbem\\wmic.exe"],
+    ["missing .exe suffix", "netstat"],
+    ["wrong suffix", "payload.com"],
+    ["space in name", "my program.exe"],
+    ["empty name", ""],
+  ])("rejects %s", (_label, name) => {
+    expect(() => resolveWindowsSystem32Path(name, env({}))).toThrow(
+      /Invalid Windows System32 executable name/,
+    );
+  });
+});
+
+describe("named binary resolvers", () => {
+  it("pins cmd.exe into System32", () => {
+    expect(resolveWindowsCmdExePath(env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\cmd.exe",
+    );
+  });
+
+  // PowerShell is NOT in System32 directly — a plain System32 join would produce
+  // a path that does not exist on any Windows install.
+  it("pins powershell.exe under WindowsPowerShell\\v1.0", () => {
+    expect(resolveWindowsPowerShellPath(env({ SystemRoot: "D:\\WinNT" }))).toBe(
+      "D:\\WinNT\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+  });
+
+  // Every pinned binary is joined onto the one resolved root, so a single bad
+  // root redirects all of them at once.
+  it.each([
+    ["UNC", "\\\\attacker\\share"],
+    ["traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
+  ])("keeps a hostile %s SystemRoot out of every resolved binary path", (_label, raw) => {
+    const hostile = env({ SystemRoot: raw });
+    expect(resolveWindowsSystem32Path("netstat.exe", hostile)).toBe(
+      "C:\\Windows\\System32\\netstat.exe",
+    );
+    expect(resolveWindowsCmdExePath(hostile)).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(resolveWindowsPowerShellPath(hostile)).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+  });
+});
+
+// The hand-sync note in both file headers is prose; this is the gate. A guard
+// added to one twin and forgotten in the other fails here rather than shipping a
+// hole on whichever path the reviewer did not have in mind — the build-tooling
+// copy is the easy one to miss, since it is the one bind-mounted into the
+// docker-e2e container away from the TypeScript build.
+describe("twin parity with src/infra/windows-system-paths.ts", () => {
+  const ROOTS = [
+    // Only the well-formed roots the single-case tests above use are spelled out;
+    // every other shape is derived, so this corpus cannot fall behind the tables.
+    "D:\\WinNT",
+    "E:\\Windows",
+    "D:\\WinNT\\\\",
+    "D:\\WinNT/",
+    ...ACCEPTED_ROOTS.map(([, raw]) => raw),
+    ...REJECTED_ROOTS.map(([, raw]) => raw),
+  ];
+
+  it.each(ROOTS)("resolves %j identically in both twins", (raw) => {
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(
+      srcTwin.resolveWindowsSystemRoot(env({ SystemRoot: raw })),
+    );
+  });
+
+  it.each([
+    ["a WINDIR-only env", { WINDIR: "E:\\Windows" }],
+    [
+      "a rejected SystemRoot falling through",
+      { SystemRoot: "\\\\evil\\share", WINDIR: "D:\\WinNT" },
+    ],
+    [
+      "a traversal SystemRoot falling through",
+      { SystemRoot: "C:\\Windows\\..\\Users\\pub\\evil", WINDIR: "D:\\WinNT" },
+    ],
+    [
+      "a traversal in both variables",
+      { SystemRoot: "C:\\Windows\\..\\Users\\pub\\evil", WINDIR: "C:\\Windows\\..\\evil" },
+    ],
+    ["a differently cased key", { SYSTEMROOT: "D:\\WinNT" }],
+    ["an empty env", {}],
+  ])("agrees on the fallback chain for %s", (_label, values) => {
+    expect(resolveWindowsSystemRoot(env(values))).toBe(
+      srcTwin.resolveWindowsSystemRoot(env(values)),
+    );
+  });
+
+  // Only the binaries both twins expose — `resolveWindowsWmicPath` is src-only.
+  it.each(ROOTS)("agrees on the pinned binary paths for %j", (raw) => {
+    const values = env({ SystemRoot: raw });
+    expect(resolveWindowsCmdExePath(values)).toBe(srcTwin.resolveWindowsCmdExePath(values));
+    expect(resolveWindowsPowerShellPath(values)).toBe(srcTwin.resolveWindowsPowerShellPath(values));
+    expect(resolveWindowsSystem32Path("netstat.exe", values)).toBe(
+      srcTwin.resolveWindowsSystem32Path("netstat.exe", values),
+    );
+  });
+});


### PR DESCRIPTION
Closes #3091.

## The defect

`path.win32.normalize()` collapses `..` **before** the resolver's hardening checks run, so a
traversal emerged as a clean absolute path that satisfied every guard:

```
SystemRoot=C:\Windows\..\Users\pub\evil   ->   C:\Users\pub\evil
                                               absolute ✓  drive-rooted ✓  non-UNC ✓  longer than root ✓
```

All 27 pinned system-binary spawns from #3088 resolve through that single root.

## The fix

Reject whole `..` segments on the **raw** value, before normalization — in both twins:

- `src/infra/windows-system-paths.ts`
- `scripts/windows-cmd-helpers.mjs`

Segment-exact rather than a substring test, so legitimate directory names survive:
`C:\Win..dows` and `D:\WinNT..` are still accepted, and `...` is a literal segment to
`path.win32.normalize`, not a parent reference.

Nothing existing was softened — the new term is appended to the same reject condition.
NUL/CR/LF/`;`, non-absolute, UNC, non-drive-letter root, bare drive root, trailing-separator
strip, case-insensitive `SystemRoot` read, `WINDIR` fallback and the `C:\Windows` default are
all untouched (zero deleted assertions in the existing suite).

## Why both copies, and a gate so they stay in sync

The twins are deliberate duplicates — the `.mjs` is loaded by plain `node`, sits outside the
tsgo `include`, and is bind-mounted standalone into a container by
`scripts/lib/docker-e2e-package.sh:258` — so a `src/` re-export is not viable and a one-sided
fix would have left the hole open on the packaged path.

`scripts/windows-cmd-helpers.mjs` had **no test coverage at all** before this. The new
`test/scripts/windows-cmd-helpers.test.ts` covers it and adds a mechanical **twin-parity
gate**: a guard added to one copy and forgotten in the other now fails a test rather than
silently shipping a hole. Verified non-vacuous — removing the guard from *only* the `.mjs`
fails 14 parity cases, while removing it from *both* fails zero (it fires on divergence, stays
silent on symmetric absence).

## Scope

Resolvers and their tests only. The 27 call sites are untouched.

## Threat model — please read this framing before merging

This is **hardening, not an exploit fix.** The guard constrains the traversal's *spelling*,
not its *target*:

```
REJECT  SystemRoot=C:\Windows\..\Users\pub\evil   ->  C:\Windows\System32\cmd.exe
ACCEPT  SystemRoot=C:\Users\pub\evil              ->  C:\Users\pub\evil\System32\cmd.exe
```

An attacker who can set the environment block gains nothing from the `..` spelling and loses
nothing by dropping it. What this closes is the *normalize-then-validate* anti-pattern: the
resolver no longer silently rewrites its input and then validates the rewrite, so the value it
accepts is the value it was given. It rejects an input shape no real Windows OS emits.

Genuinely narrowing the accepted root — issue #3091's suggested option 1 (require a direct
child of a drive root) or option 2 (allowlist) — would restrict where `%SystemRoot%` may point
at all. That is a behaviour-restricting change with real deployment risk (option 2 breaks
`D:\WinNT`-style installs, which this suite explicitly pins as valid), so I left it out rather
than fold it in silently. Happy to follow up if you want it.

Note the process-level defence already in place: `host-env-security` classifies both
`SystemRoot` and `windir` as dangerous host-env override vars.

## Verification

Every claim below is from a run in this branch, on macOS — the suites inject env objects and
never read the real `process.env`, so they are host-platform agnostic.

**Tests fail without the guard, pass with it** (same 142 tests, guard removed from both twins):

```
Tests  18 failed | 124 passed (142)     <- guard removed  (9 failures per twin)
Tests  142 passed (142)                 <- guard restored
```

**Full unit lane** (`vitest.unit.config.ts`, the config CI's `test` job runs):

```
Test Files  1052 passed | 3 skipped (1055)
     Tests  10353 passed | 42 skipped (10395)
```

**`pnpm check`** — exit 0: oxfmt clean (7800 files), tsgo no diagnostics, oxlint type-aware
`0 warnings and 0 errors` (5495 files), plus the lobster/rebrand-adjacent and CSS-drift gates.

**Standalone fork-integrity gates** — all exit 0: zombie-import, stub-debt, throwing-stub-callers,
attestations, obsolescence-audit, policy-doctor-boundary, raw-channel-fetch, and
rebrand-leakage (run `--staged` so it actually scanned these four files rather than zero).

**Not run**: `LIVE=1 pnpm test:live` — this PR does not touch `src/middleware/`, so the
project's LIVE-smoke requirement does not apply.

**Independent review**: a fresh-context adversarial pass verified all nine correctness claims,
enumerated all 33 consumers of the resolvers across both twins, and found no consumer that
could legitimately have been passing a `..`-containing root (every call site threads
`process.env`, i.e. the OS-populated canonical value). Verdict CLEAN. Its three non-blocking
notes are folded in above and into the test comments.

## One thing a reviewer should know

Two rejection rows — `C:\Windows\..` and `..\Windows` — are caught by *pre-existing* checks
(bare-drive-root and non-absolute), not by the new guard. They are kept as regression pins and
labelled as such in the test, so the guard's true exercise count is 9 per twin, not 11.
