### PR TITLE
security(commands): validate ssh hosts, stop trusting TXT beacon hints (#3093)

### DIFF
--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -3,11 +3,16 @@ import { withProgress } from "../cli/progress.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../config/config.js";
 import { probeGateway } from "../gateway/probe.js";
 import { discoverGatewayBeacons } from "../infra/bonjour-discovery.js";
-import { resolveSshConfig } from "../infra/ssh-config.js";
 import { parseSshTarget, startSshPortForward } from "../infra/ssh-tunnel.js";
 import { resolveWideAreaDiscoveryDomain } from "../infra/widearea-dns.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
+import {
+  inferSshTargetFromRemoteUrl,
+  pickAutoSshTargetFromDiscovery,
+  resolveSshTarget,
+  serializeGatewayDiscoveryBeacon,
+} from "./gateway-status/discovery.js";
 import {
   buildNetworkHints,
   extractConfigSummary,
@@ -78,7 +83,13 @@ export async function gatewayStatusCommand(
   }
 
   if (sshTarget) {
-    const resolved = await resolveSshTarget(sshTarget, sshIdentity, overallTimeoutMs);
+    const resolved = await resolveSshTarget({
+      rawTarget: sshTarget,
+      identity: sshIdentity,
+      overallTimeoutMs,
+      loadSshConfigModule: async () => await import("../infra/ssh-config.js"),
+      loadSshTunnelModule: async () => await import("../infra/ssh-tunnel.js"),
+    });
     if (resolved) {
       sshTarget = resolved.target;
       if (!sshIdentity && resolved.identity) {
@@ -120,23 +131,13 @@ export async function gatewayStatusCommand(
       const [discovery, tunnelFirst] = await Promise.all([discoveryTask, tunnelTask]);
 
       if (!sshTarget && opts.sshAuto) {
-        const user = process.env.USER?.trim() || "";
-        const candidates = discovery
-          .map((b) => {
-            const host = b.tailnetDns || b.lanHost || b.host;
-            if (!host?.trim()) {
-              return null;
-            }
-            const sshPort = typeof b.sshPort === "number" && b.sshPort > 0 ? b.sshPort : 22;
-            const base = user ? `${user}@${host.trim()}` : host.trim();
-            return sshPort !== 22 ? `${base}:${sshPort}` : base;
-          })
-          .filter((candidate): candidate is string =>
-            Boolean(candidate && parseSshTarget(candidate)),
-          );
-        if (candidates.length > 0) {
-          sshTarget = candidates[0] ?? null;
-        }
+        // TXT hints (tailnetDns / lanHost) are attacker-publishable — deliberately
+        // no longer a fallback here; only a resolved endpoint yields an auto target.
+        sshTarget = pickAutoSshTargetFromDiscovery({
+          discovery,
+          parseSshTarget,
+          sshUser: process.env.USER,
+        });
       }
 
       const tunnel =
@@ -276,21 +277,7 @@ export async function gatewayStatusCommand(
           discovery: {
             timeoutMs: discoveryTimeoutMs,
             count: discovery.length,
-            beacons: discovery.map((b) => ({
-              instanceName: b.instanceName,
-              displayName: b.displayName ?? null,
-              domain: b.domain ?? null,
-              host: b.host ?? null,
-              lanHost: b.lanHost ?? null,
-              tailnetDns: b.tailnetDns ?? null,
-              gatewayPort: b.gatewayPort ?? null,
-              sshPort: b.sshPort ?? null,
-              wsUrl: (() => {
-                const host = b.tailnetDns || b.lanHost || b.host;
-                const port = b.gatewayPort ?? 18789;
-                return host ? `ws://${host}:${port}` : null;
-              })(),
-            })),
+            beacons: discovery.map(serializeGatewayDiscoveryBeacon),
           },
           targets: probed.map((p) => ({
             id: p.target.id,
@@ -390,68 +377,4 @@ export async function gatewayStatusCommand(
   if (!ok) {
     runtime.exit(1);
   }
-}
-
-function inferSshTargetFromRemoteUrl(rawUrl?: string | null): string | null {
-  if (typeof rawUrl !== "string") {
-    return null;
-  }
-  const trimmed = rawUrl.trim();
-  if (!trimmed) {
-    return null;
-  }
-  let host: string | null = null;
-  try {
-    host = new URL(trimmed).hostname || null;
-  } catch {
-    return null;
-  }
-  if (!host) {
-    return null;
-  }
-  const user = process.env.USER?.trim() || "";
-  return user ? `${user}@${host}` : host;
-}
-
-function buildSshTarget(input: { user?: string; host?: string; port?: number }): string | null {
-  const host = input.host?.trim() ?? "";
-  if (!host) {
-    return null;
-  }
-  const user = input.user?.trim() ?? "";
-  const base = user ? `${user}@${host}` : host;
-  const port = input.port ?? 22;
-  if (port && port !== 22) {
-    return `${base}:${port}`;
-  }
-  return base;
-}
-
-async function resolveSshTarget(
-  rawTarget: string,
-  identity: string | null,
-  overallTimeoutMs: number,
-): Promise<{ target: string; identity?: string } | null> {
-  const parsed = parseSshTarget(rawTarget);
-  if (!parsed) {
-    return null;
-  }
-  const config = await resolveSshConfig(parsed, {
-    identity: identity ?? undefined,
-    timeoutMs: Math.min(800, overallTimeoutMs),
-  });
-  if (!config) {
-    return { target: rawTarget, identity: identity ?? undefined };
-  }
-  const target = buildSshTarget({
-    user: config.user ?? parsed.user,
-    host: config.host ?? parsed.host,
-    port: config.port ?? parsed.port,
-  });
-  if (!target) {
-    return { target: rawTarget, identity: identity ?? undefined };
-  }
-  const identityFile =
-    identity ?? config.identityFiles.find((entry) => entry.trim().length > 0)?.trim() ?? undefined;
-  return { target, identity: identityFile };
 }

--- a/src/commands/gateway-status/discovery.test.ts
+++ b/src/commands/gateway-status/discovery.test.ts
@@ -1,0 +1,155 @@
+// Covers SSH target inference from remote URLs and discovery beacons.
+//
+// NOTE: src/commands/** is collected by no CI lane today (tracked as one of the
+// gates on #3076), so these run locally only. The host denylist they exercise
+// is additionally unit-tested in src/infra/ssh-host-safety.test.ts, which does
+// run in the unit lane.
+import { describe, expect, it } from "vitest";
+import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import {
+  inferSshTargetFromRemoteUrl,
+  pickAutoSshTargetFromDiscovery,
+  resolveSshTarget,
+} from "./discovery.js";
+
+type SshConfigModule = typeof import("../../infra/ssh-config.js");
+type SshTunnelModule = typeof import("../../infra/ssh-tunnel.js");
+
+function fakeSshModules(
+  config: {
+    user?: string;
+    host?: string;
+    port?: number;
+    identityFiles?: string[];
+  } | null,
+) {
+  return {
+    loadSshConfigModule: async () =>
+      ({
+        resolveSshConfig: async () => (config ? { identityFiles: [], ...config } : null),
+      }) as unknown as SshConfigModule,
+    loadSshTunnelModule: async () =>
+      ({
+        parseSshTarget: (raw: string) => {
+          const [user, host] = raw.includes("@") ? raw.split("@", 2) : [undefined, raw];
+          return host ? { user, host, port: 22 } : null;
+        },
+      }) as unknown as SshTunnelModule,
+  };
+}
+
+// Stand-in for infra/ssh-tunnel.js parseSshTarget that only rejects a target
+// whose FIRST character is '-'. It cannot see a dangerous host behind a
+// "user@" prefix, which is what makes it a real test of the caller's guard
+// rather than of the tunnel parser's.
+function permissiveParseSshTarget(target: string): unknown {
+  return target.startsWith("-") ? null : { target };
+}
+
+describe("inferSshTargetFromRemoteUrl", () => {
+  it("infers user@host from a well-formed remote URL", async () => {
+    await withEnvAsync({ USER: "steipete" }, async () => {
+      expect(inferSshTargetFromRemoteUrl("wss://studio.example:18789")).toBe(
+        "steipete@studio.example",
+      );
+    });
+  });
+
+  // See discovery.ts: the WHATWG parser accepts a leading '-' in the host.
+  it("rejects a remote URL whose hostname would become an ssh option", async () => {
+    await withEnvAsync({ USER: "steipete" }, async () => {
+      expect(inferSshTargetFromRemoteUrl("wss://-V:18789")).toBeNull();
+      expect(inferSshTargetFromRemoteUrl("wss://-oProxyCommand=touch~hacked:18789")).toBeNull();
+    });
+  });
+
+  it("returns null for non-strings, blanks, and unparseable URLs", () => {
+    expect(inferSshTargetFromRemoteUrl(null)).toBeNull();
+    expect(inferSshTargetFromRemoteUrl(undefined)).toBeNull();
+    expect(inferSshTargetFromRemoteUrl("   ")).toBeNull();
+    expect(inferSshTargetFromRemoteUrl("not a url")).toBeNull();
+  });
+});
+
+describe("resolveSshTarget", () => {
+  it("adopts the host and port ssh_config resolves to", async () => {
+    const resolved = await resolveSshTarget({
+      rawTarget: "steipete@studio",
+      identity: null,
+      overallTimeoutMs: 1000,
+      ...fakeSshModules({ user: "steipete", host: "studio.example", port: 2222 }),
+    });
+
+    expect(resolved).toEqual({ target: "steipete@studio.example:2222", identity: undefined });
+  });
+
+  it("does not adopt an ssh_config HostName that would become an ssh option", async () => {
+    const resolved = await resolveSshTarget({
+      rawTarget: "steipete@studio",
+      identity: null,
+      overallTimeoutMs: 1000,
+      ...fakeSshModules({ user: "steipete", host: "-oProxyCommand=touch~hacked", port: 2222 }),
+    });
+
+    expect(resolved).toEqual({ target: "steipete@studio", identity: undefined });
+  });
+
+  it("returns null when the raw target does not parse", async () => {
+    const resolved = await resolveSshTarget({
+      rawTarget: "",
+      identity: null,
+      overallTimeoutMs: 1000,
+      ...fakeSshModules(null),
+    });
+
+    expect(resolved).toBeNull();
+  });
+});
+
+describe("pickAutoSshTargetFromDiscovery", () => {
+  it("ignores beacons that only carry TXT hints", () => {
+    const discovery: GatewayBonjourBeacon[] = [
+      { instanceName: "bad", tailnetDns: "-V" },
+      { instanceName: "txt-only", tailnetDns: "goodhost", gatewayPort: 18789 },
+      { instanceName: "lan-hint", lanHost: "lan.example", gatewayPort: 18789 },
+    ];
+
+    expect(
+      pickAutoSshTargetFromDiscovery({
+        discovery,
+        parseSshTarget: permissiveParseSshTarget,
+        sshUser: "steipete",
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the first beacon that resolved to a real host and port", () => {
+    const discovery: GatewayBonjourBeacon[] = [
+      { instanceName: "bad", tailnetDns: "-V" },
+      { instanceName: "Gateway", host: "goodhost", port: 18789, sshPort: 2222 },
+    ];
+
+    expect(
+      pickAutoSshTargetFromDiscovery({
+        discovery,
+        parseSshTarget: permissiveParseSshTarget,
+        sshUser: "steipete",
+      }),
+    ).toBe("steipete@goodhost:2222");
+  });
+
+  it("rejects a resolved host that would become an ssh option", () => {
+    const discovery: GatewayBonjourBeacon[] = [
+      { instanceName: "hostile", host: "-oProxyCommand=touch~hacked", port: 18789 },
+    ];
+
+    expect(
+      pickAutoSshTargetFromDiscovery({
+        discovery,
+        parseSshTarget: permissiveParseSshTarget,
+        sshUser: "steipete",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/commands/gateway-status/discovery.ts
+++ b/src/commands/gateway-status/discovery.ts
@@ -5,6 +5,7 @@ import {
   buildGatewayDiscoveryTarget,
   serializeGatewayDiscoveryBeacon,
 } from "../../infra/gateway-discovery-targets.js";
+import { isUnsafeSshHost } from "../../infra/ssh-host-safety.js";
 
 /** Infers a user@host SSH target from a configured remote websocket URL. */
 export function inferSshTargetFromRemoteUrl(rawUrl?: string | null): string | null {
@@ -21,7 +22,10 @@ export function inferSshTargetFromRemoteUrl(rawUrl?: string | null): string | nu
   } catch {
     return null;
   }
-  if (!host) {
+  // `new URL("wss://-oProxyCommand=x:18789").hostname` is "-oproxycommand=x":
+  // the WHATWG host parser permits a leading '-', so the hostname must be
+  // validated here rather than trusted because it came from a parsed URL.
+  if (!host || isUnsafeSshHost(host)) {
     return null;
   }
   const user = normalizeOptionalString(process.env.USER) ?? "";
@@ -30,7 +34,9 @@ export function inferSshTargetFromRemoteUrl(rawUrl?: string | null): string | nu
 
 function buildSshTarget(input: { user?: string; host?: string; port?: number }): string | null {
   const host = normalizeOptionalString(input.host) ?? "";
-  if (!host) {
+  // ssh_config can rewrite HostName, so re-validate rather than assume the
+  // resolved host inherits the safety of the target it was resolved from.
+  if (!host || isUnsafeSshHost(host)) {
     return null;
   }
   const user = normalizeOptionalString(input.user) ?? "";

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -4,7 +4,7 @@ import type { RemoteClawConfig, ConfigFileSnapshot } from "../../config/types.js
 import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import { resolveGatewayProbeSurfaceAuth } from "../../gateway/auth-surface-resolution.js";
 import type { GatewayProbeResult } from "../../gateway/probe.js";
-import { pickPrimaryTailnetIPv4 } from "../../infra/tailnet.js";
+import { inspectBestEffortPrimaryTailnetIPv4 } from "../../infra/network-discovery-display.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { colorize, theme } from "../../terminal/theme.js";
 import { pickGatewaySelfPresence } from "../gateway-presence.js";
@@ -222,7 +222,7 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
 }
 
 export function buildNetworkHints(cfg: RemoteClawConfig) {
-  const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
   const port = resolveGatewayPort(cfg);
   const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   return {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -10,9 +10,13 @@ import { resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
-import { pickPrimaryLanIPv4, isValidIPv4 } from "../gateway/net.js";
+import { isValidIPv4 } from "../gateway/net.js";
+import { movePathToTrash } from "../infra/fs-safe.js";
+import {
+  inspectBestEffortPrimaryTailnetIPv4,
+  pickBestEffortPrimaryLanIPv4,
+} from "../infra/network-discovery-display.js";
 import { isSafeExecutableValue } from "../infra/safe-executable-value.js";
-import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import { isWSL } from "../infra/wsl.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -129,12 +133,20 @@ type BrowserOpenCommand = {
   argv: string[] | null;
   reason?: string;
   command?: string;
-  /**
-   * Whether the URL must be wrapped in quotes when appended to argv.
-   * Needed for Windows `cmd /c start` where `&` splits commands.
-   */
-  quoteUrl?: boolean;
 };
+
+// Only web URLs may be handed to an OS URL handler. `file://` would open a
+// local file, and custom schemes reach whatever application claims them, so a
+// URL that reaches openUrl by mistake must not become an arbitrary OS action.
+const BROWSER_OPEN_ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function isBrowserOpenableUrl(url: string): boolean {
+  try {
+    return BROWSER_OPEN_ALLOWED_PROTOCOLS.has(new URL(url).protocol);
+  } catch {
+    return false;
+  }
+}
 
 export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
   const platform = process.platform;
@@ -149,10 +161,13 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
   }
 
   if (platform === "win32") {
+    // rundll32 + FileProtocolHandler hands the URL to the registered handler as
+    // a single argument. `cmd /c start` instead re-parses it through the shell,
+    // where `&` in an OAuth query string splits it into further commands.
+    const rundll32 = resolveWindowsSystem32Path("rundll32.exe");
     return {
-      argv: ["cmd", "/c", "start", ""],
-      command: "cmd",
-      quoteUrl: true,
+      argv: [rundll32, "url.dll,FileProtocolHandler"],
+      command: rundll32,
     };
   }
 
@@ -229,26 +244,15 @@ export async function openUrl(url: string): Promise<boolean> {
   if (shouldSkipBrowserOpenInTests()) {
     return false;
   }
+  if (!isBrowserOpenableUrl(url)) {
+    return false;
+  }
   const resolved = await resolveBrowserOpenCommand();
   if (!resolved.argv) {
     return false;
   }
-  const quoteUrl = resolved.quoteUrl === true;
-  const command = [...resolved.argv];
-  if (quoteUrl) {
-    if (command.at(-1) === "") {
-      // Preserve the empty title token for `start` when using verbatim args.
-      command[command.length - 1] = '""';
-    }
-    command.push(`"${url}"`);
-  } else {
-    command.push(url);
-  }
   try {
-    await runCommandWithTimeout(command, {
-      timeoutMs: 5_000,
-      windowsVerbatimArguments: quoteUrl,
-    });
+    await runCommandWithTimeout([...resolved.argv, url], { timeoutMs: 5_000 });
     return true;
   } catch {
     // ignore; we still print the URL for manual open
@@ -258,6 +262,9 @@ export async function openUrl(url: string): Promise<boolean> {
 
 export async function openUrlInBackground(url: string): Promise<boolean> {
   if (shouldSkipBrowserOpenInTests()) {
+    return false;
+  }
+  if (!isBrowserOpenableUrl(url)) {
     return false;
   }
   if (process.platform !== "darwin") {
@@ -293,16 +300,45 @@ export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promis
     return;
   }
   try {
-    await fs.access(pathname);
+    await fs.lstat(pathname);
   } catch {
     return;
   }
   try {
-    await runCommandWithTimeout(["trash", pathname], { timeoutMs: 5000 });
+    const targetPath = path.resolve(pathname);
+    const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
+    await movePathToTrash(sourcePath, {
+      allowedRoots: await resolveMoveToTrashAllowedRoots(sourcePath),
+    });
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
   } catch {
     runtime.log(`Failed to move to Trash (manual delete): ${shortenHomePath(pathname)}`);
   }
+}
+
+// Mirror the canonicalization movePathToTrash performs internally, so the
+// allowed roots below are derived from the same parent the rename will use.
+async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string> {
+  return path.join(await fs.realpath(path.dirname(targetPath)), path.basename(targetPath));
+}
+
+// These roots are derived from the target, so they do NOT bound where a reset
+// can reach — a config path that is itself a symlink into /etc still resolves
+// inside its own canonical parent. They exist to satisfy the fs-safe contract
+// and to keep a link whose target lives elsewhere from being read as an escape.
+// Bounding reset to known-owned directories would need roots sourced from
+// resolveConfigDir()/resolveStateDir() instead.
+async function resolveMoveToTrashAllowedRoots(sourcePath: string): Promise<string[]> {
+  const allowedRoots = [path.dirname(sourcePath)];
+  const stat = await fs.lstat(sourcePath);
+  if (stat.isSymbolicLink()) {
+    try {
+      allowedRoots.push(path.dirname(await fs.realpath(sourcePath)));
+    } catch {
+      // Broken symlink: the lexical parent is the only root that applies.
+    }
+  }
+  return [...new Set(allowedRoots)];
 }
 
 export async function handleReset(scope: ResetScope, workspaceDir: string, runtime: RuntimeEnv) {
@@ -444,7 +480,7 @@ export function resolveControlUiLinks(params: {
   const port = params.port;
   const bind = params.bind ?? "loopback";
   const customBindHost = params.customBindHost?.trim();
-  const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
   const host = (() => {
     if (bind === "custom" && customBindHost && isValidIPv4(customBindHost)) {
       return customBindHost;
@@ -453,7 +489,7 @@ export function resolveControlUiLinks(params: {
       return tailnetIPv4 ?? "127.0.0.1";
     }
     if (bind === "lan") {
-      return pickPrimaryLanIPv4() ?? "127.0.0.1";
+      return pickBestEffortPrimaryLanIPv4() ?? "127.0.0.1";
     }
     return "127.0.0.1";
   })();

--- a/src/infra/fs-safe-trash.test.ts
+++ b/src/infra/fs-safe-trash.test.ts
@@ -1,0 +1,128 @@
+// Covers containment and symlink handling for the subprocess-free trash move.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { movePathToTrash } from "./fs-safe-trash.js";
+
+let homeDir: string;
+let envSnapshot: ReturnType<typeof captureEnv>;
+
+function trashEntries(): string[] {
+  const dir =
+    process.platform === "linux"
+      ? path.join(homeDir, ".local", "share", "Trash", "files")
+      : path.join(homeDir, ".Trash");
+  return fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+}
+
+// os.homedir() reads $HOME on POSIX, and resolveTrashDir() derives the trash
+// directory from it, so pointing HOME at a temp dir keeps every move inside the
+// fixture instead of the developer's real Trash.
+beforeEach(() => {
+  envSnapshot = captureEnv(["HOME", "XDG_DATA_HOME", "USERPROFILE"]);
+  homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-fs-safe-trash-"));
+  setTestEnvValue("HOME", homeDir);
+  setTestEnvValue("USERPROFILE", homeDir);
+  setTestEnvValue("XDG_DATA_HOME", path.join(homeDir, ".local", "share"));
+});
+
+afterEach(() => {
+  envSnapshot.restore();
+  fs.rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe("movePathToTrash", () => {
+  it("moves a file into the trash directory and returns its destination", async () => {
+    const workDir = path.join(homeDir, "work");
+    const target = path.join(workDir, "remoteclaw.json");
+    fs.mkdirSync(workDir, { recursive: true });
+    fs.writeFileSync(target, "{}\n");
+
+    const destination = await movePathToTrash(target, { allowedRoots: [workDir] });
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.readFileSync(destination, "utf8")).toBe("{}\n");
+    expect(trashEntries()).toHaveLength(1);
+  });
+
+  it("refuses a symlink whose target resolves outside every allowed root", async () => {
+    const workDir = path.join(homeDir, "work");
+    const outsideDir = path.join(homeDir, "outside");
+    fs.mkdirSync(workDir, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    const outsideTarget = path.join(outsideDir, "payload.txt");
+    fs.writeFileSync(outsideTarget, "do not touch\n");
+    const link = path.join(workDir, "link");
+    fs.symlinkSync(outsideTarget, link);
+
+    // The link sits inside workDir, but the containment check follows it: only
+    // a caller that also allows outsideDir may trash it.
+    await expect(movePathToTrash(link, { allowedRoots: [workDir] })).rejects.toThrow(
+      /outside the allowed roots/,
+    );
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(trashEntries()).toHaveLength(0);
+  });
+
+  it("refuses a target that resolves outside every allowed root", async () => {
+    const workDir = path.join(homeDir, "work");
+    const otherDir = path.join(homeDir, "other");
+    const target = path.join(otherDir, "keep-me.json");
+    fs.mkdirSync(workDir, { recursive: true });
+    fs.mkdirSync(otherDir, { recursive: true });
+    fs.writeFileSync(target, "keep\n");
+
+    await expect(movePathToTrash(target, { allowedRoots: [workDir] })).rejects.toThrow(
+      /outside the allowed roots/,
+    );
+    expect(fs.readFileSync(target, "utf8")).toBe("keep\n");
+    expect(trashEntries()).toHaveLength(0);
+  });
+
+  it("canonicalizes a symlinked parent before the containment check", async () => {
+    const realParent = path.join(homeDir, "state-real");
+    const lexicalParent = path.join(homeDir, "state-link");
+    fs.mkdirSync(realParent, { recursive: true });
+    fs.symlinkSync(realParent, lexicalParent, "dir");
+    const target = path.join(lexicalParent, "remoteclaw.json");
+    fs.writeFileSync(target, "{}\n");
+
+    // The root is the symlink, the resolved target is under the real parent:
+    // both sides canonicalize, so this is contained rather than an escape.
+    await movePathToTrash(target, { allowedRoots: [lexicalParent] });
+
+    expect(fs.existsSync(path.join(realParent, "remoteclaw.json"))).toBe(false);
+    expect(trashEntries()).toHaveLength(1);
+  });
+
+  it("trashes a symlink as a link without following it to its target", async () => {
+    const workDir = path.join(homeDir, "work");
+    const outsideDir = path.join(homeDir, "outside");
+    fs.mkdirSync(workDir, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    const outsideTarget = path.join(outsideDir, "payload.txt");
+    fs.writeFileSync(outsideTarget, "do not touch\n");
+    const link = path.join(workDir, "link");
+    fs.symlinkSync(outsideTarget, link);
+
+    const destination = await movePathToTrash(link, {
+      allowedRoots: [workDir, outsideDir],
+    });
+
+    expect(fs.lstatSync(destination).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(outsideTarget, "utf8")).toBe("do not touch\n");
+    expect(fs.existsSync(link)).toBe(false);
+  });
+
+  it("skips the containment check when no allowed roots are given", async () => {
+    const workDir = path.join(homeDir, "work");
+    const target = path.join(workDir, "scratch.txt");
+    fs.mkdirSync(workDir, { recursive: true });
+    fs.writeFileSync(target, "scratch\n");
+
+    await expect(movePathToTrash(target)).resolves.toContain("scratch.txt");
+    expect(fs.existsSync(target)).toBe(false);
+  });
+});

--- a/src/infra/fs-safe-trash.ts
+++ b/src/infra/fs-safe-trash.ts
@@ -1,0 +1,111 @@
+// Moves a path to the user's trash directory without spawning a helper binary.
+//
+// This exists alongside `infra/trash.ts` (the browser-profile mover — same
+// export name, still shells out to a PATH-resolved `trash`). Resolving `trash`
+// through %PATH% lets whatever comes first on the path run in our process
+// context — the untrusted-search-path class this fork already closed for
+// Windows system binaries — so the onboarding reset path uses this module.
+//
+// `allowedRoots` is the CALLER's assertion of where the target is expected to
+// live, checked against the fully-resolved target. It is not a defence against
+// a local attacker: there is an unavoidable window between the check and the
+// rename (no `renameat` binding).
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isPathInside } from "./path-guards.js";
+import { generateSecureToken } from "./secure-random.js";
+
+export type MovePathToTrashOptions = {
+  /**
+   * Directories the fully-resolved target must live under. An empty or omitted
+   * list disables the check. Supplying roots derived from the target itself
+   * makes the check trivially true — pass independently-known roots for it to
+   * mean anything.
+   */
+  allowedRoots?: string[];
+};
+
+/** Best-effort canonicalization: paths that do not exist resolve lexically. */
+async function realpathOrResolve(candidate: string): Promise<string> {
+  try {
+    return await fs.realpath(candidate);
+  } catch {
+    return path.resolve(candidate);
+  }
+}
+
+function resolveTrashDir(): string {
+  // Linux desktops read ~/.local/share/Trash. No companion `info/*.trashinfo`
+  // is written, so entries land in the right place but cannot be restored from
+  // a desktop trash UI — same as `infra/trash.ts`'s fallback. Elsewhere
+  // (darwin, win32) use ~/.Trash, matching that module's convention rather than
+  // inventing a second one.
+  if (process.platform === "linux") {
+    const dataHome = process.env.XDG_DATA_HOME?.trim();
+    const base =
+      dataHome && path.isAbsolute(dataHome) ? dataHome : path.join(os.homedir(), ".local", "share");
+    return path.join(base, "Trash", "files");
+  }
+  return path.join(os.homedir(), ".Trash");
+}
+
+async function assertWithinAllowedRoots(target: string, allowedRoots: string[]) {
+  // Compare canonical forms on both sides: a root given as a symlink and a
+  // target reached through one must agree.
+  const resolvedTarget = await realpathOrResolve(target);
+  const roots = await Promise.all(allowedRoots.map(realpathOrResolve));
+  if (roots.some((root) => isPathInside(root, resolvedTarget))) {
+    return;
+  }
+  throw new Error(`refusing to trash a path outside the allowed roots: ${resolvedTarget}`);
+}
+
+/** Move `targetPath` into the trash directory, returning its new location. */
+export async function movePathToTrash(
+  targetPath: string,
+  options?: MovePathToTrashOptions,
+): Promise<string> {
+  const absoluteTarget = path.resolve(targetPath);
+  // Canonicalize the parent but keep the basename as written, so the rename
+  // moves the entry itself even when it is a symlink.
+  const source = path.join(
+    await realpathOrResolve(path.dirname(absoluteTarget)),
+    path.basename(absoluteTarget),
+  );
+
+  const allowedRoots = options?.allowedRoots ?? [];
+  if (allowedRoots.length > 0) {
+    await assertWithinAllowedRoots(source, allowedRoots);
+  }
+
+  const trashDir = resolveTrashDir();
+  await fs.mkdir(trashDir, { recursive: true });
+  // Always disambiguate. `fs.rename` silently replaces an existing file, so
+  // testing for a collision first and only then adding entropy would let two
+  // items trashed in the same millisecond destroy each other.
+  const destination = path.join(
+    trashDir,
+    `${path.basename(source)}-${Date.now()}-${generateSecureToken(6)}`,
+  );
+
+  try {
+    await fs.rename(source, destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EXDEV") {
+      throw error;
+    }
+    // The trash directory is on a different filesystem than the target (state
+    // on an external drive, a separate /data partition, a container volume).
+    // rename(2) cannot cross that boundary, so copy and unlink instead.
+    await fs.cp(source, destination, {
+      recursive: true,
+      verbatimSymlinks: true,
+      errorOnExist: true,
+      force: false,
+    });
+    await fs.rm(source, { recursive: true, force: true });
+  }
+  return destination;
+}

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -20,6 +20,8 @@ import {
   isSymlinkOpenError,
 } from "./path-guards.js";
 
+export { movePathToTrash, type MovePathToTrashOptions } from "./fs-safe-trash.js";
+
 export type SafeOpenErrorCode =
   | "invalid-path"
   | "not-found"

--- a/src/infra/gateway-discovery-targets.test.ts
+++ b/src/infra/gateway-discovery-targets.test.ts
@@ -1,0 +1,95 @@
+// Covers beacon -> connection-target normalization, including the host guard.
+//
+// This lives beside the source rather than with the gateway-status command
+// tests because src/infra/** runs in the CI unit lane and src/commands/** does
+// not, so the guard regresses loudly here.
+import { describe, expect, it } from "vitest";
+import type { GatewayBonjourBeacon } from "./bonjour-discovery.js";
+import {
+  buildGatewayDiscoveryTarget,
+  serializeGatewayDiscoveryBeacon,
+} from "./gateway-discovery-targets.js";
+
+describe("buildGatewayDiscoveryTarget", () => {
+  it("builds ws and ssh targets from a resolved beacon", () => {
+    const target = buildGatewayDiscoveryTarget(
+      { instanceName: "Gateway", host: "studio.example", port: 18789, sshPort: 2222 },
+      { sshUser: "steipete" },
+    );
+
+    expect(target.wsUrl).toBe("ws://studio.example:18789");
+    expect(target.sshTarget).toBe("steipete@studio.example:2222");
+  });
+
+  it("yields no targets for a beacon carrying only TXT hints", () => {
+    // TXT records are published by anyone on the discovery network. Without a
+    // resolved SRV/A endpoint there is nothing authenticated to connect to.
+    const target = buildGatewayDiscoveryTarget(
+      {
+        instanceName: "txt-only",
+        tailnetDns: "attacker.tailnet.ts.net",
+        lanHost: "attacker.example.com",
+        gatewayPort: 19443,
+      },
+      { sshUser: "steipete" },
+    );
+
+    expect(target.endpoint).toBeNull();
+    expect(target.wsUrl).toBeNull();
+    expect(target.sshTarget).toBeNull();
+  });
+
+  it("refuses a resolved host ssh(1) would parse as an option", () => {
+    const target = buildGatewayDiscoveryTarget(
+      { instanceName: "hostile", host: "-oProxyCommand=touch~hacked", port: 18789 },
+      { sshUser: "steipete" },
+    );
+
+    expect(target.sshTarget).toBeNull();
+  });
+
+  it("omits the port suffix for the default ssh port and when none is advertised", () => {
+    const withDefault = buildGatewayDiscoveryTarget(
+      { instanceName: "Gateway", host: "studio.example", port: 18789, sshPort: 22 },
+      { sshUser: "steipete" },
+    );
+    const withNone = buildGatewayDiscoveryTarget(
+      { instanceName: "Gateway", host: "studio.example", port: 18789 },
+      { sshUser: "steipete" },
+    );
+
+    expect(withDefault.sshTarget).toBe("steipete@studio.example");
+    expect(withNone.sshTarget).toBe("steipete@studio.example");
+  });
+
+  it("drops the user prefix when no ssh user is known", () => {
+    const target = buildGatewayDiscoveryTarget({
+      instanceName: "Gateway",
+      host: "studio.example",
+      port: 18789,
+    });
+
+    expect(target.sshTarget).toBe("studio.example");
+  });
+});
+
+describe("serializeGatewayDiscoveryBeacon", () => {
+  it("reports the raw TXT hints but a null wsUrl when nothing resolved", () => {
+    const beacon: GatewayBonjourBeacon = {
+      instanceName: "txt-only",
+      tailnetDns: "attacker.tailnet.ts.net",
+      lanHost: "attacker.example.com",
+      gatewayPort: 19443,
+    };
+
+    // The hints stay visible for diagnostics; only the actionable URL is
+    // withheld, so an operator can still see what was advertised.
+    expect(serializeGatewayDiscoveryBeacon(beacon)).toMatchObject({
+      tailnetDns: "attacker.tailnet.ts.net",
+      lanHost: "attacker.example.com",
+      gatewayPort: 19443,
+      host: null,
+      wsUrl: null,
+    });
+  });
+});

--- a/src/infra/gateway-discovery-targets.ts
+++ b/src/infra/gateway-discovery-targets.ts
@@ -5,6 +5,7 @@ import {
   type GatewayBonjourBeacon,
   type GatewayDiscoveryResolvedEndpoint,
 } from "./bonjour-discovery.js";
+import { isUnsafeSshHost } from "./ssh-host-safety.js";
 
 // Gateway discovery targets turn Bonjour beacons into display, websocket, and
 // SSH connection hints without assuming every beacon has all fields.
@@ -31,7 +32,10 @@ export function buildGatewayDiscoveryTarget(
   const endpoint = resolveGatewayDiscoveryEndpoint(beacon);
   const sshPort = pickSshPort(beacon);
   const sshUser = normalizeOptionalString(opts?.sshUser) ?? "";
-  const baseSshTarget = endpoint ? (sshUser ? `${sshUser}@${endpoint.host}` : endpoint.host) : null;
+  // A beacon's host comes from whoever is on the discovery network, so it is
+  // attacker-influenceable before it can be handed to a tunnel.
+  const sshHost = endpoint && !isUnsafeSshHost(endpoint.host) ? endpoint.host : null;
+  const baseSshTarget = sshHost ? (sshUser ? `${sshUser}@${sshHost}` : sshHost) : null;
   const sshTarget =
     baseSshTarget && sshPort && sshPort !== 22 ? `${baseSshTarget}:${sshPort}` : baseSshTarget;
   return {

--- a/src/infra/ssh-host-safety.test.ts
+++ b/src/infra/ssh-host-safety.test.ts
@@ -1,0 +1,37 @@
+// Covers the shared SSH host denylist used by the tunnel parser and discovery.
+import { describe, expect, it } from "vitest";
+import { isUnsafeSshHost } from "./ssh-host-safety.js";
+
+describe("isUnsafeSshHost", () => {
+  it("rejects hosts ssh(1) would parse as an option", () => {
+    expect(isUnsafeSshHost("-V")).toBe(true);
+    expect(isUnsafeSshHost("-oProxyCommand=touch /tmp/pwned")).toBe(true);
+    expect(isUnsafeSshHost("-oproxycommand=x")).toBe(true);
+    expect(isUnsafeSshHost("-J")).toBe(true);
+  });
+
+  it("rejects hosts with a stray leading or trailing colon", () => {
+    expect(isUnsafeSshHost(":22")).toBe(true);
+    expect(isUnsafeSshHost("host:")).toBe(true);
+  });
+
+  it("rejects empty and whitespace-bearing hosts", () => {
+    expect(isUnsafeSshHost("")).toBe(true);
+    expect(isUnsafeSshHost("host name")).toBe(true);
+    expect(isUnsafeSshHost("host\tname")).toBe(true);
+    expect(isUnsafeSshHost("host\nname")).toBe(true);
+  });
+
+  // Regression guard: an interior hyphen is ordinary in a hostname. A denylist
+  // that rejects '-' anywhere rather than only in the leading position would
+  // break most real tailnet and LAN names while still reading as "hardened".
+  it("accepts ordinary hostnames, including hyphenated labels", () => {
+    expect(isUnsafeSshHost("studio")).toBe(false);
+    expect(isUnsafeSshHost("peters-mac-studio-1.sheep-coho.ts.net")).toBe(false);
+    expect(isUnsafeSshHost("my-host.example.com")).toBe(false);
+    expect(isUnsafeSshHost("host-")).toBe(false);
+    expect(isUnsafeSshHost("192.168.1.10")).toBe(false);
+    expect(isUnsafeSshHost("100.64.0.9")).toBe(false);
+    expect(isUnsafeSshHost("under_score")).toBe(false);
+  });
+});

--- a/src/infra/ssh-host-safety.ts
+++ b/src/infra/ssh-host-safety.ts
@@ -1,0 +1,26 @@
+// Rejects hostnames that ssh(1) would not treat as a host.
+//
+// A leading '-' is the dangerous case: ssh parses the argument as an option, so
+// a host of "-oProxyCommand=..." becomes remote code execution. A leading or
+// trailing ':' produces an invalid HostName (e.g. sliced from "host::22"), and
+// whitespace cannot appear in a hostname at all, so its presence means the
+// value was mangled or injected somewhere upstream. An empty host is rejected
+// here too, so callers get one guard rather than a separate emptiness check.
+//
+// Deliberately NOT a full hostname/IP grammar allowlist. ssh_config aliases are
+// user-defined and may legitimately contain characters a strict grammar would
+// reject, so this stays a denylist of the shapes that are actually dangerous or
+// structurally invalid.
+
+const HOST_WHITESPACE_PATTERN = /\s/;
+
+/** True when `host` must not be used as an SSH host. */
+export function isUnsafeSshHost(host: string): boolean {
+  return (
+    host.length === 0 ||
+    host.startsWith("-") ||
+    host.startsWith(":") ||
+    host.endsWith(":") ||
+    HOST_WHITESPACE_PATTERN.test(host)
+  );
+}

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -5,6 +5,7 @@ import { normalizeStringEntries } from "../shared/string-normalization.js";
 import { formatErrorMessage, isErrno } from "./errors.js";
 import { parseStrictPositiveInteger } from "./parse-finite-number.js";
 import { ensurePortAvailable, PortInUseError } from "./ports.js";
+import { isUnsafeSshHost } from "./ssh-host-safety.js";
 
 export type SshParsedTarget = {
   user?: string;
@@ -20,13 +21,6 @@ export type SshTunnel = {
   stderr: string[];
   stop: () => Promise<void>;
 };
-
-// Reject hosts that would corrupt the SSH HostName field or enable argument
-// injection: a leading '-' becomes an ssh option, and a stray leading/trailing
-// ':' (e.g. sliced from "host::22") produces an invalid HostName.
-function isMalformedHost(host: string): boolean {
-  return host.startsWith("-") || host.startsWith(":") || host.endsWith(":");
-}
 
 export function parseSshTarget(raw: string): SshParsedTarget | null {
   const trimmed = raw.trim().replace(/^ssh\s+/, "");
@@ -51,7 +45,7 @@ export function parseSshTarget(raw: string): SshParsedTarget | null {
     if (!host || port === undefined || port > 65535) {
       return null;
     }
-    if (isMalformedHost(host)) {
+    if (isUnsafeSshHost(host)) {
       return null;
     }
     return { user: userPart, host, port };
@@ -60,7 +54,7 @@ export function parseSshTarget(raw: string): SshParsedTarget | null {
   if (!hostPart) {
     return null;
   }
-  if (isMalformedHost(hostPart)) {
+  if (isUnsafeSshHost(hostPart)) {
     return null;
   }
   return { user: userPart, host: hostPart, port: 22 };


### PR DESCRIPTION
Closes #3093.

Fixes the 6 confirmed defect clusters in `src/commands/**`. All are trust-boundary
failures on externally-influenced input: a host from a discovery beacon or a remote
URL, a URL handed to an OS handler, a path handed to a PATH-resolved binary.

## Severity correction (please read before reviewing as an RCE fix)

The issue frames cluster 1 as a discovery-supplied `-`-prefixed host reaching the
`ssh` argv **as a flag**. It does **not**, today. Two sink guards in
`src/infra/ssh-tunnel.ts` hold:

- `:112-114` re-parses the target via `parseSshTarget`, whose malformed-host check
  already rejects a leading `-`, and throws `invalid SSH target` otherwise;
- `:154` pushes `"--"` before `user@host`, so even a host that got through is an
  operand, not an option.

Verified against the local OpenSSH (`OpenSSH_10.2p1`): `ssh -G -- '-oProxyCommand=…'`
→ `hostname contains invalid characters`; the same string **without** `--` is parsed
as an option. So this PR is **missing boundary validation / defence in depth**, not a
live RCE. It is still worth fixing — the guard is what the already-committed tests
assert, and the boundary is one `--` away from being load-bearing.

## Why the tests were already failing

`src/commands/gateway-status/discovery.ts` and `src/infra/gateway-discovery-targets.ts`
already existed in the fork, fully hardened and fork-native — as **dead code**. Upstream
syncs brought in the tests and the hardened helpers; `gateway-status.ts` was never
rewired to them and kept its own unhardened duplicates. Because **no CI lane collects
`src/commands/**`**, the drift was invisible. Clusters 1–3 are therefore mostly a
rewiring job, not new implementation: `gateway-status.ts` loses 98 lines of duplicated
helpers and gains the hardened ones.

## What changed

| Cluster | Fix |
|---|---|
| 1. SSH argument injection | New `src/infra/ssh-host-safety.ts` — one `isUnsafeSshHost()` used by `ssh-tunnel.ts`, `gateway-discovery-targets.ts`, and `gateway-status/discovery.ts`. `new URL("wss://-oProxyCommand=x:18789").hostname` is `"-oproxycommand=x"`: the WHATWG host parser permits a leading `-`, so a parsed hostname is not a validated host. Also re-validated after `ssh_config` resolution, since `HostName` can rewrite it. |
| 2. ssh-auto trusted TXT-only beacons | `gateway-status.ts` now calls `pickAutoSshTargetFromDiscovery`, which requires a **resolved** endpoint. TXT hints (`tailnetDns` / `lanHost`) are publishable by anyone on the discovery network and are no longer an auto-target fallback. |
| 3. `wsUrl` trusted TXT-only metadata | Same — `serializeGatewayDiscoveryBeacon` replaces the inline `b.tailnetDns \|\| b.lanHost \|\| b.host` builder. |
| 4. Interface-discovery throws escaped | `buildNetworkHints` / `resolveControlUiLinks` now use the `inspectBestEffortPrimaryTailnetIPv4` / `pickBestEffortPrimaryLanIPv4` probes instead of the throwing `pick*` pair. |
| 5. Windows browser launch | `cmd /c start` re-parses the URL through the shell, where `&` in an OAuth query string splits it into further commands. Replaced with `rundll32.exe url.dll,FileProtocolHandler` at an absolute `%SystemRoot%` path (the pattern #3077 established), plus an `http:`/`https:`-only scheme allowlist on `openUrl` / `openUrlInBackground`. |
| 6. `moveToTrash` PATH-spawn | New `src/infra/fs-safe-trash.ts` — subprocess-free move, no PATH-resolved `trash` binary, canonicalizes the parent, and refuses a target that resolves outside the caller's allowed roots. |

## Evidence — local only, because CI cannot show it

`src/commands/**` is collected by no CI lane (that lane is #3076's keystone and is
maintainer-gated; **this PR deliberately does not wire it** — a lane wired while 244
tests fail would block every merge in the repo). So the `src/commands` numbers below
are local runs, quoted verbatim.

**Target suites** — `vitest.config.ts --pool=forks`, `src/commands/gateway-status.test.ts`
+ `src/commands/onboard-helpers.test.ts`:

```
before: Tests  32 failed | 32 passed (64)
after:  Tests  20 failed | 44 passed (64)
```

Set-diff of the failing test names before vs after: **12 fixed, 0 newly failing.** The
remaining 20 are the out-of-scope failures the issue's own triage classifies as harness
rot / fork-decision divergence.

**New tests** — 4 files, 25 passed. Three of them *do* run in CI
(`src/infra/ssh-host-safety.test.ts`, `src/infra/fs-safe-trash.test.ts`,
`src/infra/gateway-discovery-targets.test.ts`), so the guard itself is CI-covered even
though its `src/commands` call site is not.

**Mutation check on the anchor guard** — reverting `isUnsafeSshHost` in
`inferSshTargetFromRemoteUrl` fails the test rather than passing vacuously:

```
AssertionError: expected 'steipete@-v' to be null
```

**Repo gates:**

| Gate | Result |
|---|---|
| Full CI unit lane (`vitest.unit.config.ts`) | 1054 files / 10256 tests passed, exit 0 |
| `./node_modules/.bin/tsgo --noEmit` | exit 0, no output |
| `pnpm check` | exit 0 — `oxlint --type-aware`: "Found 0 warnings and 0 errors" |
| rebrand / zombie-import / stub-debt / throwing-stub-callers / obsolescence / attestations / raw-channel-fetch | all exit 0 |

Two intermittent failures appeared across four full-lane runs and did not reproduce: an
`EPIPE` in `src/secrets/resolve.ts` and an `ENOENT` on a transient
`extensions/zalouser/__rootdir_boundary_canary__.ts` created by
`scripts/check-extension-*-boundary.mjs`. Neither file is in this diff; both suites pass
in isolation.

## Review note — a defect the adversarial reviewer caught in my own code

The first version of the containment check derived `allowedRoots` from the target itself,
which made `isPathInside(dirname(X), X)` trivially true and the symlink branch dead code.
It now checks the **fully-resolved** target (a symlink pointing outside every root is
genuinely refused — there is a test), and the comments in both files were rewritten to
state what is actually guaranteed instead of overclaiming. Three further corrections came
out of the same pass: an EXDEV `fs.cp` + `fs.rm` fallback (`fs.rename` cannot cross
filesystems, so state on a separate mount would silently not be trashed — a regression vs
the `trash` CLI), an always-random collision suffix (`fs.rename` replaces silently, so
lstat-then-decide could destroy an earlier trashed item), and XDG-for-linux-only in
`resolveTrashDir` (`.local/share/Trash` is not the Windows Recycle Bin).

`movePathToTrash` deliberately shares a name with `infra/trash.ts`'s export; the header
comment says so. The two are not interchangeable — see below.

## Not fixed — needs an operator decision

These are real, same-class, and **outside the issue's 6**. Flagged rather than fixed
because each is a design call, not a mechanical hardening:

1. **`src/commands/onboard-remote.ts` still trusts TXT hints.** `pickHost` (`:12-14`)
   falls back to `beacon.tailnetDns || beacon.lanHost`, and it reaches two sinks:
   - `:118` builds `wss://${host}:${port}` and `:145` uses it as the **pre-filled default**
     of the URL prompt. It is user-confirmable, not a silent persist — but a pre-filled
     default is the value most users accept, and the validator it then passes
     (`validateGatewayWebSocketUrl`, `:34-50`) only checks the scheme and
     `isSecureWebSocketUrl`; it never validates the host. Accepting the default persists
     an attacker-influenced host into `gateway.remote.url`.
   - `:132` prints a copy-paste `ssh -N -L 18789:127.0.0.1:18789 <user>@${host}` line — a
     TXT value containing `;` or backticks lands in the user's shell when they paste it.

   Neither is an ssh argv this code builds, so it is a different (and weaker) shape than
   cluster 1. Choosing the right UX for a TXT-only beacon in an interactive wizard is a
   product decision, not a mechanical fix.
2. **`src/infra/trash.ts` still spawns a PATH-resolved `trash`.** Its live callers include
   the gateway RPC `src/gateway/server-methods/agents.ts` — a **more exposed** sink than
   the onboarding wizard this PR hardened. Migrating it to `movePathToTrash` is
   mechanical; deciding whether the browser-profile mover should stop honoring a
   user-installed `trash` is not.
3. **`src/infra/bonjour-discovery.ts:311,420`** pass unvalidated mDNS/PTR strings in argv
   position to `dns-sd -L` and `dig … SRV`. No shell is involved, so this is
   option-injection, not command-injection — a narrower class, but the same missing
   validation.
4. `sanitizeSshTarget` (`gateway-status/helpers.ts:138`) uses `/^ssh\\s+/` — the escaped
   backslash means it never strips an `ssh ` prefix the way `parseSshTarget`'s `/^ssh\s+/`
   does. Cosmetic, not a security issue.
5. `src/commands/onboard-helpers.ts` is now 506 LOC vs the ~500 advisory (`check:loc`, in
   no CI job, 552 pre-existing offenders). Not split — churn on a security PR is the worse
   trade.
6. The EXDEV fallback branch is not unit-tested (needs a mocked `fs.rename` or a second
   filesystem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
