### PR TITLE
security(discovery): reject dash-prefixed mDNS/DNS values at the producer (#3101)

### DIFF
--- a/src/infra/argv-safety.test.ts
+++ b/src/infra/argv-safety.test.ts
@@ -27,23 +27,43 @@ describe("isArgvOptionLike", () => {
   // composes it, and dig's extra prefixes carry no meaning for ssh(1) or dns-sd,
   // so folding them in here would change the SSH guard's behaviour for no gain.
   // If this ever flips, the ssh host denylist silently widened with it.
-  it("stays narrow: dig's '@' and '+' are not option-like to the shared primitive", () => {
+  it("stays narrow: dig's '+', '%' and '@' are not option-like to the shared primitive", () => {
     expect(isArgvOptionLike("@127.0.0.1")).toBe(false);
     expect(isArgvOptionLike("+tcp")).toBe(false);
+    expect(isArgvOptionLike("%evil")).toBe(false);
   });
 });
 
 describe("isUnsafeDigOperand", () => {
-  // dig(1) reads two prefixes that no other tool here does, and both were probed
-  // against the system dig: '@' selects the nameserver positionally with the LAST
-  // one winning (so an '@'-prefixed query name re-points the query at an
-  // arbitrary host:53), and '+' introduces an option (so '+tcp' in the query-name
-  // slot is consumed as one, collapsing the query name to ".").
-  it("flags dig's nameserver and option prefixes, not just '-'", () => {
-    expect(isUnsafeDigOperand("@127.0.0.1")).toBe(true);
-    expect(isUnsafeDigOperand("@evil.example.com")).toBe(true);
+  // dig(1) reads three prefixes that no other tool here does. All were probed
+  // against the system dig (DiG 9.10.6) with a loopback listener:
+  //   '+' introduces an option, so '+tcp' in the query-name slot is consumed as
+  //       one and the query name collapses to ".".
+  //   '%' is discarded as a positional, so '%evil' collapses the query to a root
+  //       ". IN NS" sent to the ALREADY-PINNED nameserver. No redirect.
+  //   '@' selects the nameserver — see the '@' case below for why that one is
+  //       defence-in-depth rather than a reachable path.
+  // Split per prefix so one failing expect cannot mask the others.
+  it("flags dig's option prefix '+'", () => {
     expect(isUnsafeDigOperand("+tcp")).toBe(true);
     expect(isUnsafeDigOperand("+short")).toBe(true);
+    expect(isUnsafeDigOperand("+tcp._remoteclaw-gw._tcp.example.")).toBe(true);
+  });
+
+  it("flags dig's discarded positional prefix '%'", () => {
+    expect(isUnsafeDigOperand("%evil")).toBe(true);
+    expect(isUnsafeDigOperand("%")).toBe(true);
+    expect(isUnsafeDigOperand("%evil._remoteclaw-gw._tcp.example.")).toBe(true);
+  });
+
+  // Defence-in-depth, deliberately kept. DiG 9.10.6 escapes '@' when printing a
+  // name, so a hostile PTR answer arrives as "\@evil…" and never reaches this
+  // predicate with a bare '@' — the guard is insurance against a dig earlier on
+  // PATH that does not escape it, not a demonstrated path. Only 9.10.6 was
+  // probed, so the escaping is untested elsewhere rather than known-universal.
+  it("flags dig's nameserver selector '@'", () => {
+    expect(isUnsafeDigOperand("@127.0.0.1")).toBe(true);
+    expect(isUnsafeDigOperand("@evil.example.com")).toBe(true);
   });
 
   // Composition with the shared primitive: everything '-' still rejects.
@@ -55,10 +75,11 @@ describe("isUnsafeDigOperand", () => {
 
   // Over-rejection guard. Only the LEADING character is structural to dig; the
   // same characters in any interior position are ordinary data.
-  it("leaves ordinary query names alone, including interior '@' and '+'", () => {
+  it("leaves ordinary query names alone, including interior '+', '%' and '@'", () => {
     expect(isUnsafeDigOperand("studio-gateway._remoteclaw-gw._tcp.example.")).toBe(false);
     expect(isUnsafeDigOperand("studio+lab._remoteclaw-gw._tcp.example.")).toBe(false);
     expect(isUnsafeDigOperand("desk@home._remoteclaw-gw._tcp.example.")).toBe(false);
+    expect(isUnsafeDigOperand("rate%limit._remoteclaw-gw._tcp.example.")).toBe(false);
     expect(isUnsafeDigOperand("peters-mac-studio-1.sheep-coho.ts.net")).toBe(false);
     expect(isUnsafeDigOperand("")).toBe(false);
   });

--- a/src/infra/argv-safety.test.ts
+++ b/src/infra/argv-safety.test.ts
@@ -1,7 +1,7 @@
 // Covers the shared argv-operand denylist used by the SSH host guard and by the
-// mDNS/DNS discovery producers.
+// mDNS/DNS discovery producers, plus the wider dig(1)-specific predicate.
 import { describe, expect, it } from "vitest";
-import { isArgvOptionLike } from "./argv-safety.js";
+import { isArgvOptionLike, isUnsafeDigOperand } from "./argv-safety.js";
 
 describe("isArgvOptionLike", () => {
   it("flags values a tool would parse as an option", () => {
@@ -21,5 +21,45 @@ describe("isArgvOptionLike", () => {
     expect(isArgvOptionLike("Peter’s Mac Studio")).toBe(false);
     expect(isArgvOptionLike("studio-gateway._remoteclaw-gw._tcp.example.")).toBe(false);
     expect(isArgvOptionLike("")).toBe(false);
+  });
+
+  // The load-bearing property of keeping this predicate narrow. `isUnsafeSshHost`
+  // composes it, and dig's extra prefixes carry no meaning for ssh(1) or dns-sd,
+  // so folding them in here would change the SSH guard's behaviour for no gain.
+  // If this ever flips, the ssh host denylist silently widened with it.
+  it("stays narrow: dig's '@' and '+' are not option-like to the shared primitive", () => {
+    expect(isArgvOptionLike("@127.0.0.1")).toBe(false);
+    expect(isArgvOptionLike("+tcp")).toBe(false);
+  });
+});
+
+describe("isUnsafeDigOperand", () => {
+  // dig(1) reads two prefixes that no other tool here does, and both were probed
+  // against the system dig: '@' selects the nameserver positionally with the LAST
+  // one winning (so an '@'-prefixed query name re-points the query at an
+  // arbitrary host:53), and '+' introduces an option (so '+tcp' in the query-name
+  // slot is consumed as one, collapsing the query name to ".").
+  it("flags dig's nameserver and option prefixes, not just '-'", () => {
+    expect(isUnsafeDigOperand("@127.0.0.1")).toBe(true);
+    expect(isUnsafeDigOperand("@evil.example.com")).toBe(true);
+    expect(isUnsafeDigOperand("+tcp")).toBe(true);
+    expect(isUnsafeDigOperand("+short")).toBe(true);
+  });
+
+  // Composition with the shared primitive: everything '-' still rejects.
+  it("still flags everything the shared primitive flags", () => {
+    expect(isUnsafeDigOperand("-f/etc/passwd")).toBe(true);
+    expect(isUnsafeDigOperand("--")).toBe(true);
+    expect(isUnsafeDigOperand("-")).toBe(true);
+  });
+
+  // Over-rejection guard. Only the LEADING character is structural to dig; the
+  // same characters in any interior position are ordinary data.
+  it("leaves ordinary query names alone, including interior '@' and '+'", () => {
+    expect(isUnsafeDigOperand("studio-gateway._remoteclaw-gw._tcp.example.")).toBe(false);
+    expect(isUnsafeDigOperand("studio+lab._remoteclaw-gw._tcp.example.")).toBe(false);
+    expect(isUnsafeDigOperand("desk@home._remoteclaw-gw._tcp.example.")).toBe(false);
+    expect(isUnsafeDigOperand("peters-mac-studio-1.sheep-coho.ts.net")).toBe(false);
+    expect(isUnsafeDigOperand("")).toBe(false);
   });
 });

--- a/src/infra/argv-safety.test.ts
+++ b/src/infra/argv-safety.test.ts
@@ -1,0 +1,25 @@
+// Covers the shared argv-operand denylist used by the SSH host guard and by the
+// mDNS/DNS discovery producers.
+import { describe, expect, it } from "vitest";
+import { isArgvOptionLike } from "./argv-safety.js";
+
+describe("isArgvOptionLike", () => {
+  it("flags values a tool would parse as an option", () => {
+    expect(isArgvOptionLike("-f/etc/passwd")).toBe(true);
+    expect(isArgvOptionLike("-oProxyCommand=touch /tmp/pwned")).toBe(true);
+    expect(isArgvOptionLike("--")).toBe(true);
+    expect(isArgvOptionLike("-")).toBe(true);
+  });
+
+  // Regression guard. These are all values real callers carry: mDNS instance
+  // names are free-form UTF-8 (RFC 6763 §4.1.1) and DNS names have interior
+  // hyphens. A guard that rejected '-' anywhere, or non-ASCII, or spaces, would
+  // break ordinary discovery while still reading as "hardened".
+  it("leaves ordinary operands alone", () => {
+    expect(isArgvOptionLike("Laptop Gateway")).toBe(false);
+    expect(isArgvOptionLike("peters-mac-studio-1.sheep-coho.ts.net")).toBe(false);
+    expect(isArgvOptionLike("Peter’s Mac Studio")).toBe(false);
+    expect(isArgvOptionLike("studio-gateway._remoteclaw-gw._tcp.example.")).toBe(false);
+    expect(isArgvOptionLike("")).toBe(false);
+  });
+});

--- a/src/infra/argv-safety.ts
+++ b/src/infra/argv-safety.ts
@@ -1,20 +1,57 @@
-// Rejects values that a spawned tool would read as an option, not as an operand.
+// Rejects values that a spawned tool would read as syntax rather than as the
+// plain operand the argv slot is meant to carry.
 //
 // Nothing here spawns through a shell (`shouldSpawnWithShell` returns false and
 // callers pass an argv array), so quoting and shell metacharacters are not the
-// risk. The risk is positional: a value that begins with '-' occupies an operand
-// slot but is parsed as a flag, and the tool then does whatever that flag does.
-// Verified against the system dig(1) — `dig +short -f<file> NS` reads <file> as a
-// query list instead of resolving a name.
+// risk. The risk is positional: a value occupies an operand slot, the tool
+// parses it as syntax instead, and then does whatever that syntax means.
 //
-// Deliberately narrow, and deliberately NOT a hostname or DNS-name grammar.
-// Callers carry values that legitimately contain spaces, apostrophes and
-// non-ASCII — mDNS instance names are free-form UTF-8 (RFC 6763 §4.1.1) and
+// The dangerous prefix set is TOOL-DEPENDENT — there is no single universal
+// "unsafe operand" shape:
+//
+//   '-'  Every tool here. `dig +short -f<file> NS` reads <file> as a query list
+//        instead of resolving a name; for ssh(1), `-oProxyCommand=…` is
+//        documented remote code execution.
+//   '@'  dig(1) only, and not a mere parse quirk: '@' selects the nameserver,
+//        positionally, and the LAST one wins. Probed against the system dig(1)
+//        with a loopback listener — `dig +short -p 5354 @127.0.0.2 @127.0.0.1
+//        <name> SRV` delivered the datagram to 127.0.0.1, the second '@'. So an
+//        '@'-prefixed value landing after an already-pinned nameserver
+//        re-points the query at an arbitrary host:53.
+//   '+'  dig(1) only. '+' introduces options, so a value like '+tcp' in the
+//        query-name slot is consumed as one. The same probe showed
+//        `dig … @127.0.0.1 +tcp SRV` switching to TCP and collapsing the query
+//        name to ".".
+//
+// Hence two predicates, and callers pick by the tool they are about to spawn:
+//
+//   `isArgvOptionLike`   Leading '-' only. The narrow shared primitive, used by
+//                        `isUnsafeSshHost` (ssh) and by the dns-sd producer.
+//   `isUnsafeDigOperand` Composes the primitive and adds dig's '@' and '+'.
+//                        Used by the dig producer path only.
+//
+// The dig prefixes are deliberately NOT folded into the shared primitive: '@'
+// and '+' introduce nothing for ssh(1) or dns-sd, so rejecting them there would
+// drop well-formed input for no security gain, and would silently change the
+// behaviour of the ssh host guard — the higher-severity surface of the two.
+//
+// Both stay deliberately narrow, and deliberately NOT a hostname or DNS-name
+// grammar. Callers carry values that legitimately contain spaces, apostrophes
+// and non-ASCII — mDNS instance names are free-form UTF-8 (RFC 6763 §4.1.1) and
 // ssh_config aliases are user-defined — so anything stricter would reject
-// well-formed input while still reading as "hardened". Only the leading '-'
-// is structurally dangerous in an argv operand slot.
+// well-formed input while still reading as "hardened". Only the LEADING
+// character is structural; the same characters are ordinary in any interior
+// position.
 
 /** True when `value` would be parsed as an option in an argv operand slot. */
 export function isArgvOptionLike(value: string): boolean {
   return value.startsWith("-");
+}
+
+/**
+ * True when `value` must not occupy a dig(1) operand slot: an option ('-'),
+ * a nameserver selector ('@'), or a dig option ('+').
+ */
+export function isUnsafeDigOperand(value: string): boolean {
+  return isArgvOptionLike(value) || value.startsWith("@") || value.startsWith("+");
 }

--- a/src/infra/argv-safety.ts
+++ b/src/infra/argv-safety.ts
@@ -10,30 +10,53 @@
 // "unsafe operand" shape:
 //
 //   '-'  Every tool here. `dig +short -f<file> NS` reads <file> as a query list
-//        instead of resolving a name; for ssh(1), `-oProxyCommand=…` is
-//        documented remote code execution.
-//   '@'  dig(1) only, and not a mere parse quirk: '@' selects the nameserver,
-//        positionally, and the LAST one wins. Probed against the system dig(1)
-//        with a loopback listener — `dig +short -p 5354 @127.0.0.2 @127.0.0.1
-//        <name> SRV` delivered the datagram to 127.0.0.1, the second '@'. So an
-//        '@'-prefixed value landing after an already-pinned nameserver
-//        re-points the query at an arbitrary host:53.
+//        instead of resolving a name — probed against the system dig(1) with a
+//        loopback listener, `dig … @127.0.0.1 -f/etc/passwd SRV` sent the
+//        contents of /etc/passwd to the nameserver, one query per token. For
+//        ssh(1), `-oProxyCommand=…` is documented remote code execution.
 //   '+'  dig(1) only. '+' introduces options, so a value like '+tcp' in the
-//        query-name slot is consumed as one. The same probe showed
+//        query-name slot is consumed as one: the same loopback probe showed
 //        `dig … @127.0.0.1 +tcp SRV` switching to TCP and collapsing the query
-//        name to ".".
+//        name to "." ("Connection to 127.0.0.1#5354(127.0.0.1) for . failed").
+//        Reachable — dig prints a PTR answer whose first label is '+' verbatim.
+//   '%'  dig(1) only. Same class as '+' and strictly less impact: dig discards a
+//        leading-'%' positional silently, so `dig … @127.0.0.1 %evil SRV`
+//        collapses to a root ". IN NS" query. Also reachable — '%' is printed
+//        bare. NOT a redirect: that query still goes to the ALREADY-PINNED
+//        nameserver, `parseDigSrv` rejects the non-SRV answer, and the record
+//        drops itself. Driven through the producer against /usr/bin/dig, no
+//        beacon resulted. Rejected because an operand slot should carry the name
+//        it was handed, not because anything is redirected.
+//   '@'  dig(1) only, and defence-in-depth rather than a demonstrated path.
+//        DiG 9.10.6 ESCAPES '@' when it prints a name: a PTR answer whose first
+//        label is "@evil" comes back as "\@evil…", which starts with '\', never
+//        trips this predicate, and which dig then reads as an ordinary 5-label
+//        name sent to the pinned nameserver. Driven through the producer against
+//        /usr/bin/dig, that is exactly what happened. A DNS server therefore
+//        cannot make `dig +short … PTR` emit a bare leading '@'. The check stays
+//        as cheap insurance against a dig earlier on PATH that does not escape
+//        '@'; only DiG 9.10.6 was probed, so that escaping is untested
+//        elsewhere rather than known to be universal.
+//
+// Correcting the record on '@', since an earlier revision of this comment had it
+// wrong: `@127.0.0.2 @127.0.0.1` landing on the second '@' is NOT "the last one
+// wins" — nothing was listening on .2. dig keeps an ORDERED server list and
+// falls back only on failure. With two responsive loopback listeners,
+// `@127.0.0.1 @::1` delivered to 127.0.0.1 and `@::1 @127.0.0.1` delivered to
+// ::1 — the first '@' both times. A trailing '@' could take over only if the
+// pinned nameserver failed first.
 //
 // Hence two predicates, and callers pick by the tool they are about to spawn:
 //
 //   `isArgvOptionLike`   Leading '-' only. The narrow shared primitive, used by
 //                        `isUnsafeSshHost` (ssh) and by the dns-sd producer.
-//   `isUnsafeDigOperand` Composes the primitive and adds dig's '@' and '+'.
+//   `isUnsafeDigOperand` Composes the primitive and adds dig's '+', '%' and '@'.
 //                        Used by the dig producer path only.
 //
-// The dig prefixes are deliberately NOT folded into the shared primitive: '@'
-// and '+' introduce nothing for ssh(1) or dns-sd, so rejecting them there would
-// drop well-formed input for no security gain, and would silently change the
-// behaviour of the ssh host guard — the higher-severity surface of the two.
+// The dig prefixes are deliberately NOT folded into the shared primitive: '+',
+// '%' and '@' introduce nothing for ssh(1) or dns-sd, so rejecting them there
+// would drop well-formed input for no security gain, and would silently change
+// the behaviour of the ssh host guard — the higher-severity surface of the two.
 //
 // Both stay deliberately narrow, and deliberately NOT a hostname or DNS-name
 // grammar. Callers carry values that legitimately contain spaces, apostrophes
@@ -49,9 +72,15 @@ export function isArgvOptionLike(value: string): boolean {
 }
 
 /**
- * True when `value` must not occupy a dig(1) operand slot: an option ('-'),
- * a nameserver selector ('@'), or a dig option ('+').
+ * True when `value` must not occupy a dig(1) operand slot: an option ('-'), a
+ * dig option ('+'), a discarded positional ('%'), or a nameserver selector
+ * ('@').
  */
 export function isUnsafeDigOperand(value: string): boolean {
-  return isArgvOptionLike(value) || value.startsWith("@") || value.startsWith("+");
+  return (
+    isArgvOptionLike(value) ||
+    value.startsWith("+") ||
+    value.startsWith("%") ||
+    value.startsWith("@")
+  );
 }

--- a/src/infra/argv-safety.ts
+++ b/src/infra/argv-safety.ts
@@ -1,0 +1,20 @@
+// Rejects values that a spawned tool would read as an option, not as an operand.
+//
+// Nothing here spawns through a shell (`shouldSpawnWithShell` returns false and
+// callers pass an argv array), so quoting and shell metacharacters are not the
+// risk. The risk is positional: a value that begins with '-' occupies an operand
+// slot but is parsed as a flag, and the tool then does whatever that flag does.
+// Verified against the system dig(1) — `dig +short -f<file> NS` reads <file> as a
+// query list instead of resolving a name.
+//
+// Deliberately narrow, and deliberately NOT a hostname or DNS-name grammar.
+// Callers carry values that legitimately contain spaces, apostrophes and
+// non-ASCII — mDNS instance names are free-form UTF-8 (RFC 6763 §4.1.1) and
+// ssh_config aliases are user-defined — so anything stricter would reject
+// well-formed input while still reading as "hardened". Only the leading '-'
+// is structurally dangerous in an argv operand slot.
+
+/** True when `value` would be parsed as an option in an argv operand slot. */
+export function isArgvOptionLike(value: string): boolean {
+  return value.startsWith("-");
+}

--- a/src/infra/bonjour-discovery.test.ts
+++ b/src/infra/bonjour-discovery.test.ts
@@ -408,6 +408,13 @@ describe("bonjour-discovery", () => {
   // are free-form UTF-8, so a guard rejecting '-' anywhere (or non-ASCII, or
   // spaces, the way the SSH host denylist does) would silently stop discovering
   // most real gateways while still reading as "hardened".
+  //
+  // The last two entries are what make the dns-sd path's narrowness an INVARIANT
+  // rather than a comment. `parseDnsSdBrowse` passes `isArgvOptionLike`, not
+  // `isUnsafeDigOperand`, because dig's extra prefixes carry no meaning in a
+  // `dns-sd -L` operand slot; without a leading-'@' and a leading-'+' name here,
+  // transposing the wider dig predicate onto that call site leaves every test in
+  // this file green, and the over-rejection it would cause ships unnoticed.
   it("still passes well-formed instance names through to dns-sd unchanged", async () => {
     const wellFormed = [
       "Laptop Gateway", // spaces
@@ -415,6 +422,8 @@ describe("bonjour-discovery", () => {
       "Peter’s Mac Studio", // non-ASCII punctuation
       "studio.local", // dots
       "gw_01", // underscore
+      "@lobby-gw", // leading '@': meaningless to dns-sd, must NOT be dropped
+      "+studio", // leading '+': meaningless to dns-sd, must NOT be dropped
     ];
 
     const calls: string[][] = [];
@@ -532,21 +541,33 @@ describe("bonjour-discovery", () => {
   });
 
   // The dig-specific half of the producer guard. dig(1)'s dangerous prefix set is
-  // wider than '-', and both extras were probed against the system dig with a
-  // loopback listener:
-  //   '@' selects the nameserver POSITIONALLY and the LAST one wins, so an
-  //       '@'-prefixed PTR answer landing after the pinned tailnet nameserver
-  //       sends the follow-up SRV/TXT query to an arbitrary host:53 — the beacon
-  //       then comes from the attacker's server, not the tailnet's.
+  // wider than '-', and every extra was probed against the system dig (DiG
+  // 9.10.6) with a loopback listener:
   //   '+' introduces a dig option, so a '+tcp' answer is consumed as one and the
-  //       query name collapses to ".".
-  // Neither is caught by `isArgvOptionLike`, which is why the dig path uses the
+  //       query name collapses to ".". Reachable: dig prints a leading '+' bare.
+  //   '%' is discarded as a positional, so a '%evil' answer collapses the query
+  //       to a root ". IN NS". Also reachable, and printed bare. NOT a redirect —
+  //       that query still goes to the pinned nameserver, `parseDigSrv` rejects
+  //       the non-SRV answer, and the record drops itself; driven through this
+  //       producer against /usr/bin/dig, no beacon resulted. Same class as '+',
+  //       strictly less impact.
+  //   '@' selects the nameserver, and is kept as DEFENCE IN DEPTH rather than a
+  //       demonstrated path: DiG 9.10.6 escapes '@' when printing a name, so a
+  //       PTR answer of "@evil…" comes back as "\@evil…", never trips the guard,
+  //       and is read as an ordinary name sent to the pinned nameserver. Driven
+  //       through this producer against /usr/bin/dig, that is what happened — a
+  //       DNS server cannot make `dig +short … PTR` emit a bare leading '@'. The
+  //       guard covers a dig earlier on PATH that does not escape it; only 9.10.6
+  //       was probed. See argv-safety.ts, which also corrects the earlier
+  //       last-'@'-wins claim: dig's server list is first-wins-with-fallback.
+  // None is caught by `isArgvOptionLike`, which is why the dig path uses the
   // wider `isUnsafeDigOperand` rather than that shared predicate being widened.
   //
   // Split per prefix rather than asserted in one test: a single test stops at its
-  // first failing expect, so one hostile prefix would mask the other.
+  // first failing expect, so one hostile prefix would mask the others.
   const HOSTILE_PTR_NAMESERVER = "@127.0.0.1";
   const HOSTILE_PTR_OPTION = "+tcp";
+  const HOSTILE_PTR_DISCARDED_POSITIONAL = "%evil";
   const PINNED_NAMESERVER = "100.69.232.64";
 
   // Drives the wide-area dig fallback with `hostile` present in the PTR answer
@@ -614,6 +635,10 @@ describe("bonjour-discovery", () => {
     return { calls, beacons };
   }
 
+  // Defence-in-depth, not a demonstrated end-to-end outcome: real dig escapes a
+  // leading '@', so this argv shape is one only a non-escaping dig could produce.
+  // The assertion is scoped to what the producer controls — argv — and claims
+  // nothing about where the beacon would have come from.
   it("never lets an '@'-prefixed PTR answer reach dig argv", async () => {
     const { calls, beacons } = await runWideAreaWithHostilePtr(HOSTILE_PTR_NAMESERVER);
     const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
@@ -621,9 +646,8 @@ describe("bonjour-discovery", () => {
     const digCalls = calls.filter((c) => c[0] === "dig");
     expect(digCalls.length).toBeGreaterThan(0);
 
-    // The assertion that bites: the attack is a SECOND '@' argument after the
-    // pinned one, which dig resolves last-wins. So no dig invocation may carry
-    // any nameserver selector other than the one this code pinned itself.
+    // The assertion that bites: no dig invocation may carry any nameserver
+    // selector other than the one this code pinned itself.
     const extraNameservers = digCalls.flatMap((argv) =>
       argv.filter((a) => a.startsWith("@") && a !== `@${PINNED_NAMESERVER}`),
     );
@@ -646,22 +670,41 @@ describe("bonjour-discovery", () => {
     );
     expect(digOperands.filter((arg) => arg.startsWith("+"))).toEqual([]);
     // Belt and braces across dig's whole prefix set.
-    expect(digOperands.filter((arg) => /^[-@+]/.test(arg))).toEqual([]);
+    expect(digOperands.filter((arg) => /^[-@+%]/.test(arg))).toEqual([]);
+
+    expect(beacons.map((b) => b.host)).toEqual([`studio.${zone}`]);
+  });
+
+  it("never lets a '%'-prefixed PTR answer reach dig argv", async () => {
+    const { calls, beacons } = await runWideAreaWithHostilePtr(HOSTILE_PTR_DISCARDED_POSITIONAL);
+    const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
+
+    // dig discards a leading-'%' positional, so the query name collapses to the
+    // root and the SRV lookup this producer meant to make never happens. The
+    // slot must never start with one.
+    const digOperands = collectMatching(
+      calls,
+      (c) => c[0] === "dig",
+      (c) => c[c.length - 2] ?? "",
+    );
+    expect(digOperands.filter((arg) => arg.startsWith("%"))).toEqual([]);
+    expect(digOperands.filter((arg) => /^[-@+%]/.test(arg))).toEqual([]);
 
     expect(beacons.map((b) => b.host)).toEqual([`studio.${zone}`]);
   });
 
   // The regression a too-eager dig guard would cause. Only the LEADING character
-  // is structural to dig — '@' and '+' anywhere else are ordinary bytes in a
-  // name, and DNS-SD instance labels are free-form, so rejecting them outright
+  // is structural to dig — '+', '%' and '@' anywhere else are ordinary bytes in
+  // a name, and DNS-SD instance labels are free-form, so rejecting them outright
   // would drop well-formed peers while still reading as "hardened".
-  it("still passes PTR answers with interior '@' or '+' through to dig", async () => {
+  it("still passes PTR answers with interior '+', '%' or '@' through to dig", async () => {
     const calls: string[][] = [];
     const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
     const serviceBase = `_remoteclaw-gw._tcp.${zone}`;
     const services = [
       `studio+lab.${serviceBase}`, // interior '+'
       `desk@home.${serviceBase}`, // interior '@'
+      `rate%limit.${serviceBase}`, // interior '%'
       `plain-gw.${serviceBase}`, // interior '-'
     ];
 
@@ -722,8 +765,18 @@ describe("bonjour-discovery", () => {
       (c) => c[c.length - 2] ?? "",
     );
     expect(srvOperands).toEqual(services);
-    expect(beacons.map((b) => b.host)).toEqual([`host0.${zone}`, `host1.${zone}`, `host2.${zone}`]);
-    expect(beacons.map((b) => b.instanceName)).toEqual(["studio+lab", "desk@home", "plain-gw"]);
+    expect(beacons.map((b) => b.host)).toEqual([
+      `host0.${zone}`,
+      `host1.${zone}`,
+      `host2.${zone}`,
+      `host3.${zone}`,
+    ]);
+    expect(beacons.map((b) => b.instanceName)).toEqual([
+      "studio+lab",
+      "desk@home",
+      "rate%limit",
+      "plain-gw",
+    ]);
   });
 
   it("normalizes domains and respects domains override", async () => {

--- a/src/infra/bonjour-discovery.test.ts
+++ b/src/infra/bonjour-discovery.test.ts
@@ -341,6 +341,196 @@ describe("bonjour-discovery", () => {
     expect(calls.map((c) => c.argv[0])).toContain("dig");
   });
 
+  // Producer-side argv guard (#3101). An mDNS instance name is publishable by
+  // any LAN peer and a PTR answer by any responding DNS server; both land in an
+  // argv operand slot where a leading '-' is read as a flag. Neither dns-sd nor
+  // dig accepts "--", so the hostile record is dropped rather than neutralized.
+  it("never lets a dash-prefixed mDNS instance name reach dns-sd argv", async () => {
+    const calls: string[][] = [];
+    const run = vi.fn(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv[0] === "dns-sd" && argv[1] === "-B") {
+        return {
+          stdout: [
+            "Add 2 3 local. _remoteclaw-gw._tcp. -f/etc/passwd",
+            // The same attack smuggled through a dns-sd octal escape: "\045" is
+            // '-', so this decodes to "-oEscaped" and is caught only if the guard
+            // runs after decodeDnsSdEscapes. Kept distinct from the literal case
+            // above so the Set cannot dedupe the two into one assertion.
+            "Add 2 3 local. _remoteclaw-gw._tcp. \\045oEscaped",
+            "Add 2 3 local. _remoteclaw-gw._tcp. Laptop Gateway",
+            "",
+          ].join("\n"),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      if (argv[0] === "dns-sd" && argv[1] === "-L") {
+        return {
+          stdout: [
+            `${argv[2]}._remoteclaw-gw._tcp. can be reached at laptop.local:18789`,
+            "txtvers=1 gatewayPort=18789",
+            "",
+          ].join("\n"),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      throw new Error(`unexpected argv: ${argv.join(" ")}`);
+    });
+
+    const beacons = await discoverGatewayBeacons({
+      platform: "darwin",
+      timeoutMs: 800,
+      domains: ["local."],
+      run: run as unknown as typeof runCommandWithTimeout,
+    });
+
+    const resolveArgs = collectMatching(
+      calls,
+      (c) => c[0] === "dns-sd" && c[1] === "-L",
+      (c) => c[2] ?? "",
+    );
+    // The assertion that bites: nothing option-shaped occupies the operand slot.
+    expect(resolveArgs.filter((arg) => arg.startsWith("-"))).toEqual([]);
+    expect(resolveArgs).toEqual(["Laptop Gateway"]);
+
+    // Over-rejection guard: one hostile publisher must not suppress its
+    // well-behaved neighbours, or the fix is worse than the bug.
+    expect(beacons.map((b) => b.instanceName)).toEqual(["Laptop Gateway"]);
+  });
+
+  // The regression a too-eager guard would cause. RFC 6763 §4.1.1 instance names
+  // are free-form UTF-8, so a guard rejecting '-' anywhere (or non-ASCII, or
+  // spaces, the way the SSH host denylist does) would silently stop discovering
+  // most real gateways while still reading as "hardened".
+  it("still passes well-formed instance names through to dns-sd unchanged", async () => {
+    const wellFormed = [
+      "Laptop Gateway", // spaces
+      "peters-mac-studio-1", // interior and trailing hyphens
+      "Peter’s Mac Studio", // non-ASCII punctuation
+      "studio.local", // dots
+      "gw_01", // underscore
+    ];
+
+    const calls: string[][] = [];
+    const run = vi.fn(async (argv: string[]) => {
+      calls.push(argv);
+      if (argv[0] === "dns-sd" && argv[1] === "-B") {
+        return {
+          stdout: [
+            ...wellFormed.map((name) => `Add 2 3 local. _remoteclaw-gw._tcp. ${name}`),
+            "",
+          ].join("\n"),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      if (argv[0] === "dns-sd" && argv[1] === "-L") {
+        return {
+          stdout: [`${argv[2]}._remoteclaw-gw._tcp. can be reached at host.local:18789`, ""].join(
+            "\n",
+          ),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      throw new Error(`unexpected argv: ${argv.join(" ")}`);
+    });
+
+    const beacons = await discoverGatewayBeacons({
+      platform: "darwin",
+      timeoutMs: 800,
+      domains: ["local."],
+      run: run as unknown as typeof runCommandWithTimeout,
+    });
+
+    const resolveArgs = collectMatching(
+      calls,
+      (c) => c[0] === "dns-sd" && c[1] === "-L",
+      (c) => c[2] ?? "",
+    );
+    expect(resolveArgs).toEqual(wellFormed);
+    expect(beacons.map((b) => b.instanceName)).toEqual(wellFormed);
+  });
+
+  it("never lets a dash-prefixed PTR answer reach dig argv", async () => {
+    const calls: string[][] = [];
+    const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
+    const serviceBase = `_remoteclaw-gw._tcp.${zone}`;
+    const goodService = `studio-gateway.${serviceBase}`;
+
+    const run = vi.fn(async (argv: string[]) => {
+      calls.push(argv);
+      const cmd = argv[0];
+
+      if (cmd === "dns-sd" && argv[1] === "-B") {
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      if (cmd === "tailscale" && argv[1] === "status") {
+        return {
+          stdout: JSON.stringify({ Self: { TailscaleIPs: ["100.69.232.64"] } }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      if (cmd === "dig") {
+        const qname = argv[argv.length - 2] ?? "";
+        const qtype = argv[argv.length - 1] ?? "";
+        if (qtype === "PTR" && qname === serviceBase) {
+          // A hostile DNS server answering the PTR probe with a flag.
+          return {
+            stdout: `-f/etc/passwd\n${goodService}.\n`,
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+          };
+        }
+        if (qtype === "SRV" && qname === goodService) {
+          return {
+            stdout: `0 0 18789 studio.${zone}.\n`,
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+          };
+        }
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      throw new Error(`unexpected argv: ${argv.join(" ")}`);
+    });
+
+    const beacons = await discoverGatewayBeacons({
+      platform: "darwin",
+      timeoutMs: 1200,
+      domains: [WIDE_AREA_DOMAIN],
+      wideAreaDomain: WIDE_AREA_DOMAIN,
+      run: run as unknown as typeof runCommandWithTimeout,
+    });
+
+    // dig takes the query name as an operand; nothing there may start with '-'.
+    const digOperands = collectMatching(
+      calls,
+      (c) => c[0] === "dig",
+      (c) => c[c.length - 2] ?? "",
+    );
+    expect(digOperands.filter((arg) => arg.startsWith("-"))).toEqual([]);
+
+    // The clean PTR from the same answer set still resolves.
+    expect(beacons.map((b) => b.host)).toEqual([`studio.${zone}`]);
+  });
+
   it("normalizes domains and respects domains override", async () => {
     const calls: string[][] = [];
     const run = vi.fn(async (argv: string[]) => {

--- a/src/infra/bonjour-discovery.test.ts
+++ b/src/infra/bonjour-discovery.test.ts
@@ -531,6 +531,201 @@ describe("bonjour-discovery", () => {
     expect(beacons.map((b) => b.host)).toEqual([`studio.${zone}`]);
   });
 
+  // The dig-specific half of the producer guard. dig(1)'s dangerous prefix set is
+  // wider than '-', and both extras were probed against the system dig with a
+  // loopback listener:
+  //   '@' selects the nameserver POSITIONALLY and the LAST one wins, so an
+  //       '@'-prefixed PTR answer landing after the pinned tailnet nameserver
+  //       sends the follow-up SRV/TXT query to an arbitrary host:53 — the beacon
+  //       then comes from the attacker's server, not the tailnet's.
+  //   '+' introduces a dig option, so a '+tcp' answer is consumed as one and the
+  //       query name collapses to ".".
+  // Neither is caught by `isArgvOptionLike`, which is why the dig path uses the
+  // wider `isUnsafeDigOperand` rather than that shared predicate being widened.
+  //
+  // Split per prefix rather than asserted in one test: a single test stops at its
+  // first failing expect, so one hostile prefix would mask the other.
+  const HOSTILE_PTR_NAMESERVER = "@127.0.0.1";
+  const HOSTILE_PTR_OPTION = "+tcp";
+  const PINNED_NAMESERVER = "100.69.232.64";
+
+  // Drives the wide-area dig fallback with `hostile` present in the PTR answer
+  // set alongside one well-formed service, and returns every argv it spawned.
+  async function runWideAreaWithHostilePtr(hostile: string): Promise<{
+    calls: string[][];
+    beacons: GatewayBonjourBeacon[];
+  }> {
+    const calls: string[][] = [];
+    const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
+    const serviceBase = `_remoteclaw-gw._tcp.${zone}`;
+    const goodService = `studio-gateway.${serviceBase}`;
+
+    const run = vi.fn(async (argv: string[]) => {
+      calls.push(argv);
+      const cmd = argv[0];
+
+      if (cmd === "dns-sd" && argv[1] === "-B") {
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      if (cmd === "tailscale" && argv[1] === "status") {
+        return {
+          stdout: JSON.stringify({ Self: { TailscaleIPs: [PINNED_NAMESERVER] } }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      if (cmd === "dig") {
+        const qname = argv[argv.length - 2] ?? "";
+        const qtype = argv[argv.length - 1] ?? "";
+        if (qtype === "PTR" && qname === serviceBase) {
+          // A hostile DNS server answering the PTR probe with dig syntax rather
+          // than a name. Both payloads survive a leading-'-' check untouched.
+          return {
+            stdout: `${hostile}\n${goodService}.\n`,
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+          };
+        }
+        if (qtype === "SRV" && qname === goodService) {
+          return {
+            stdout: `0 0 18789 studio.${zone}.\n`,
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+          };
+        }
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      throw new Error(`unexpected argv: ${argv.join(" ")}`);
+    });
+
+    const beacons = await discoverGatewayBeacons({
+      platform: "darwin",
+      timeoutMs: 1200,
+      domains: [WIDE_AREA_DOMAIN],
+      wideAreaDomain: WIDE_AREA_DOMAIN,
+      run: run as unknown as typeof runCommandWithTimeout,
+    });
+    return { calls, beacons };
+  }
+
+  it("never lets an '@'-prefixed PTR answer reach dig argv", async () => {
+    const { calls, beacons } = await runWideAreaWithHostilePtr(HOSTILE_PTR_NAMESERVER);
+    const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
+
+    const digCalls = calls.filter((c) => c[0] === "dig");
+    expect(digCalls.length).toBeGreaterThan(0);
+
+    // The assertion that bites: the attack is a SECOND '@' argument after the
+    // pinned one, which dig resolves last-wins. So no dig invocation may carry
+    // any nameserver selector other than the one this code pinned itself.
+    const extraNameservers = digCalls.flatMap((argv) =>
+      argv.filter((a) => a.startsWith("@") && a !== `@${PINNED_NAMESERVER}`),
+    );
+    expect(extraNameservers).toEqual([]);
+
+    // Over-rejection guard: the clean PTR in the same answer set still resolves.
+    expect(beacons.map((b) => b.host)).toEqual([`studio.${zone}`]);
+  });
+
+  it("never lets a '+'-prefixed PTR answer reach dig argv", async () => {
+    const { calls, beacons } = await runWideAreaWithHostilePtr(HOSTILE_PTR_OPTION);
+    const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
+
+    // dig takes the query name as an operand; a '+' there is eaten as an option
+    // and the query name collapses, so the slot must never start with one.
+    const digOperands = collectMatching(
+      calls,
+      (c) => c[0] === "dig",
+      (c) => c[c.length - 2] ?? "",
+    );
+    expect(digOperands.filter((arg) => arg.startsWith("+"))).toEqual([]);
+    // Belt and braces across dig's whole prefix set.
+    expect(digOperands.filter((arg) => /^[-@+]/.test(arg))).toEqual([]);
+
+    expect(beacons.map((b) => b.host)).toEqual([`studio.${zone}`]);
+  });
+
+  // The regression a too-eager dig guard would cause. Only the LEADING character
+  // is structural to dig — '@' and '+' anywhere else are ordinary bytes in a
+  // name, and DNS-SD instance labels are free-form, so rejecting them outright
+  // would drop well-formed peers while still reading as "hardened".
+  it("still passes PTR answers with interior '@' or '+' through to dig", async () => {
+    const calls: string[][] = [];
+    const zone = WIDE_AREA_DOMAIN.replace(/\.$/, "");
+    const serviceBase = `_remoteclaw-gw._tcp.${zone}`;
+    const services = [
+      `studio+lab.${serviceBase}`, // interior '+'
+      `desk@home.${serviceBase}`, // interior '@'
+      `plain-gw.${serviceBase}`, // interior '-'
+    ];
+
+    const run = vi.fn(async (argv: string[]) => {
+      calls.push(argv);
+      const cmd = argv[0];
+
+      if (cmd === "dns-sd" && argv[1] === "-B") {
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      if (cmd === "tailscale" && argv[1] === "status") {
+        return {
+          stdout: JSON.stringify({ Self: { TailscaleIPs: ["100.69.232.64"] } }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      if (cmd === "dig") {
+        const qname = argv[argv.length - 2] ?? "";
+        const qtype = argv[argv.length - 1] ?? "";
+        if (qtype === "PTR" && qname === serviceBase) {
+          return {
+            stdout: `${services.map((s) => `${s}.`).join("\n")}\n`,
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+          };
+        }
+        const idx = services.indexOf(qname);
+        if (qtype === "SRV" && idx >= 0) {
+          return {
+            stdout: `0 0 1878${idx} host${idx}.${zone}.\n`,
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+          };
+        }
+        return { stdout: "", stderr: "", code: 0, signal: null, killed: false };
+      }
+      throw new Error(`unexpected argv: ${argv.join(" ")}`);
+    });
+
+    const beacons = await discoverGatewayBeacons({
+      platform: "darwin",
+      timeoutMs: 1200,
+      domains: [WIDE_AREA_DOMAIN],
+      wideAreaDomain: WIDE_AREA_DOMAIN,
+      run: run as unknown as typeof runCommandWithTimeout,
+    });
+
+    const srvOperands = collectMatching(
+      calls,
+      (c) => c[0] === "dig" && c[c.length - 1] === "SRV",
+      (c) => c[c.length - 2] ?? "",
+    );
+    expect(srvOperands).toEqual(services);
+    expect(beacons.map((b) => b.host)).toEqual([`host0.${zone}`, `host1.${zone}`, `host2.${zone}`]);
+    expect(beacons.map((b) => b.instanceName)).toEqual(["studio+lab", "desk@home", "plain-gw"]);
+  });
+
   it("normalizes domains and respects domains override", async () => {
     const calls: string[][] = [];
     const run = vi.fn(async (argv: string[]) => {

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -118,10 +118,12 @@ function decodeDnsSdEscapes(value: string): string {
 // publishable by any LAN peer, a PTR answer by any DNS server that responds.
 //
 // What counts as unsafe differs by tool, so the predicate is a parameter rather
-// than baked in: dig also reads a leading '@' as a nameserver selector — last
-// one wins, so an '@'-prefixed PTR answer re-points the follow-up SRV/TXT query
-// at an arbitrary host:53 — and a leading '+' as an option. dns-sd gives neither
-// character any meaning. See argv-safety.ts for the probes behind that.
+// than baked in: dig consumes a leading '+' as an option and discards a leading
+// '%' positional, either of which collapses the follow-up SRV/TXT query to the
+// root name, and reads a leading '@' as a nameserver selector. dns-sd gives none
+// of the three any meaning. See argv-safety.ts for the probes behind that,
+// including why '@' is defence-in-depth rather than a reachable path, and why
+// dig's server list is first-wins-with-fallback rather than last-wins.
 //
 // Neither tool accepts "--", so a hostile value cannot be neutralized in place;
 // it is dropped instead. Dropping is per record, so one hostile publisher costs
@@ -278,9 +280,11 @@ function parseDnsSdBrowse(stdout: string): string[] {
   // sequence "\045evil" decodes to "-evil", so a check upstream of the decode
   // would pass the very value that reaches argv.
   //
-  // Narrow predicate on purpose: dns-sd's operand slot gives '@' and '+' no
+  // Narrow predicate on purpose: dns-sd's operand slot gives '+', '%' and '@' no
   // meaning, and instance names are free-form UTF-8, so widening here would
-  // drop well-formed names for nothing.
+  // drop well-formed names for nothing. Guarded, not merely asserted: the
+  // well-formed fixture in bonjour-discovery.test.ts carries a leading-'@' and a
+  // leading-'+' instance name, so transposing `isUnsafeDigOperand` here fails.
   return dropUnsafeArgvOperands(
     Array.from(instances.values()),
     "mDNS instance name",

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -2,7 +2,7 @@ import { logDebug } from "../logger.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { normalizeStringEntries, uniqueStrings } from "../shared/string-normalization.js";
-import { isArgvOptionLike } from "./argv-safety.js";
+import { isArgvOptionLike, isUnsafeDigOperand } from "./argv-safety.js";
 import { parseStrictInteger } from "./parse-finite-number.js";
 import { isTailnetIPv4 } from "./tailnet.js";
 import { resolveWideAreaDiscoveryDomain } from "./widearea-dns.js";
@@ -117,16 +117,26 @@ function decodeDnsSdEscapes(value: string): string {
 // is supplied by whoever answered on the network: an mDNS instance name is
 // publishable by any LAN peer, a PTR answer by any DNS server that responds.
 //
+// What counts as unsafe differs by tool, so the predicate is a parameter rather
+// than baked in: dig also reads a leading '@' as a nameserver selector — last
+// one wins, so an '@'-prefixed PTR answer re-points the follow-up SRV/TXT query
+// at an arbitrary host:53 — and a leading '+' as an option. dns-sd gives neither
+// character any meaning. See argv-safety.ts for the probes behind that.
+//
 // Neither tool accepts "--", so a hostile value cannot be neutralized in place;
 // it is dropped instead. Dropping is per record, so one hostile publisher costs
 // only its own entry and cannot suppress discovery of well-behaved peers.
-function dropArgvOptionLike(values: readonly string[], kind: string): string[] {
+function dropUnsafeArgvOperands(
+  values: readonly string[],
+  kind: string,
+  isUnsafe: (value: string) => boolean,
+): string[] {
   const safe: string[] = [];
   for (const value of values) {
-    if (isArgvOptionLike(value)) {
+    if (isUnsafe(value)) {
       // JSON.stringify so a value carrying newlines cannot forge log lines.
       logDebug(
-        `bonjour discovery: dropped ${kind} that argv would parse as an option: ${JSON.stringify(
+        `bonjour discovery: dropped ${kind} that argv would not carry as a plain operand: ${JSON.stringify(
           value,
         )}`,
       );
@@ -138,7 +148,12 @@ function dropArgvOptionLike(values: readonly string[], kind: string): string[] {
 }
 
 function parseDigShortLines(stdout: string): string[] {
-  return dropArgvOptionLike(normalizeStringEntries(stdout.split("\n")), "DNS answer");
+  // These become dig(1) query names, so they carry dig's wider prefix set.
+  return dropUnsafeArgvOperands(
+    normalizeStringEntries(stdout.split("\n")),
+    "DNS answer",
+    isUnsafeDigOperand,
+  );
 }
 
 function parseDigTxt(stdout: string): string[] {
@@ -262,7 +277,15 @@ function parseDnsSdBrowse(stdout: string): string[] {
   // Filtered after decodeDnsSdEscapes, never on the wire form: the escape
   // sequence "\045evil" decodes to "-evil", so a check upstream of the decode
   // would pass the very value that reaches argv.
-  return dropArgvOptionLike(Array.from(instances.values()), "mDNS instance name");
+  //
+  // Narrow predicate on purpose: dns-sd's operand slot gives '@' and '+' no
+  // meaning, and instance names are free-form UTF-8, so widening here would
+  // drop well-formed names for nothing.
+  return dropUnsafeArgvOperands(
+    Array.from(instances.values()),
+    "mDNS instance name",
+    isArgvOptionLike,
+  );
 }
 
 function parseDnsSdResolve(stdout: string, instanceName: string): GatewayBonjourBeacon | null {

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -1,6 +1,8 @@
+import { logDebug } from "../logger.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { normalizeStringEntries, uniqueStrings } from "../shared/string-normalization.js";
+import { isArgvOptionLike } from "./argv-safety.js";
 import { parseStrictInteger } from "./parse-finite-number.js";
 import { isTailnetIPv4 } from "./tailnet.js";
 import { resolveWideAreaDiscoveryDomain } from "./widearea-dns.js";
@@ -110,8 +112,33 @@ function decodeDnsSdEscapes(value: string): string {
   return Buffer.from(bytes).toString("utf8");
 }
 
+// Both discovery paths hand a parsed value straight to an argv operand slot —
+// `dns-sd -L <instance>` and `dig … <ptrName> SRV` — and in both cases the value
+// is supplied by whoever answered on the network: an mDNS instance name is
+// publishable by any LAN peer, a PTR answer by any DNS server that responds.
+//
+// Neither tool accepts "--", so a hostile value cannot be neutralized in place;
+// it is dropped instead. Dropping is per record, so one hostile publisher costs
+// only its own entry and cannot suppress discovery of well-behaved peers.
+function dropArgvOptionLike(values: readonly string[], kind: string): string[] {
+  const safe: string[] = [];
+  for (const value of values) {
+    if (isArgvOptionLike(value)) {
+      // JSON.stringify so a value carrying newlines cannot forge log lines.
+      logDebug(
+        `bonjour discovery: dropped ${kind} that argv would parse as an option: ${JSON.stringify(
+          value,
+        )}`,
+      );
+      continue;
+    }
+    safe.push(value);
+  }
+  return safe;
+}
+
 function parseDigShortLines(stdout: string): string[] {
-  return normalizeStringEntries(stdout.split("\n"));
+  return dropArgvOptionLike(normalizeStringEntries(stdout.split("\n")), "DNS answer");
 }
 
 function parseDigTxt(stdout: string): string[] {
@@ -232,7 +259,10 @@ function parseDnsSdBrowse(stdout: string): string[] {
       instances.add(decodeDnsSdEscapes(match[1].trim()));
     }
   }
-  return Array.from(instances.values());
+  // Filtered after decodeDnsSdEscapes, never on the wire form: the escape
+  // sequence "\045evil" decodes to "-evil", so a check upstream of the decode
+  // would pass the very value that reaches argv.
+  return dropArgvOptionLike(Array.from(instances.values()), "mDNS instance name");
 }
 
 function parseDnsSdResolve(stdout: string, instanceName: string): GatewayBonjourBeacon | null {

--- a/src/infra/ssh-host-safety.test.ts
+++ b/src/infra/ssh-host-safety.test.ts
@@ -34,4 +34,15 @@ describe("isUnsafeSshHost", () => {
     expect(isUnsafeSshHost("100.64.0.9")).toBe(false);
     expect(isUnsafeSshHost("under_score")).toBe(false);
   });
+
+  // Scope pin for the dig(1) operand predicate (`isUnsafeDigOperand`). dig reads
+  // a leading '@' as a nameserver selector and a leading '+' as an option; ssh(1)
+  // reads neither that way, so those prefixes must NOT have leaked into this
+  // guard when the dig path was hardened. A failure here means the shared
+  // primitive was widened instead of composed, changing ssh host admission.
+  it("is unchanged by dig's operand rules: '@' and '+' are not ssh options", () => {
+    expect(isUnsafeSshHost("@127.0.0.1")).toBe(false);
+    expect(isUnsafeSshHost("+tcp")).toBe(false);
+    expect(isUnsafeSshHost("user@studio.ts.net")).toBe(false);
+  });
 });

--- a/src/infra/ssh-host-safety.ts
+++ b/src/infra/ssh-host-safety.ts
@@ -1,7 +1,9 @@
 // Rejects hostnames that ssh(1) would not treat as a host.
 //
 // A leading '-' is the dangerous case: ssh parses the argument as an option, so
-// a host of "-oProxyCommand=..." becomes remote code execution. A leading or
+// a host of "-oProxyCommand=..." becomes remote code execution. That check is
+// shared with the other argv producers via `isArgvOptionLike` rather than
+// restated here, so there is one definition of "reads as an option". A leading or
 // trailing ':' produces an invalid HostName (e.g. sliced from "host::22"), and
 // whitespace cannot appear in a hostname at all, so its presence means the
 // value was mangled or injected somewhere upstream. An empty host is rejected
@@ -12,13 +14,15 @@
 // reject, so this stays a denylist of the shapes that are actually dangerous or
 // structurally invalid.
 
+import { isArgvOptionLike } from "./argv-safety.js";
+
 const HOST_WHITESPACE_PATTERN = /\s/;
 
 /** True when `host` must not be used as an SSH host. */
 export function isUnsafeSshHost(host: string): boolean {
   return (
     host.length === 0 ||
-    host.startsWith("-") ||
+    isArgvOptionLike(host) ||
     host.startsWith(":") ||
     host.endsWith(":") ||
     HOST_WHITESPACE_PATTERN.test(host)


### PR DESCRIPTION
Closes #3101.

PR #3099 hardened the **consumers** of mDNS/DNS discovery values but not the
**producers**, in a file its changed modules import directly. Two spawn sites in
`src/infra/bonjour-discovery.ts` pass a network-supplied string into an argv
position where a leading `-` is parsed as a flag:

| Site | Value | Who controls it |
|---|---|---|
| `:311` `run(["dns-sd", "-L", instance, …])` | `instance` from `parseDnsSdBrowse` | any LAN peer can publish an mDNS instance name |
| `:420` `run(["dig", …, ptrName, "SRV"])` | `ptrName` from `parseDigShortLines` | whichever DNS server answers the PTR probe |

Discovery runs unconditionally on `remoteclaw gateway status`
(`gateway-status.ts:59`), so no user action gates it.

## Severity: argument injection, not RCE

Stated precisely so this is not read as more than it is:

- **No shell is involved.** `shouldSpawnWithShell` (`src/process/exec.ts:125-136`)
  returns `false` unconditionally, and both sites spawn with an argv array.
- **Neither tool has a command-executing flag.** Worst realistic case is
  `dig -f <file>` treating a local file as a query list.

Two things I checked rather than assumed, against the system tools on macOS:

**`dig` really does parse an operand-position flag.** With a file containing
`example.com`:

```
$ dig +short +time=1 +tries=1 "-f.tmp/digprobe.txt" NS
elliott.ns.cloudflare.com.
hera.ns.cloudflare.com.
```

Those are `example.com`'s real nameservers — `dig` read the file as a query list
rather than resolving a name. The `dig` half is a demonstrated live defect.

**`dns-sd` did *not* flag-parse on this build.** `dns-sd -L "-f/etc/passwd"
_remoteclaw-gw._tcp local.` produced no output and no error in 3s, i.e. it took
the value positionally. That site is therefore **defence in depth**, not a
demonstrated exploit — one probe, one build, and I would rather not hand it an
unvalidated operand on the strength of that.

## Reject, not neutralize

Neutralizing with a `--` separator is **unavailable in both tools** — probed, not
assumed:

```
$ dig +short +time=1 +tries=1 -- example.com
Invalid option: --
```
```
$ dns-sd -L -- "Studio Gateway" _remoteclaw-gw._tcp local.
Lookup --.Studio Gateway._tcp._remoteclaw-gw._tcp
```

`dig` refuses it outright; `dns-sd` silently consumes `--` as the *instance*
operand and shifts everything along, which corrupts the query rather than
protecting it. So the hostile record is **dropped** and logged at debug.

Re-encoding a leading `-` as the DNS-SD escape `\045` was considered and
rejected: the round-trip through dns-sd's own unescaping is unverified, and that
second probe shows dns-sd happily builds a nonsense query from bad operands
instead of erroring — a wrong guess would silently break resolution.

**Dropping is per record.** One hostile publisher costs only its own entry; the
loops at `:310` and `:409` continue over the rest. A fix that let any LAN peer
suppress discovery for everyone would be a worse trade than the bug, and there
is an assertion for exactly that.

## The predicate is reused, not re-copied

The leading-dash test moved to `isArgvOptionLike` in a new
`src/infra/argv-safety.ts`; `isUnsafeSshHost` now **composes** it. There is one
definition of "reads as an option", not a third copy.

`isUnsafeSshHost` could not be reused wholesale: it also rejects whitespace and
colons, but mDNS instance names are free-form UTF-8 (RFC 6763 §4.1.1). Applying
it here would have rejected `Peter's Mac Studio` and `Laptop Gateway` — the names
already in this repo's own fixtures — so the guard stays narrowed to the leading
dash, which is the only structurally dangerous shape in an operand slot.

The mDNS filter runs **after** `decodeDnsSdEscapes`, because `\045evil` decodes
to `-evil`; a check on the wire form would pass the very value that reaches argv.

## Proof the guard bites

Green (`vitest.unit.config.ts`, 3 files):

```
 Test Files  3 passed (3)
      Tests  14 passed (14)
```

Same tests with `isArgvOptionLike` temporarily neutralized to `return false`:

```
AssertionError: expected [ '-f/etc/passwd', '-oEscaped' ] to deeply equal []
  ↳ never lets a dash-prefixed mDNS instance name reach dns-sd argv
AssertionError: expected [ '-f/etc/passwd' ] to deeply equal []
  ↳ never lets a dash-prefixed PTR answer reach dig argv
AssertionError: expected false to be true
  ↳ isUnsafeSshHost > rejects hosts ssh(1) would parse as an option
 Test Files  3 failed (3)
      Tests  4 failed | 10 passed (14)
```

Both hostile forms appear at the sink — the literal `-f/etc/passwd` **and** the
escape-smuggled `-oEscaped` — so the post-decode ordering is independently
covered. The `ssh-host-safety` failure is the useful one: it proves the SSH guard
genuinely routes through the shared predicate rather than a leftover copy.

The over-rejection test stayed **green** under the same injection, confirming it
asserts real pass-through rather than restating the guard.

## Verification

| Gate | Result |
|---|---|
| New + touched suites | 14 passed (3 files), exit 0 |
| Full `bonjour-discovery.test.ts` | 8 passed, exit 0 |
| All predicate consumers (`ssh-tunnel`, `gateway-discovery-targets`, `ssh-host-safety`, `argv-safety`, `bonjour-discovery`) | 26 passed (5 files), exit 0 |
| `src/commands/gateway-status/discovery.test.ts` (base config; in no CI lane) | 9 passed, exit 0 |
| `./node_modules/.bin/tsgo --noEmit` | exit 0, zero bytes of output |
| `oxlint --type-aware` on the 5 touched files | `Found 0 warnings and 0 errors` / `on 5 files` |
| `pnpm check` (full) | exit 0 |
| zombie-import / stub-debt / throwing-stub-callers / raw-channel-fetch gates | all exit 0 |

## Over-rejection: one real behaviour change

A peer whose mDNS instance name *begins* with `-` is no longer discovered. RFC
6763 permits it, so this is a genuine (if unlikely) narrowing rather than a
no-op, and it is worth a reviewer's attention. It costs that publisher only, no
one else. Interior and trailing hyphens, spaces, dots, underscores and non-ASCII
all still pass — there is a test pinning exactly that list.

## Noticed, not changed

- The issue's **two nits** are untouched, as out of scope for a producer-side
  guard: the TXT-vs-SRV rationale in `gateway-status.ts:134-135` /
  `gateway-discovery-targets.ts:35-36` overstates the trust boundary (`beacon.host`
  is SRV-derived and equally publishable), and the DI seam at
  `gateway-status/discovery.ts:92` types `parseSshTarget` as returning `unknown`.
  Both are worth doing; neither belongs in this diff.
- `check-stub-debt.mjs` reports `fork-boundary-mock decreased: 129 < baseline 139`
  and asks for a baseline refresh. Pre-existing and unrelated — not touched here.
- `src/commands/**` still runs in no CI lane, so the
  `gateway-status/discovery.test.ts` row above is a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)