### PR TITLE
test(e2e): restore gateway e2e harness with a fork-native test instance (#3080)

### DIFF
--- a/test/helpers/remoteclaw-test-instance.ts
+++ b/test/helpers/remoteclaw-test-instance.ts
@@ -1,0 +1,371 @@
+// Spawns an isolated RemoteClaw gateway process against a throwaway home for e2e tests.
+//
+// Fork-native, deliberately minimal: it covers exactly the surface
+// `gateway-e2e-harness.ts` consumes. Upstream's `openclaw-test-instance.ts` is NOT
+// portable here — it builds on `src/test-utils/openclaw-test-state.ts`, which imports
+// `src/state/*` and `src/agents/auth-profiles/sqlite.js`. This fork has no `src/state/`
+// directory at all, so adopting it would mean porting a gutted subsystem (#3080).
+import { type ChildProcessByStdio, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import type { Readable } from "node:stream";
+import { sleep } from "../../src/utils.js";
+import { createBoundedChildOutput } from "./bounded-child-output.js";
+
+const GATEWAY_START_TIMEOUT_MS = 60_000;
+const GATEWAY_STOP_TIMEOUT_MS = 10_000;
+const GATEWAY_READY_POLL_MS = 25;
+const GATEWAY_READY_PROBE_TIMEOUT_MS = 1_000;
+
+type BoundedOutput = ReturnType<typeof createBoundedChildOutput>;
+type TestChildProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+export type RemoteClawTestInstanceOptions = {
+  name: string;
+  cwd?: string;
+  port?: number;
+  gatewayToken?: string;
+  hookToken?: string;
+  /** Merged over the generated gateway/hooks config before it is written to disk. */
+  config?: Record<string, unknown>;
+  env?: Record<string, string | undefined>;
+  gatewayArgs?: string[];
+  startTimeoutMs?: number;
+  stopTimeoutMs?: number;
+};
+
+export type RemoteClawTestInstance = {
+  name: string;
+  port: number;
+  url: string;
+  hookToken: string;
+  gatewayToken: string;
+  homeDir: string;
+  stateDir: string;
+  configPath: string;
+  env: NodeJS.ProcessEnv;
+  startGateway: () => Promise<void>;
+  stopGateway: () => Promise<void>;
+  logs: () => string;
+  cleanup: () => Promise<void>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeConfig(
+  base: Record<string, unknown>,
+  override: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!override) {
+    return base;
+  }
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const existing = result[key];
+    result[key] = isRecord(existing) && isRecord(value) ? mergeConfig(existing, value) : value;
+  }
+  return result;
+}
+
+async function getFreePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error("failed to bind an ephemeral port");
+  }
+  const { port } = address;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
+/**
+ * Prefers a `dist/` build; falls back to the source runner so an unbuilt tree still works.
+ *
+ * Upstream additionally requires `dist/.buildstamp` + `dist/.runtime-postbuildstamp` to guard
+ * against a partial build. That check is NOT replicated here: this fork's `pnpm build` invokes
+ * neither `scripts/build-stamp.mjs` nor `scripts/runtime-postbuild-stamp.mjs`, so both stamps are
+ * always absent and the condition would never be true — a dead branch that silently forces the
+ * fallback. Verified: `pnpm build` exits 0 and writes `dist/index.js` with neither stamp present.
+ */
+async function resolveGatewayEntrypoint(cwd: string): Promise<string[]> {
+  for (const entrypoint of ["dist/index.js", "dist/index.mjs"]) {
+    try {
+      await fs.access(path.join(cwd, entrypoint));
+      return [entrypoint];
+    } catch {
+      // Try the next built entrypoint, then fall through to the source runner.
+    }
+  }
+  return ["scripts/run-node.mjs"];
+}
+
+function useProcessGroup(): boolean {
+  return process.platform !== "win32";
+}
+
+function signalChild(child: TestChildProcess, signal: NodeJS.Signals): void {
+  if (useProcessGroup() && typeof child.pid === "number") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // The group is already gone; fall back to signalling the child directly.
+    }
+  }
+  child.kill(signal);
+}
+
+function hasExited(child: TestChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function formatLogs(stdout: BoundedOutput, stderr: BoundedOutput): string {
+  return `--- stdout ---\n${stdout.text()}\n--- stderr ---\n${stderr.text()}`;
+}
+
+async function waitForExit(child: TestChildProcess, timeoutMs: number): Promise<boolean> {
+  return await Promise.race([
+    new Promise<boolean>((resolve) => {
+      if (hasExited(child)) {
+        resolve(true);
+        return;
+      }
+      child.once("exit", () => resolve(true));
+    }),
+    sleep(timeoutMs).then(() => false),
+  ]);
+}
+
+async function probeReady(port: number): Promise<boolean> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), GATEWAY_READY_PROBE_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/readyz`, { signal: abort.signal });
+    if (!response.ok) {
+      return false;
+    }
+    const body: unknown = await response.json();
+    return isRecord(body) && body.ready === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function waitForGatewayReady(
+  child: TestChildProcess,
+  stdout: BoundedOutput,
+  stderr: BoundedOutput,
+  port: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    // A dead child can never become ready, so surface its logs instead of polling to the deadline.
+    if (hasExited(child)) {
+      throw new Error(
+        `gateway exited before readiness (code=${String(child.exitCode)} signal=${String(
+          child.signalCode,
+        )})\n${formatLogs(stdout, stderr)}`,
+      );
+    }
+    if (await probeReady(port)) {
+      return;
+    }
+    await sleep(GATEWAY_READY_POLL_MS);
+  }
+  throw new Error(
+    `timeout waiting for gateway readiness on port ${port}\n${formatLogs(stdout, stderr)}`,
+  );
+}
+
+/**
+ * Builds the child env. Note this never touches `process.env` — `gateway.multi.e2e.test.ts`
+ * runs two instances concurrently, so mutating global env would race between them.
+ */
+function createInstanceEnv(params: {
+  homeDir: string;
+  stateDir: string;
+  configPath: string;
+  extraEnv: Record<string, string | undefined>;
+}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: params.homeDir,
+    USERPROFILE: params.homeDir,
+    REMOTECLAW_STATE_DIR: params.stateDir,
+    REMOTECLAW_CONFIG_PATH: params.configPath,
+    // Auth comes from the written config; clear inherited overrides so they cannot win.
+    REMOTECLAW_GATEWAY_TOKEN: "",
+    REMOTECLAW_GATEWAY_PASSWORD: "",
+    REMOTECLAW_SKIP_CHANNELS: "1",
+    REMOTECLAW_SKIP_PROVIDERS: "1",
+    REMOTECLAW_SKIP_GMAIL_WATCHER: "1",
+    REMOTECLAW_SKIP_CRON: "1",
+    REMOTECLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+    REMOTECLAW_SKIP_CANVAS_HOST: "1",
+    REMOTECLAW_SKIP_ONBOARDING: "1",
+    REMOTECLAW_TEST_MINIMAL_GATEWAY: "1",
+    VITEST: "1",
+  };
+  if (process.platform === "win32") {
+    const match = params.homeDir.match(/^([A-Za-z]:)(.*)$/u);
+    if (match) {
+      env.HOMEDRIVE = match[1];
+      env.HOMEPATH = match[2] || "\\";
+    }
+  }
+  for (const [key, value] of Object.entries(params.extraEnv)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+/** Creates an isolated gateway instance; call `startGateway()` to boot it. */
+export async function createRemoteClawTestInstance(
+  options: RemoteClawTestInstanceOptions,
+): Promise<RemoteClawTestInstance> {
+  const cwd = options.cwd ?? process.cwd();
+  const port = options.port ?? (await getFreePort());
+  const gatewayToken = options.gatewayToken ?? `gateway-${options.name}-${randomUUID()}`;
+  const hookToken = options.hookToken ?? `token-${options.name}-${randomUUID()}`;
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), `remoteclaw-e2e-${options.name}-`));
+  const homeDir = path.join(root, "home");
+  const stateDir = path.join(homeDir, ".remoteclaw");
+  const workspaceDir = path.join(root, "workspace");
+  const configPath = path.join(stateDir, "remoteclaw.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    `${JSON.stringify(
+      mergeConfig(
+        {
+          gateway: {
+            port,
+            auth: { mode: "token", token: gatewayToken },
+            controlUi: { enabled: false },
+          },
+          hooks: { enabled: true, token: hookToken, path: "/hooks" },
+          // Fork-specific: `startGatewayServer` resolves the default workspace from the first
+          // `agents.list` entry and throws "No agents configured" without one
+          // (`src/gateway/server.impl.ts:293-298`). Upstream's harness needs no equivalent.
+          agents: { list: [{ id: "main", workspace: workspaceDir }] },
+        },
+        options.config,
+      ),
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+
+  const stdout = createBoundedChildOutput();
+  const stderr = createBoundedChildOutput();
+  const env = createInstanceEnv({
+    homeDir,
+    stateDir,
+    configPath,
+    extraEnv: options.env ?? {},
+  });
+
+  let child: TestChildProcess | undefined;
+  let cleaned = false;
+
+  const instance: RemoteClawTestInstance = {
+    name: options.name,
+    port,
+    url: `ws://127.0.0.1:${port}`,
+    hookToken,
+    gatewayToken,
+    homeDir,
+    stateDir,
+    configPath,
+    env,
+    startGateway: async () => {
+      if (child && !hasExited(child) && !child.killed) {
+        return;
+      }
+      const entrypoint = await resolveGatewayEntrypoint(cwd);
+      child = spawn(
+        "node",
+        [
+          ...entrypoint,
+          "gateway",
+          "--port",
+          String(port),
+          "--bind",
+          "loopback",
+          "--allow-unconfigured",
+          ...(options.gatewayArgs ?? []),
+        ],
+        {
+          cwd,
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+          detached: useProcessGroup(),
+        },
+      ) as TestChildProcess;
+
+      child.stdout.on("data", (chunk) => stdout.append(chunk));
+      child.stderr.on("data", (chunk) => stderr.append(chunk));
+
+      try {
+        await waitForGatewayReady(
+          child,
+          stdout,
+          stderr,
+          port,
+          options.startTimeoutMs ?? GATEWAY_START_TIMEOUT_MS,
+        );
+      } catch (err) {
+        await instance.stopGateway();
+        throw err;
+      }
+    },
+    stopGateway: async () => {
+      if (!child) {
+        return;
+      }
+      const stopTimeoutMs = options.stopTimeoutMs ?? GATEWAY_STOP_TIMEOUT_MS;
+      if (!hasExited(child) && !child.killed) {
+        signalChild(child, "SIGTERM");
+      }
+      let exited = await waitForExit(child, stopTimeoutMs);
+      if (!exited && !hasExited(child)) {
+        signalChild(child, "SIGKILL");
+        exited = await waitForExit(child, stopTimeoutMs);
+      }
+      if (exited) {
+        child = undefined;
+      }
+    },
+    logs: () => formatLogs(stdout, stderr),
+    cleanup: async () => {
+      if (cleaned) {
+        return;
+      }
+      cleaned = true;
+      await instance.stopGateway();
+      await fs.rm(root, { recursive: true, force: true });
+    },
+  };
+
+  return instance;
+}


### PR DESCRIPTION
Closes #3080.

## What this does

Adds `test/helpers/remoteclaw-test-instance.ts`, the module
`test/helpers/gateway-e2e-harness.ts` has been importing since the rebrand but that never
existed. One new file; nothing else in the repo changes.

**`test/gateway.multi.e2e.test.ts` now collects _and_ passes.**

```
$ node ./node_modules/vitest/vitest.mjs run --config vitest.e2e.config.ts test/gateway.multi
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  20.12s
```

## Why not port the upstream helper

The issue comment proposed porting upstream's two files and assessed
*"Feasibility: GOOD — no gutted-layer coupling."* **That assessment is wrong**, and it is worth
recording why so nobody re-derives it. It examined the *instance* file's gateway-spawn path — which
is indeed clean — but not the *state* file it depends on. `src/test-utils/openclaw-test-state.ts`
imports:

| upstream import | fork |
|---|---|
| `../state/openclaw-agent-db.js` | **`src/state/` does not exist at all** |
| `../state/openclaw-state-db.js` | missing |
| `../state/openclaw-state-db.paths.js` | missing |
| `../agents/auth-profiles/sqlite.js` | missing |
| `./session-state-cleanup.js` | missing |

So "port two files" is really "port a gutted subsystem". The fork-native helper covers exactly the
surface the harness consumes instead.

## Three deltas from upstream, each grounded rather than assumed

1. **No build-stamp gate.** Upstream requires `dist/.buildstamp` + `dist/.runtime-postbuildstamp`.
   This fork's `pnpm build` invokes neither `scripts/build-stamp.mjs` nor
   `scripts/runtime-postbuild-stamp.mjs`, so both are *always* absent — replicating the check would
   be a dead branch permanently forcing the fallback. Verified: `pnpm build` exits 0, writes
   `dist/index.js`, neither stamp present.
2. **Seeds `agents.list`.** `src/gateway/server.impl.ts:293-298` throws `No agents configured`
   without a resolvable first-agent workspace. Upstream has no equivalent gate; without this the
   gateway exits 1 before readiness.
3. **Never mutates `process.env`.** The test boots two gateways concurrently, so global env
   mutation would race. The child env is built per instance.

## Verification

| Gate | Result |
|---|---|
| `vitest list … test/gateway.multi` | exit 0, test enumerated (the issue's bar) |
| `vitest run … test/gateway.multi` | **1 passed**, exit 0, 20.12s |
| `oxfmt --check` (new file) | PASS |
| `oxlint --type-aware` (3 files, 145 rules) | 0 warnings, 0 errors |
| `tsgo -p test/tsconfig.json` | **382 → 381** errors; `TS2307 Cannot find module` gone; **0 errors in the new file** |
| `check-stub-debt.mjs` | exit 0 |
| `check-throwing-stub-callers.mjs` | exit 0, 0 violations |

The 382→381 delta was proven by hiding the new file, re-running, and diffing — not inferred. The two
remaining `gateway-e2e-harness.ts` errors (`TS2339`/`TS7006` at line 227) are pre-existing and
untouched: `client.request("node.list", {})` is typed `{}`.

---

## ⚠ Three defects this surfaced — reported, deliberately NOT fixed here

Each is independent of the harness repair; folding any in would make both unreviewable.

### 1. `main` is red — `pnpm check` fails on a stale `#3076` baseline

`pnpm typecheck:scripts` fails with 2 STALE `.scripts-typecheck-baseline` entries for
`scripts/lib/openclaw-release-clawhub-plan.ts`. **This blocks every commit in the repo** (the
`pre-commit` hook runs `pnpm check`); this PR was committed with the hook's own sanctioned
`FAST_COMMIT=1` escape hatch.

Not attributable to this PR: `scripts/tsconfig.json` scopes to `scripts/**`, and this change touches
only `test/**`. The baseline was introduced by this PR's own base commit, `034ecfd4071`
(#3076/#3098) — whose CI run shows **cancelled**, and the next commit on main (`49acde89949`) shows
**failure**. Reproduces with `dist/` parked, so it is not a local build artifact. The gate is working
as designed (a paid-off entry fails as STALE so the ledger drains) — the ledger just needs draining.

### 2. `scripts/runtime-postbuild.mjs` is missing — `pnpm dev` / `remoteclaw` / `tui` are all broken

`scripts/run-node.mjs:37` imports `./runtime-postbuild.mjs`; neither it nor
`scripts/runtime-postbuild-shared.mjs` exists in the fork (both exist upstream). Any entry through
`run-node.mjs` dies at import:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../scripts/runtime-postbuild.mjs'
    imported from .../scripts/run-node.mjs
```

That is `pnpm dev`, `pnpm remoteclaw`, `pnpm remoteclaw:rpc`, `pnpm tui`, `pnpm tui:dev`,
`pnpm gateway:dev`, `pnpm gateway:dev:reset`. `scripts/build-all.mjs:82` also invokes it, but
`pnpm build` does not go through `build-all.mjs`, which is why CI's build job stays green and this
has gone unnoticed.

This is exactly the #3076 dangling-reference class, one level over: that gate checks *config-file*
path literals in `scripts/`, not *module* imports. Worth considering as a gate extension.

Practical consequence here: **the gateway e2e tests require a built `dist/`**, since the source-runner
fallback is dead.

### 3. Two other e2e files still cannot be collected

Unchanged by this PR, listed for the record — see the audit below.

---

## e2e lane audit (issue scope item 2)

`vitest list --config vitest.e2e.config.ts` **aborts entirely** on unresolved imports — before this
PR it enumerated **0** of its tests because 3 files failed to resolve. Now 2 do:

| file | unresolved import | status |
|---|---|---|
| `test/cli-json-stdout.e2e.test.ts` | `remoteclaw/plugin-sdk/test-env` | ❌ still broken |
| `test/gateway.multi.e2e.test.ts` | `./remoteclaw-test-instance.js` | ✅ **fixed here** |
| `test/openshell-sandbox.e2e.test.ts` | `../extensions/openshell/src/backend.js` | ❌ still broken |

Coverage of all 23 `*.e2e.test.ts` files:

| group | count | reached by a lane's `include`? | collects? |
|---|---|---|---|
| `src/**` | 12 | yes — `vitest.e2e.config.ts` | yes (172 cases) |
| `test/**` | 3 | yes — `vitest.e2e.config.ts` | 1 of 3 before this PR, **2 of 3 after** |
| `extensions/**` | 4 | **no** — `vitest.extensions.config.ts` inherits the base `**/*.e2e.test.ts` exclude | yes when forced (29 cases) |
| `ui/**` | 4 | yes — `ui/vitest.config.ts`, but that lane is not in CI | not verified locally (blocked by the known cold-cache `optimizeDeps` failure) |

Separately: **`test/vitest/vitest.e2e.config.ts` is dead.** It is referenced by
`scripts/run-vitest.mjs`, `scripts/test-projects.test-support.mjs`, and
`src/infra/vitest-e2e-config.test.ts`, but both `test/non-isolated-runner.ts` (its *runner*) and
`test/setup-remoteclaw-runtime.ts` (its setup file) are missing, so it cannot execute.

---

## Recommendation on wiring the e2e lane into CI (issue scope item 3)

### ❌ Do not wire it — not in this PR, and not yet in any PR.

Full lane, 13 files (the 2 unresolvable ones excluded), macOS, `dist/` built:

```
 Test Files  7 failed | 6 passed (13)
      Tests  86 failed | 87 passed (173)
   Duration  61.42s
```

**86 of 173 tests fail — 49.7%.** Wiring this today creates a required check that is red on arrival
and blocks every merge, which is precisely the failure mode #3076 exists to prevent.

| failing file | failed / total |
|---|---|
| `src/agents/subagent-announce.format.e2e.test.ts` | 44 / 69 |
| `src/docker-setup.e2e.test.ts` | 20 / 34 |
| `src/cli/program.nodes-basic.e2e.test.ts` | 12 / 25 |
| `src/agents/subagent-registry.archive.e2e.test.ts` | 6 / 7 |
| `src/auto-reply/reply.triggers…native-stop.e2e.test.ts` | 2 / 3 |
| `src/cli/skills-cli.clawhub-install.e2e.test.ts` | 1 / 1 |
| `src/gateway/control-ui-assistant-media.e2e.test.ts` | 1 / 1 |

`test/gateway.multi.e2e.test.ts` is among the 6 passing files.

### Cost and infrastructure (the good news)

The blocker is failure volume, not cost or infrastructure:

- **Runtime: ~62s wall.** Cheap — comparable to existing lanes. CI would use
  `min(2, cpus × 0.25)` workers vs 1 locally, so likely similar or better.
- **No exotic infrastructure.** `src/docker-setup.e2e.test.ts` stubs the `docker` binary rather than
  needing a daemon; `src/daemon/launchd.integration.e2e.test.ts` is `describe.skip`-gated to darwin
  and self-skips on `ubuntu-latest`.
- **One real requirement: a built `dist/`**, because defect 2 above kills the source-runner fallback.
  The lane would need `pnpm build` (or to reuse the `build` job's artifact), unlike existing test
  lanes.

### Suggested order

1. Drain the stale `.scripts-typecheck-baseline` entries so `main` and the pre-commit hook are green
   again (defect 1) — this is blocking everyone right now.
2. Restore `scripts/runtime-postbuild.mjs` (defect 2), which unbreaks `pnpm dev`/`tui`/`remoteclaw`
   and removes the e2e lane's build dependency.
3. Triage the 86 failures — the `src/agents/**` cluster (50 of 86) is one likely-common root cause,
   plausibly gutted-Pi-era signals, matching the quarantine pattern already used for the
   extensions/auto-reply lanes.
4. Only then wire the lane, with a `vitest.quarantine.ts`-style debt ledger for whatever is left, so
   the gate is required-and-green from day one.

Fixing the remaining 2 unresolvable files is worth doing alongside step 3 — until then the lane
cannot even enumerate its own tests without `--exclude` flags.

## Caveat on the local run

All numbers above are from macOS (darwin), not `ubuntu-latest`. The failure *counts* should be
treated as indicative rather than exact for CI — the ~50% failure rate is far too large to be a
platform artifact, but the precise per-file split may differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
