### PR TITLE
security(plugins): refuse npm resolution from the unclaimed @remoteclaw scope (#3075)

### DIFF
--- a/.scripts-typecheck-baseline
+++ b/.scripts-typecheck-baseline
@@ -40,8 +40,6 @@
 1	scripts/gh-read.ts	TS2554	Expected 2 arguments, but got 1.
 1	scripts/lib/android-version.ts	TS2307	Cannot find module './npm-publish-plan.mjs' or its corresponding type declarations.
 1	scripts/lib/ios-version.ts	TS2307	Cannot find module './npm-publish-plan.mjs' or its corresponding type declarations.
-1	scripts/lib/openclaw-release-clawhub-plan.ts	TS2339	Property 'bootstrapCandidates' does not exist on type 'PluginReleasePlan'.
-2	scripts/lib/openclaw-release-clawhub-plan.ts	TS2339	Property 'missingTrustedPublisher' does not exist on type 'PluginReleasePlan'.
 1	scripts/lib/plugin-clawhub-release.ts	TS2307	Cannot find module '../../packages/plugin-package-contract/src/index.ts' or its corresponding type declarations.
 2	scripts/lib/plugin-clawhub-release.ts	TS2322	Type 'import("scripts/lib/plugin-npm-release").PublishablePluginPackage[]' is not assignable to type 'import("scripts/lib/plugin-clawhub-release").PublishablePluginPackage[]'.
 1	scripts/lib/plugin-clawhub-release.ts	TS2339	Property 'publishToClawHub' does not exist on type '{ publishToNpm?: boolean | undefined; }'.

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -32,7 +32,7 @@ const tarTraversalBuffer = fs.readFileSync(path.join(fixturesDir, "tar-traversal
 const tarEvilIdBuffer = fs.readFileSync(path.join(fixturesDir, "tar-evil-id.tar"));
 const tarReservedIdBuffer = fs.readFileSync(path.join(fixturesDir, "tar-reserved-id.tar"));
 const npmPackHooksBuffer = await createTarGzHookPackBuffer({
-  packageName: "@remoteclaw/test-hooks",
+  packageName: "@example/test-hooks",
   hookName: "one-hook",
   hookDescription: "One hook",
   heading: "One Hook",
@@ -441,8 +441,8 @@ describe("installHooksFromNpmSpec", () => {
           code: 0,
           stdout: JSON.stringify([
             {
-              id: "@remoteclaw/test-hooks@0.0.1",
-              name: "@remoteclaw/test-hooks",
+              id: "@example/test-hooks@0.0.1",
+              name: "@example/test-hooks",
               version: "0.0.1",
               filename: packedName,
               integrity: "sha512-hook-test",
@@ -460,7 +460,7 @@ describe("installHooksFromNpmSpec", () => {
 
     const hooksDir = path.join(stateDir, "hooks");
     const result = await installHooksFromNpmSpec({
-      spec: "@remoteclaw/test-hooks@0.0.1",
+      spec: "@example/test-hooks@0.0.1",
       hooksDir,
       logger: { info: () => {}, warn: () => {} },
     });
@@ -469,13 +469,13 @@ describe("installHooksFromNpmSpec", () => {
       return;
     }
     expect(result.hookPackId).toBe("test-hooks");
-    expect(result.npmResolution?.resolvedSpec).toBe("@remoteclaw/test-hooks@0.0.1");
+    expect(result.npmResolution?.resolvedSpec).toBe("@example/test-hooks@0.0.1");
     expect(result.npmResolution?.integrity).toBe("sha512-hook-test");
     expect(fs.existsSync(path.join(result.targetDir, "hooks", "one-hook", "HOOK.md"))).toBe(true);
 
     expectSingleNpmPackIgnoreScriptsCall({
       calls: run.mock.calls,
-      expectedSpec: "@remoteclaw/test-hooks@0.0.1",
+      expectedSpec: "@example/test-hooks@0.0.1",
     });
 
     expect(packTmpDir).not.toBe("");
@@ -486,11 +486,32 @@ describe("installHooksFromNpmSpec", () => {
     await expectUnsupportedNpmSpec((spec) => installHooksFromNpmSpec({ spec }));
   });
 
+  it("refuses hook packs from the unclaimed first-party scope", async () => {
+    // Hook packs reach the registry through installFromValidatedNpmSpecArchive, a
+    // different entry point from plugin installs. Both funnel through the same pack
+    // site, which is why the guard lives there rather than in one caller.
+    const run = vi.mocked(runCommandWithTimeout);
+    run.mockReset();
+
+    const result = await installHooksFromNpmSpec({
+      spec: "@remoteclaw/test-hooks@0.0.1",
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected the unclaimed-scope guard to refuse");
+    }
+    expect(result.error).toContain("not registered");
+    expect(result.error).toContain("dependency confusion");
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("aborts when integrity drift callback rejects the fetched artifact", async () => {
     const run = vi.mocked(runCommandWithTimeout);
     mockNpmPackMetadataResult(run, {
-      id: "@remoteclaw/test-hooks@0.0.1",
-      name: "@remoteclaw/test-hooks",
+      id: "@example/test-hooks@0.0.1",
+      name: "@example/test-hooks",
       version: "0.0.1",
       filename: "test-hooks-0.0.1.tgz",
       integrity: "sha512-new",
@@ -499,7 +520,7 @@ describe("installHooksFromNpmSpec", () => {
 
     const onIntegrityDrift = vi.fn(async () => false);
     const result = await installHooksFromNpmSpec({
-      spec: "@remoteclaw/test-hooks@0.0.1",
+      spec: "@example/test-hooks@0.0.1",
       expectedIntegrity: "sha512-old",
       onIntegrityDrift,
     });
@@ -514,8 +535,8 @@ describe("installHooksFromNpmSpec", () => {
   it("rejects bare npm specs that resolve to prerelease versions", async () => {
     const run = vi.mocked(runCommandWithTimeout);
     mockNpmPackMetadataResult(run, {
-      id: "@remoteclaw/test-hooks@0.0.2-beta.1",
-      name: "@remoteclaw/test-hooks",
+      id: "@example/test-hooks@0.0.2-beta.1",
+      name: "@example/test-hooks",
       version: "0.0.2-beta.1",
       filename: "test-hooks-0.0.2-beta.1.tgz",
       integrity: "sha512-beta",
@@ -523,13 +544,13 @@ describe("installHooksFromNpmSpec", () => {
     });
 
     const result = await installHooksFromNpmSpec({
-      spec: "@remoteclaw/test-hooks",
+      spec: "@example/test-hooks",
       logger: { info: () => {}, warn: () => {} },
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("prerelease version 0.0.2-beta.1");
-      expect(result.error).toContain('"@remoteclaw/test-hooks@beta"');
+      expect(result.error).toContain('"@example/test-hooks@beta"');
     }
   });
 });

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -5,6 +5,10 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import { fileExists } from "./archive.js";
 import { assertCanonicalPathWithinBase } from "./install-safe-path.js";
 import { createNpmProjectInstallEnv } from "./npm-install-env.js";
+import {
+  findUnclaimedNpmScopeForPackageName,
+  formatUnclaimedNpmScopeDependencyError,
+} from "./npm-registry-spec.js";
 
 const INSTALL_BASE_CHANGED_ERROR_MESSAGE = "install base directory changed during install";
 const INSTALL_BASE_CHANGED_ABORT_WARNING =
@@ -22,6 +26,56 @@ type HiddenProjectConfigFile = {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Collects declared dependency names that sit in an npm scope nobody has registered.
+ *
+ * `npm install` below resolves the staged package's own dependencies from the public
+ * registry. That is the same dependency-confusion exposure as installing the package
+ * directly, but it is reached from *every* install lane — including local path and
+ * archive installs, which never touch the npm-spec guard. It also lands after the
+ * code-safety scan has already run against the pre-copy source, so anything fetched
+ * here is never scanned.
+ */
+async function findUnclaimedScopeDependencies(
+  stageDir: string,
+): Promise<{ scope: string; names: string[] } | null> {
+  let manifest: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(
+      await fs.readFile(path.join(stageDir, "package.json"), "utf-8"),
+    ) as unknown;
+    if (!isObjectRecord(parsed)) {
+      return null;
+    }
+    manifest = parsed;
+  } catch {
+    // An unreadable manifest means npm install will fail on its own terms; this
+    // guard has nothing to say about it.
+    return null;
+  }
+
+  const declared = new Set<string>();
+  for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+    const value = manifest[field];
+    if (isObjectRecord(value)) {
+      for (const name of Object.keys(value)) {
+        declared.add(name);
+      }
+    }
+  }
+
+  let scope: string | null = null;
+  const names: string[] = [];
+  for (const name of declared) {
+    const match = findUnclaimedNpmScopeForPackageName(name);
+    if (match) {
+      scope ??= match;
+      names.push(name);
+    }
+  }
+  return scope ? { scope, names: names.toSorted() } : null;
 }
 
 async function sanitizeManifestForNpmInstall(targetDir: string): Promise<void> {
@@ -230,6 +284,15 @@ export async function installPackageDir(params: {
   }
 
   if (params.hasDeps) {
+    const unclaimed = await findUnclaimedScopeDependencies(stageDir);
+    if (unclaimed) {
+      return await fail(
+        formatUnclaimedNpmScopeDependencyError({
+          dependencies: unclaimed.names,
+          scope: unclaimed.scope,
+        }),
+      );
+    }
     try {
       await sanitizeManifestForNpmInstall(stageDir);
       const hiddenProjectNpmConfig = await hideProjectNpmConfigForInstall(stageDir);

--- a/src/infra/npm-pack-install.test.ts
+++ b/src/infra/npm-pack-install.test.ts
@@ -22,7 +22,7 @@ vi.mock("./install-source-utils.js", async () => {
 });
 
 describe("installFromNpmSpecArchive", () => {
-  const baseSpec = "@remoteclaw/test@1.0.0";
+  const baseSpec = "@example/test@1.0.0";
   const baseArchivePath = "/tmp/remoteclaw-test.tgz";
 
   const mockPackedSuccess = (overrides?: {
@@ -84,7 +84,7 @@ describe("installFromNpmSpecArchive", () => {
 
     const result = await installFromNpmSpecArchive({
       tempDirPrefix: "remoteclaw-test-",
-      spec: "@remoteclaw/test@1.0.0",
+      spec: "@example/test@1.0.0",
       timeoutMs: 1000,
       installFromArchive,
     });
@@ -120,8 +120,49 @@ describe("installFromNpmSpecArchive", () => {
     expect(installFromArchive).not.toHaveBeenCalled();
   });
 
+  it("refuses specs in an unclaimed first-party scope before touching the registry", async () => {
+    const installFromArchive = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await installFromNpmSpecArchive({
+      tempDirPrefix: "remoteclaw-test-",
+      // The exact spec this project's own docs told operators to run.
+      spec: "@remoteclaw/discord",
+      timeoutMs: 1000,
+      installFromArchive,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected the unclaimed-scope guard to refuse");
+    }
+    expect(result.error).toContain("not registered");
+    expect(result.error).toContain("dependency confusion");
+    // The whole point: no registry traffic and no extraction. If `npm pack` ran, a
+    // squatter's tarball would already be on disk before any later gate could object.
+    expect(packNpmSpecToArchive).not.toHaveBeenCalled();
+    expect(installFromArchive).not.toHaveBeenCalled();
+  });
+
+  it("still resolves look-alike specs outside the unclaimed scope", async () => {
+    // Guards against over-blocking: the unscoped package is genuinely ours, and
+    // neighbouring scopes belong to other publishers.
+    mockPackedSuccess({ resolvedSpec: "remoteclaw@1.0.0", name: "remoteclaw", version: "1.0.0" });
+    const installFromArchive = vi.fn(async () => ({ ok: true as const }));
+
+    const result = await installFromNpmSpecArchive({
+      tempDirPrefix: "remoteclaw-test-",
+      spec: "remoteclaw@1.0.0",
+      timeoutMs: 1000,
+      installFromArchive,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(packNpmSpecToArchive).toHaveBeenCalledTimes(1);
+    expect(installFromArchive).toHaveBeenCalledTimes(1);
+  });
+
   it("returns resolution metadata and installer result on success", async () => {
-    mockPackedSuccess({ name: "@remoteclaw/test", version: "1.0.0" });
+    mockPackedSuccess({ name: "@example/test", version: "1.0.0" });
     const installFromArchive = vi.fn(async () => ({ ok: true as const, target: "done" }));
 
     const result = await runInstall({
@@ -131,7 +172,7 @@ describe("installFromNpmSpecArchive", () => {
 
     const okResult = expectWrappedOkResult(result, { ok: true, target: "done" });
     expect(okResult.integrityDrift).toBeUndefined();
-    expect(okResult.npmResolution.resolvedSpec).toBe("@remoteclaw/test@1.0.0");
+    expect(okResult.npmResolution.resolvedSpec).toBe("@example/test@1.0.0");
     const resolvedAt = okResult.npmResolution.resolvedAt;
     if (!resolvedAt) {
       throw new Error("expected npm resolution timestamp");
@@ -171,7 +212,7 @@ describe("installFromNpmSpecArchive", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "aborted: npm package integrity drift detected for @remoteclaw/test@1.0.0",
+      error: "aborted: npm package integrity drift detected for @example/test@1.0.0",
     });
     expect(installFromArchive).not.toHaveBeenCalled();
   });
@@ -189,10 +230,10 @@ describe("installFromNpmSpecArchive", () => {
 
     expect(result).toEqual({
       ok: false,
-      error: "aborted: npm package integrity drift detected for @remoteclaw/test@1.0.0",
+      error: "aborted: npm package integrity drift detected for @example/test@1.0.0",
     });
     expect(warn).toHaveBeenCalledWith(
-      "Integrity drift detected for @remoteclaw/test@1.0.0: expected sha512-old, got sha512-new",
+      "Integrity drift detected for @example/test@1.0.0: expected sha512-old, got sha512-new",
     );
     expect(installFromArchive).not.toHaveBeenCalled();
   });
@@ -215,7 +256,7 @@ describe("installFromNpmSpecArchive", () => {
       ok: true,
       archivePath: baseArchivePath,
       metadata: {
-        resolvedSpec: "@remoteclaw/test@latest",
+        resolvedSpec: "@example/test@latest",
         integrity: "sha512-same",
         version: "1.1.0-beta.1",
       },
@@ -224,7 +265,7 @@ describe("installFromNpmSpecArchive", () => {
 
     const result = await installFromNpmSpecArchive({
       tempDirPrefix: "remoteclaw-test-",
-      spec: "@remoteclaw/test@latest",
+      spec: "@example/test@latest",
       timeoutMs: 1000,
       installFromArchive,
     });
@@ -242,7 +283,7 @@ describe("installFromNpmSpecArchive", () => {
       ok: true,
       archivePath: baseArchivePath,
       metadata: {
-        resolvedSpec: "@remoteclaw/test@beta",
+        resolvedSpec: "@example/test@beta",
         integrity: "sha512-same",
         version: "1.1.0-beta.1",
       },
@@ -251,7 +292,7 @@ describe("installFromNpmSpecArchive", () => {
 
     const result = await installFromNpmSpecArchive({
       tempDirPrefix: "remoteclaw-test-",
-      spec: "@remoteclaw/test@beta",
+      spec: "@example/test@beta",
       timeoutMs: 1000,
       installFromArchive,
     });
@@ -271,7 +312,7 @@ describe("installFromNpmSpecArchiveWithInstaller", () => {
       ok: true,
       archivePath: "/tmp/remoteclaw-plugin.tgz",
       metadata: {
-        resolvedSpec: "@remoteclaw/voice-call@1.0.0",
+        resolvedSpec: "@example/voice-call@1.0.0",
         integrity: "sha512-same",
       },
     });
@@ -282,7 +323,7 @@ describe("installFromNpmSpecArchiveWithInstaller", () => {
 
     const result = await installFromNpmSpecArchiveWithInstaller({
       tempDirPrefix: "remoteclaw-test-",
-      spec: "@remoteclaw/voice-call@1.0.0",
+      spec: "@example/voice-call@1.0.0",
       timeoutMs: 1000,
       installFromArchive,
       archiveInstallParams: { pluginId: "voice-call" },
@@ -315,7 +356,7 @@ describe("finalizeNpmSpecArchiveInstall", () => {
       ok: true,
       installResult: { ok: false, error: "install failed" },
       npmResolution: {
-        resolvedSpec: "@remoteclaw/test@1.0.0",
+        resolvedSpec: "@example/test@1.0.0",
         integrity: "sha512-same",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },
@@ -331,7 +372,7 @@ describe("finalizeNpmSpecArchiveInstall", () => {
       ok: true,
       installResult: { ok: true, pluginId: "voice-call" },
       npmResolution: {
-        resolvedSpec: "@remoteclaw/voice-call@1.0.0",
+        resolvedSpec: "@example/voice-call@1.0.0",
         integrity: "sha512-same",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },
@@ -345,7 +386,7 @@ describe("finalizeNpmSpecArchiveInstall", () => {
       ok: true,
       pluginId: "voice-call",
       npmResolution: {
-        resolvedSpec: "@remoteclaw/voice-call@1.0.0",
+        resolvedSpec: "@example/voice-call@1.0.0",
         integrity: "sha512-same",
         resolvedAt: "2026-01-01T00:00:00.000Z",
       },

--- a/src/infra/npm-pack-install.ts
+++ b/src/infra/npm-pack-install.ts
@@ -10,7 +10,9 @@ import {
   resolveNpmIntegrityDriftWithDefaultMessage,
 } from "./npm-integrity.js";
 import {
+  findUnclaimedNpmScope,
   formatPrereleaseResolutionError,
+  formatUnclaimedNpmScopeError,
   isPrereleaseResolutionAllowed,
   parseRegistryNpmSpec,
 } from "./npm-registry-spec.js";
@@ -125,6 +127,24 @@ export async function installFromNpmSpecArchive<TResult extends { ok: boolean }>
         error: "unsupported npm spec",
       };
     }
+    // Fail closed BEFORE any registry traffic. This is the single point every
+    // registry-resolving caller funnels through — plugin install, plugin update,
+    // onboarding, and hook packs — so the refusal cannot be bypassed by a caller
+    // that forgets to run the spec validator first. A spec in an unclaimed
+    // first-party scope cannot be ours, and packing it would hand whoever squatted
+    // the scope in-process execution on the gateway host.
+    //
+    // Deliberately not bypassable via `dangerouslyForceUnsafeInstall`: that flag
+    // means "I reviewed the scanner findings and accept them", which an operator
+    // cannot do for a package whose provenance is the thing in question.
+    const unclaimedScope = findUnclaimedNpmScope(params.spec);
+    if (unclaimedScope) {
+      return {
+        ok: false,
+        error: formatUnclaimedNpmScopeError({ spec: params.spec, scope: unclaimedScope }),
+      };
+    }
+
     // Pack before checking prerelease policy so dist-tag and range specs are
     // evaluated against the version the registry actually resolved.
     const packedResult = await packNpmSpecToArchive({

--- a/src/infra/npm-registry-spec.test.ts
+++ b/src/infra/npm-registry-spec.test.ts
@@ -2,13 +2,18 @@
 import { describe, expect, it } from "vitest";
 import {
   compareRemoteClawReleaseVersions,
+  findUnclaimedNpmScope,
+  findUnclaimedNpmScopeForPackageName,
   formatPrereleaseResolutionError,
+  formatUnclaimedNpmScopeDependencyError,
+  formatUnclaimedNpmScopeError,
   isExactSemverVersion,
   isRemoteClawOrgNpmSpec,
   isRemoteClawStableCorrectionVersion,
   isPrereleaseSemverVersion,
   isPrereleaseResolutionAllowed,
   parseRegistryNpmSpec,
+  UNCLAIMED_FIRST_PARTY_NPM_SCOPES,
   validateRegistryNpmSpec,
 } from "./npm-registry-spec.js";
 
@@ -220,5 +225,84 @@ describe("npm prerelease resolution policy", () => {
         resolvedVersion,
       }),
     ).toContain(expected);
+  });
+});
+
+describe("unclaimed first-party npm scope guard", () => {
+  it.each([
+    "@remoteclaw/discord",
+    "@remoteclaw/slack",
+    "@remoteclaw/whatsapp",
+    "@remoteclaw/discord@1.2.3",
+    "@remoteclaw/discord@latest",
+  ])("refuses %s because the scope is not registered", (spec) => {
+    expect(findUnclaimedNpmScope(spec)).toBe("@remoteclaw");
+  });
+
+  it.each([
+    // The unscoped package IS published by this project — blocking it would be a
+    // self-inflicted outage, so the guard must match the scope segment, not a substring.
+    "remoteclaw",
+    "remoteclaw@1.2.3",
+    "remoteclaw-plugin-yuanbao@2.15.0",
+    // Adjacent scopes belong to other people; over-blocking them is not ours to do.
+    "@remoteclaw-community/discord",
+    // Real third-party catalog entries must keep resolving.
+    "@wecom/wecom-remoteclaw-plugin@2026.5.7",
+    "@tencent-weixin/remoteclaw-weixin@2.4.3",
+  ])("allows %s", (spec) => {
+    expect(findUnclaimedNpmScope(spec)).toBeNull();
+  });
+
+  it("returns null for specs that do not parse, leaving rejection to the validator", () => {
+    expect(findUnclaimedNpmScope("https://evil.example/pkg.tgz")).toBeNull();
+    expect(findUnclaimedNpmScope("@remoteclaw/discord@^1.0.0")).toBeNull();
+    expect(findUnclaimedNpmScope(undefined)).toBeNull();
+    // ...but the validator still rejects them, so nothing is admitted by the pair.
+    expect(validateRegistryNpmSpec("https://evil.example/pkg.tgz")).not.toBeNull();
+    expect(validateRegistryNpmSpec("@remoteclaw/discord@^1.0.0")).not.toBeNull();
+  });
+
+  it("keeps the scope list explicit so registering a scope is a reviewed change", () => {
+    expect(UNCLAIMED_FIRST_PARTY_NPM_SCOPES).toEqual(["@remoteclaw"]);
+  });
+
+  it("explains why the install was refused and how to proceed", () => {
+    const message = formatUnclaimedNpmScopeError({
+      spec: "@remoteclaw/discord",
+      scope: "@remoteclaw",
+    });
+    expect(message).toContain("@remoteclaw/discord");
+    expect(message).toContain("not registered");
+    expect(message).toContain("dependency confusion");
+    // The two routes an operator actually has: bundled channel, or a local build.
+    expect(message).toContain("already bundled");
+    expect(message).toContain("remoteclaw plugins install ./my-plugin");
+  });
+});
+
+describe("unclaimed scope guard for declared dependencies", () => {
+  it.each(["@remoteclaw/telemetry-core", "@remoteclaw/anything"])(
+    "flags dependency name %s",
+    (name) => {
+      expect(findUnclaimedNpmScopeForPackageName(name)).toBe("@remoteclaw");
+    },
+  );
+
+  it.each(["remoteclaw", "@remoteclaw-community/x", "left-pad", "@wecom/plugin"])(
+    "leaves dependency name %s alone",
+    (name) => {
+      expect(findUnclaimedNpmScopeForPackageName(name)).toBeNull();
+    },
+  );
+
+  it("names the offending dependencies and why they are refused", () => {
+    const message = formatUnclaimedNpmScopeDependencyError({
+      dependencies: ["@remoteclaw/a", "@remoteclaw/b"],
+      scope: "@remoteclaw",
+    });
+    expect(message).toContain("@remoteclaw/a, @remoteclaw/b");
+    expect(message).toContain("not registered");
+    expect(message).toContain("dependency confusion");
   });
 });

--- a/src/infra/npm-registry-spec.ts
+++ b/src/infra/npm-registry-spec.ts
@@ -135,6 +135,85 @@ export function isRemoteClawOrgNpmSpec(rawSpec: string | undefined): boolean {
   return parsed?.name.startsWith("@remoteclaw/") === true;
 }
 
+/**
+ * npm scopes this project's docs and channel catalog present as first-party, but
+ * which are NOT registered on the public npm registry.
+ *
+ * A scope nobody owns is a dependency-confusion vector. Our own documentation tells
+ * operators to run `remoteclaw plugins install @remoteclaw/<channel>`; whoever
+ * registers the scope first serves that install, and installed plugins run in-process
+ * with full host capability (no sandbox). So resolution from these scopes fails closed.
+ *
+ * The refusal is scope-wide rather than an allowlist of the names we document: those
+ * names are precisely what a squatter would publish, so allowlisting them would
+ * allowlist the attack. It is also narrower than it looks — only *registry* resolution
+ * is refused. Local path, directory, and tarball installs never consult this list, so
+ * the in-tree `@remoteclaw/*` extensions still install from disk.
+ *
+ * Remove a scope from this list once it is actually registered and its packages are
+ * published by this project. At that point the durable control is `expectedIntegrity`
+ * pinning, which the third-party catalog entries already carry.
+ *
+ * Distinct from `isRemoteClawOrgNpmSpec` above, which asks whether a spec is *ours* —
+ * an ownership question that stays true after the scope is registered. This asks
+ * whether the scope is *unowned on the registry*, which is what gates installs. The two
+ * agree today only by coincidence; do not collapse them.
+ */
+export const UNCLAIMED_FIRST_PARTY_NPM_SCOPES: readonly string[] = ["@remoteclaw"];
+
+/**
+ * Returns the unclaimed first-party scope a spec resolves into, or null when the spec
+ * is safe to resolve from the registry.
+ *
+ * Matches the scope segment only, so the unscoped `remoteclaw` package — which this
+ * project does publish — is unaffected. Unparseable specs return null; they are
+ * rejected separately by `validateRegistryNpmSpec`.
+ */
+export function findUnclaimedNpmScope(rawSpec: string | undefined): string | null {
+  const parsed = rawSpec ? parseRegistryNpmSpec(rawSpec) : null;
+  return parsed ? findUnclaimedNpmScopeForPackageName(parsed.name) : null;
+}
+
+/**
+ * Scope check for a bare package name, as it appears as a key in a `dependencies`
+ * map — where there is no selector to parse.
+ *
+ * Needed because `npm install` resolves a package's own declared dependencies from
+ * the registry, which is the same exposure as installing the package directly: a
+ * plugin depending on `@remoteclaw/anything` would pull a squatted package into its
+ * `node_modules` and import it in-process.
+ */
+export function findUnclaimedNpmScopeForPackageName(name: string): string | null {
+  const trimmed = name.trim();
+  return UNCLAIMED_FIRST_PARTY_NPM_SCOPES.find((scope) => trimmed.startsWith(`${scope}/`)) ?? null;
+}
+
+/** Formats the refusal shown when an installed package declares an unclaimed-scope dependency. */
+export function formatUnclaimedNpmScopeDependencyError(params: {
+  dependencies: readonly string[];
+  scope: string;
+}): string {
+  const list = params.dependencies.join(", ");
+  return (
+    `Refusing to install dependencies for this package: it requires ${list} from the ` +
+    `"${params.scope}" npm scope, which is not registered. Whoever claims that scope would ` +
+    `supply the code, and it would run in-process with no sandbox (dependency confusion). ` +
+    `Ask the package author to depend on a package published under a scope they control.`
+  );
+}
+
+/** Formats the operator-facing refusal shown when a spec targets an unclaimed scope. */
+export function formatUnclaimedNpmScopeError(params: { spec: string; scope: string }): string {
+  return (
+    `Refusing to resolve "${params.spec}" from the public npm registry: the "${params.scope}" ` +
+    `scope is not registered, so any package published under it is not ours and installing it ` +
+    `would run unverified code in-process (dependency confusion). Channels that ship with ` +
+    `RemoteClaw are already bundled — enable the channel in your config instead of installing ` +
+    `it. To install a plugin you built yourself, pass its path or tarball, for example ` +
+    `"remoteclaw plugins install ./my-plugin".`
+  );
+}
+
 /** Validates a registry-only npm spec and returns a user-facing error when rejected. */
 export function validateRegistryNpmSpec(rawSpec: string): string | null {
   const parsed = parseRegistryNpmSpecInternal(rawSpec);

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -714,6 +714,74 @@ describe("installPluginFromArchive", () => {
 });
 
 describe("installPluginFromDir", () => {
+  it("still installs an @remoteclaw/* package from a local directory", async () => {
+    // The other half of the unclaimed-scope guard: only *registry* resolution is
+    // refused. Every bundled channel is named @remoteclaw/*, so installing one from
+    // disk must keep working — otherwise the guard would break the very route its
+    // own error message recommends.
+    const { pluginDir, extensionsDir } = setupInstallPluginFromDirFixture();
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(pluginDir, "package.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(manifest.name).toBe("@remoteclaw/test-plugin");
+
+    vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    const { result } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(`expected local install to succeed, got: ${result.error}`);
+    }
+    expect(result.pluginId).toBe("test-plugin");
+    expect(fs.existsSync(path.join(extensionsDir, "test-plugin", "package.json"))).toBe(true);
+  });
+
+  it("refuses a local package that depends on the unclaimed scope, without running npm", async () => {
+    // The npm-spec guard does not cover this: `npm install` resolves the package's
+    // OWN dependencies from the registry, and it runs after the code-safety scan has
+    // already inspected the pre-copy source. Reached from every lane, including the
+    // local-path install the scope-refusal message recommends.
+    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
+    fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@vendor/looks-legitimate",
+        version: "1.0.0",
+        remoteclaw: { extensions: ["./dist/index.js"] },
+        dependencies: { "@remoteclaw/telemetry-core": "^1.0.0" },
+      }),
+      "utf-8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "dist", "index.js"), "export {};\n", "utf-8");
+
+    const run = vi.mocked(runCommandWithTimeout);
+    run.mockReset();
+
+    const result = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected the dependency guard to refuse");
+    }
+    expect(result.error).toContain("@remoteclaw/telemetry-core");
+    expect(result.error).toContain("not registered");
+    expect(run).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(extensionsDir, "looks-legitimate"))).toBe(false);
+  });
+
   function expectInstalledAsMemoryCognee(
     result: Awaited<ReturnType<typeof installPluginFromDir>>,
     extensionsDir: string,
@@ -1017,8 +1085,8 @@ describe("installPluginFromNpmSpec", () => {
           code: 0,
           stdout: JSON.stringify([
             {
-              id: "@remoteclaw/voice-call@0.0.1",
-              name: "@remoteclaw/voice-call",
+              id: "@example/voice-call@0.0.1",
+              name: "@example/voice-call",
               version: "0.0.1",
               filename: packedName,
               integrity: "sha512-plugin-test",
@@ -1035,7 +1103,7 @@ describe("installPluginFromNpmSpec", () => {
     });
 
     const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/voice-call@0.0.1",
+      spec: "@example/voice-call@0.0.1",
       extensionsDir,
       logger: { info: () => {}, warn: () => {} },
     });
@@ -1043,12 +1111,12 @@ describe("installPluginFromNpmSpec", () => {
     if (!result.ok) {
       return;
     }
-    expect(result.npmResolution?.resolvedSpec).toBe("@remoteclaw/voice-call@0.0.1");
+    expect(result.npmResolution?.resolvedSpec).toBe("@example/voice-call@0.0.1");
     expect(result.npmResolution?.integrity).toBe("sha512-plugin-test");
 
     expectSingleNpmPackIgnoreScriptsCall({
       calls: run.mock.calls,
-      expectedSpec: "@remoteclaw/voice-call@0.0.1",
+      expectedSpec: "@example/voice-call@0.0.1",
     });
 
     expect(packTmpDir).not.toBe("");
@@ -1064,11 +1132,42 @@ describe("installPluginFromNpmSpec", () => {
     }
   });
 
+  it.each([
+    "@remoteclaw/discord",
+    "@remoteclaw/slack",
+    "@remoteclaw/whatsapp",
+    "@remoteclaw/discord@1.2.3",
+  ])("refuses %s: the scope is unclaimed, so the registry cannot be serving ours", async (spec) => {
+    const run = vi.mocked(runCommandWithTimeout);
+    run.mockReset();
+
+    const result = await installPluginFromNpmSpec({
+      spec,
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected the unclaimed-scope guard to refuse");
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.UNCLAIMED_NPM_SCOPE);
+    expect(result.error).toContain("not registered");
+    expect(result.error).toContain("dependency confusion");
+    // No subprocess at all: the refusal lands before `npm pack` is spawned. This is
+    // the property that survives a squatter registering the scope — an install that
+    // fails only because the registry currently 404s is not a control.
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  // The other half of this property — that an @remoteclaw/* package still installs
+  // from a local directory — is asserted in the installPluginFromDir describe above,
+  // where the dependency-install subprocess is mocked appropriately.
+
   it("aborts when integrity drift callback rejects the fetched artifact", async () => {
     const run = vi.mocked(runCommandWithTimeout);
     mockNpmPackMetadataResult(run, {
-      id: "@remoteclaw/voice-call@0.0.1",
-      name: "@remoteclaw/voice-call",
+      id: "@example/voice-call@0.0.1",
+      name: "@example/voice-call",
       version: "0.0.1",
       filename: "voice-call-0.0.1.tgz",
       integrity: "sha512-new",
@@ -1077,7 +1176,7 @@ describe("installPluginFromNpmSpec", () => {
 
     const onIntegrityDrift = vi.fn(async () => false);
     const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/voice-call@0.0.1",
+      spec: "@example/voice-call@0.0.1",
       expectedIntegrity: "sha512-old",
       onIntegrityDrift,
     });
@@ -1101,7 +1200,7 @@ describe("installPluginFromNpmSpec", () => {
     });
 
     const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/not-found",
+      spec: "@example/not-found",
       logger: { info: () => {}, warn: () => {} },
     });
     expect(result.ok).toBe(false);
@@ -1113,8 +1212,8 @@ describe("installPluginFromNpmSpec", () => {
   it("rejects bare npm specs that resolve to prerelease versions", async () => {
     const run = vi.mocked(runCommandWithTimeout);
     mockNpmPackMetadataResult(run, {
-      id: "@remoteclaw/voice-call@0.0.2-beta.1",
-      name: "@remoteclaw/voice-call",
+      id: "@example/voice-call@0.0.2-beta.1",
+      name: "@example/voice-call",
       version: "0.0.2-beta.1",
       filename: "voice-call-0.0.2-beta.1.tgz",
       integrity: "sha512-beta",
@@ -1122,13 +1221,13 @@ describe("installPluginFromNpmSpec", () => {
     });
 
     const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/voice-call",
+      spec: "@example/voice-call",
       logger: { info: () => {}, warn: () => {} },
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("prerelease version 0.0.2-beta.1");
-      expect(result.error).toContain('"@remoteclaw/voice-call@beta"');
+      expect(result.error).toContain('"@example/voice-call@beta"');
     }
   });
 
@@ -1145,8 +1244,8 @@ describe("installPluginFromNpmSpec", () => {
           code: 0,
           stdout: JSON.stringify([
             {
-              id: "@remoteclaw/voice-call@0.0.2-beta.1",
-              name: "@remoteclaw/voice-call",
+              id: "@example/voice-call@0.0.2-beta.1",
+              name: "@example/voice-call",
               version: "0.0.2-beta.1",
               filename: packedName,
               integrity: "sha512-beta",
@@ -1167,7 +1266,7 @@ describe("installPluginFromNpmSpec", () => {
       version: "0.0.1",
     });
     const result = await installPluginFromNpmSpec({
-      spec: "@remoteclaw/voice-call@beta",
+      spec: "@example/voice-call@beta",
       extensionsDir,
       logger: { info: () => {}, warn: () => {} },
     });
@@ -1176,10 +1275,10 @@ describe("installPluginFromNpmSpec", () => {
       return;
     }
     expect(result.npmResolution?.version).toBe("0.0.2-beta.1");
-    expect(result.npmResolution?.resolvedSpec).toBe("@remoteclaw/voice-call@0.0.2-beta.1");
+    expect(result.npmResolution?.resolvedSpec).toBe("@example/voice-call@0.0.2-beta.1");
     expectSingleNpmPackIgnoreScriptsCall({
       calls: run.mock.calls,
-      expectedSpec: "@remoteclaw/voice-call@beta",
+      expectedSpec: "@example/voice-call@beta",
     });
     expect(packTmpDir).not.toBe("");
   });

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -26,7 +26,11 @@ import {
   finalizeNpmSpecArchiveInstall,
   installFromNpmSpecArchiveWithInstaller,
 } from "../infra/npm-pack-install.js";
-import { validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import {
+  findUnclaimedNpmScope,
+  formatUnclaimedNpmScopeError,
+  validateRegistryNpmSpec,
+} from "../infra/npm-registry-spec.js";
 import { extensionUsesSkippedScannerPath, isPathInside } from "../security/scan-paths.js";
 import * as skillScanner from "../security/skill-scanner.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
@@ -55,6 +59,7 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   EMPTY_REMOTECLAW_EXTENSIONS: "empty_remoteclaw_extensions",
   INVALID_REMOTECLAW_EXTENSIONS: "invalid_remoteclaw_extensions",
   NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
+  UNCLAIMED_NPM_SCOPE: "unclaimed_npm_scope",
   PLUGIN_ID_MISMATCH: "plugin_id_mismatch",
   SECURITY_SCAN_BLOCKED: "security_scan_blocked",
   SECURITY_SCAN_FAILED: "security_scan_failed",
@@ -625,6 +630,21 @@ export async function installPluginFromNpmSpec(params: {
       ok: false,
       error: specError,
       code: PLUGIN_INSTALL_ERROR_CODE.INVALID_NPM_SPEC,
+    };
+  }
+
+  // NOT the security boundary — that is the pack site (installFromNpmSpecArchive),
+  // which refuses this spec whether or not this block exists. What this adds is the
+  // typed classification: every other rejection in this function returns a
+  // PLUGIN_INSTALL_ERROR_CODE, and a caller inspecting `code` should be able to tell
+  // "refused, the scope is unowned" from "npm 404" — they are different situations
+  // with different remedies, and only one of them changes if a squatter publishes.
+  const unclaimedScope = findUnclaimedNpmScope(spec);
+  if (unclaimedScope) {
+    return {
+      ok: false,
+      error: formatUnclaimedNpmScopeError({ spec, scope: unclaimedScope }),
+      code: PLUGIN_INSTALL_ERROR_CODE.UNCLAIMED_NPM_SCOPE,
     };
   }
 


### PR DESCRIPTION
Closes the code-side half of #3075. **The npm scope is still unregistered — see § For the maintainer.**

## The problem

Our docs and `scripts/lib/official-external-channel-catalog.json` tell operators to run
`remoteclaw plugins install @remoteclaw/<channel>`. Nobody owns `@remoteclaw` on npm
(`search?text=scope:remoteclaw` → `total = 0`). `src/plugins/install.ts` resolves that spec
through a real `npm pack` against `registry.npmjs.org`, and installed plugins run in-process
with full host capability, no sandbox. Whoever registers the scope first serves those installs.

Two findings from investigation shaped the fix:

1. **`src/plugins/update.ts` has no bundled-first protection.** It calls
   `installPluginFromNpmSpec({ spec: record.spec })` directly (`:266` dry-run probe, `:326` real
   update), so `plugins update` resolves a recorded `@remoteclaw/*` spec straight from the registry.
2. **The CLI's existing bundled fallback is accidental, not designed.**
   `resolveBundledInstallPlanForNpmFailure` fires only on `NPM_PACKAGE_NOT_FOUND` — which is
   returned *only because the scope is currently unclaimed*. The moment a squatter publishes,
   `npm pack` succeeds, no failure occurs, the fallback never runs, and the attacker's package
   installs. A control that works only while the attack hasn't happened is not a control.

## Why a hard refusal (and not the alternatives)

- **Allowlist of known-first-party names — rejected.** The 21 catalogued names are precisely what a
  squatter would publish. Allowlisting them allowlists the attack; it inverts the property.
- **Registry-provenance check — rejected *for now*.** Provenance needs something to verify against:
  a trusted publisher identity or a pinned integrity hash. The scope has no npm org and no published
  tarball, so both prerequisites are exactly what's missing. This is the right control *after* the
  scope is registered.
- **Scope-wide refusal — chosen.** The scope is empty, so *every* resolution from it is necessarily
  not ours: blocking it blocks zero legitimate installs.

## What changed

Two fail-closed choke points, both before any network call:

- **`installFromNpmSpecArchive`** (`src/infra/npm-pack-install.ts`) — the single point every
  registry caller funnels through (plugin install, plugin update, onboarding, hook packs), so the
  refusal can't be bypassed by a caller that skips the spec validator.
- **`installPackageDir`** (`src/infra/install-package-dir.ts`) — refuses a staged package that
  *declares* an unclaimed-scope dependency. This one was found during review and matters: `npm install`
  resolves a package's own `dependencies` from the registry on **every** lane, including the local-path
  install this PR's own error message recommends, and it runs *after* the code-safety scan has inspected
  the pre-copy source — so anything fetched there is never scanned. Verified safe to add: **zero**
  in-tree extensions declare `@remoteclaw/*` runtime dependencies.

`PLUGIN_INSTALL_ERROR_CODE.UNCLAIMED_NPM_SCOPE` gives callers a typed classification distinguishing
"refused, scope unowned" from "npm 404" — different situations, different remedies, and only one of
them changes if a squatter publishes.

## Proof

Attacker case and legitimate case, run against the real unmocked code paths. Note it is the **same
package name** in A and C — the outcome keys on registry-vs-local, which is exactly the intended property.

```
── A. `remoteclaw plugins install @remoteclaw/discord` ──
ok=false  code=unclaimed_npm_scope  elapsed=1ms
error: Refusing to resolve "@remoteclaw/discord" from the public npm registry: the "@remoteclaw"
scope is not registered, so any package published under it is not ours and installing it would run
unverified code in-process (dependency confusion). Channels that ship with RemoteClaw are already
bundled — enable the channel in your config instead of installing it. To install a plugin you built
yourself, pass its path or tarball, for example "remoteclaw plugins install ./my-plugin".

── B. `remoteclaw plugins install ./looks-legitimate` (transitive dep confusion) ──
ok=false
error: Refusing to install dependencies for this package: it requires @remoteclaw/telemetry-core
from the "@remoteclaw" npm scope, which is not registered. Whoever claims that scope would supply
the code, and it would run in-process with no sandbox (dependency confusion). Ask the package author
to depend on a package published under a scope they control.

── C. `remoteclaw plugins install ./discord` (bundled channel route) ──
ok=true  pluginId=discord
on disk: true
```

`elapsed=1ms` in A is the load-bearing detail: the refusal lands before `npm pack` is spawned.
The regression tests assert `runCommandWithTimeout` was never called, not merely that the install failed.

Mutation-tested: deleting the pack-site guard fails 6 targeted tests across all three suites.

## Not blocked (deliberately)

- Unscoped `remoteclaw` — we **do** publish it; the guard matches the scope segment, not a substring.
- Adjacent scopes (`@remoteclaw-community/*`) — not ours to block.
- The 4 third-party catalog entries (`@wecom`, `@tencent-weixin`, `@zalo-platforms`,
  `remoteclaw-plugin-yuanbao`) — all 4 carry `expectedIntegrity`; all 21 `@remoteclaw/*` entries carry none.
- Local path / directory / tarball installs of `@remoteclaw/*` — that's how the 29 bundled channels install.

Case-, encoding- and alias-bypasses (`@RemoteClaw/x`, `%40remoteclaw/x`, `npm:@remoteclaw/x`) are already
rejected upstream by the spec validator.

## Verification

- `./node_modules/.bin/tsgo --noEmit` → exit 0, no diagnostics
- `pnpm lint` → `Found 0 warnings and 0 errors`
- `pnpm format:check` → `All matched files use the correct format`
- unit sweep over `src/infra src/plugins src/cli src/hooks` → **419 files, 4126 passed**, 13 skipped
- `check-no-zombie-imports`, `check-stub-debt`, `check-throwing-stub-callers`, `check-obsolescence-audit`,
  `lint:no-lobster-leak`, `lint:no-dangling-tooling-config-refs`, `lint:ui:no-css-class-drift` → all exit 0

## Separate first commit — please read

`4435364935f` is **unrelated** to this issue and is separated so it can be reviewed or dropped on its own.

`.scripts-typecheck-baseline` (added by #3076) carries two entries for
`scripts/lib/openclaw-release-clawhub-plan.ts`, **a file that does not exist in this fork** — the only
references to that path anywhere in the repo are the two baseline lines themselves. The gate correctly
reports them STALE, failing `pnpm check`, which both the pre-commit hook and the `lint` CI job run. That
blocks *every* commit and *every* PR on `main`, not just this one. #3076's own CI run was cancelled, so
the gate never fired on itself.

The gate is working as designed; the seeded baseline was wrong. Drained via
`node scripts/check-scripts-typecheck.mjs --update`; diff is exactly those two deletions, no new errors
absorbed (72 → 70 lines).

## For the maintainer — what this PR does NOT do

1. **Register the `@remoteclaw` npm scope.** Account action, deliberately not in this PR. Until it's done
   the scope stays squattable; this PR only makes RemoteClaw refuse to *consume* it. **When you do register
   it**, the exit criterion is not simply deleting the guard — add `expectedIntegrity` to the catalog's
   `@remoteclaw/*` entries first, matching what the four third-party entries already do. Dropping the guard
   without pinning removes the only control that exists.
2. **The 25 doc files** still containing `plugins install @remoteclaw/…` are untouched, per scope. No
   regression: those commands already failed (E404), and for bundled channels the bundled-first path still
   absorbs them. One is now a hard failure with a clear message rather than an E404:
   `docs/plugins/memory-lancedb.md:24` documents `@remoteclaw/memory-lancedb`, which has no `extensions/`
   directory.
3. **`failClosedOnNoCoverage: false`** for package installs (`src/plugins/install.ts`) is unchanged — the
   issue flags it as an aggravating factor and explicitly defers it.
4. **Dormant unguarded paths**, zero production callers today, worth knowing before anyone wires one up:
   `src/plugins/marketplace.ts` `installPluginFromMarketplace`, `src/plugins/install-overrides.ts`
   `resolvePluginInstallOverride` (accepts raw `npm:<spec>` with format-only validation),
   `src/plugins/legacy-npm-declaration.ts`.
5. **Pre-existing UX bug, not introduced here:** `src/cli/plugin-install-plan.ts:107` and
   `docs/cli/plugins.md:174` both advise `npm:@remoteclaw/discord` to force an external package — a form the
   spec parser rejects outright. Fails closed, so it's cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
