### PR TITLE
security(windows): validate ComSpec and close the CWE-426 resolver class (#3100, #3112)

### DIFF
--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -388,6 +388,41 @@ exit 0
       await cleanupScript(scriptPath);
     });
 
+    // The PowerShell body names schtasks.exe twice — once as a ProcessStartInfo.FileName
+    // and once behind the `&` call operator. Both used to be bare names resolved through
+    // the *script's* %PATH% when it finally runs, which no source scan can see (#3112 §4).
+    it("pins schtasks.exe in the emitted PowerShell on Windows", async () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        REMOTECLAW_PROFILE: "default",
+        // A non-default root, so these literals cannot be satisfied by the C:\Windows
+        // fallback — the resolution has to actually read SystemRoot.
+        SystemRoot: "D:\\WinNT",
+      });
+
+      expect(content).toContain("$startInfo.FileName = 'D:\\WinNT\\System32\\schtasks.exe'");
+      expect(content).toContain(
+        "$queryOutput = & 'D:\\WinNT\\System32\\schtasks.exe' /Query /TN $TaskName",
+      );
+      expect(content).not.toContain('$startInfo.FileName = "schtasks.exe"');
+      expect(content).not.toContain("& schtasks.exe");
+      await cleanupScript(scriptPath);
+    });
+
+    it("falls back to the default root when SystemRoot is hostile", async () => {
+      Object.defineProperty(process, "platform", { value: "win32" });
+
+      const { scriptPath, content } = await prepareAndReadScript({
+        REMOTECLAW_PROFILE: "default",
+        SystemRoot: "C:\\Windows\\..\\Users\\pub\\evil",
+      });
+
+      expect(content).toContain("$startInfo.FileName = 'C:\\Windows\\System32\\schtasks.exe'");
+      expect(content).not.toContain("Users\\pub\\evil");
+      await cleanupScript(scriptPath);
+    });
+
     it("uses REMOTECLAW_WINDOWS_TASK_NAME override on Windows", async () => {
       Object.defineProperty(process, "platform", { value: "win32" });
 

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -16,7 +16,10 @@ import {
   resolveGatewayRestartLogPath,
   shellEscapeRestartLogValue,
 } from "../../daemon/restart-logs.js";
-import { resolveWindowsCmdExePath } from "../../infra/windows-system-paths.js";
+import {
+  resolveWindowsCmdExePath,
+  resolveWindowsSystem32Path,
+} from "../../infra/windows-system-paths.js";
 
 /**
  * Shell-escape a string for embedding in single-quoted shell arguments.
@@ -172,6 +175,14 @@ exit "$status"
       const restartLogPath = resolveGatewayRestartLogPath({ ...process.env, ...env });
       const quotedLogPath = powerShellSingleQuote(restartLogPath);
       const quotedTaskName = powerShellSingleQuote(taskName);
+      // Pinned at emission time, for the same reason as every argv site: a binary named
+      // inside generated script content resolves through the *script's* %PATH% when it
+      // finally runs, which no source scan of this repo can see. The substrate differs
+      // (a PowerShell literal, not argv) but the escape hatch is the same one already
+      // used for the log path and task name above.
+      const quotedSchtasksPath = powerShellSingleQuote(
+        resolveWindowsSystem32Path("schtasks.exe", { ...process.env, ...env }),
+      );
       filename = `remoteclaw-restart-${timestamp}.cmd`;
       scriptContent = `@echo off
 REM Standalone restart script - survives parent process termination.
@@ -224,7 +235,7 @@ function Invoke-RemoteClawSchtasksWithTimeout {
   $process = $null
   try {
     $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-    $startInfo.FileName = "schtasks.exe"
+    $startInfo.FileName = ${quotedSchtasksPath}
     $startInfo.Arguments = Join-RemoteClawProcessArguments -Arguments $Arguments
     $startInfo.UseShellExecute = $false
     $startInfo.RedirectStandardOutput = $true
@@ -264,7 +275,7 @@ function Get-RemoteClawScheduledTaskState {
   }
 
   try {
-    $queryOutput = & schtasks.exe /Query /TN $TaskName /FO LIST 2>$null
+    $queryOutput = & ${quotedSchtasksPath} /Query /TN $TaskName /FO LIST 2>$null
     foreach ($line in $queryOutput) {
       if ($line -match "^\\s*Status:\\s*(.+?)\\s*$") {
         return $Matches[1]

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
-import { resolveWindowsCmdExePath } from "../infra/windows-system-paths.js";
+import {
+  formatRejectedWindowsShellOverride,
+  selectWindowsShellPath,
+} from "../infra/windows-system-paths.js";
+import { logError } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
 import {
@@ -106,9 +110,13 @@ async function execLaunchctl(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const isWindows = process.platform === "win32";
-  // ComSpec stays the primary override; the fallback is pinned so an unset
-  // ComSpec cannot fall through to a %PATH% lookup (CWE-426).
-  const file = isWindows ? (process.env.ComSpec ?? resolveWindowsCmdExePath()) : "launchctl";
+  // ComSpec stays the documented Windows override, but it is validated rather than
+  // trusted — an unusable value falls back to the pinned `cmd.exe` and is reported.
+  const shell = isWindows ? selectWindowsShellPath() : null;
+  if (shell?.rejectedComSpec !== undefined) {
+    logError(formatRejectedWindowsShellOverride(shell));
+  }
+  const file = shell ? shell.path : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
   return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
 }

--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -1,0 +1,117 @@
+// Pins the schtasks.exe path the DETACHED HANDOFF SCRIPT runs.
+//
+// `windows-system-paths.call-sites.test.ts` can see that this module calls a resolver;
+// it cannot see what the emitted `handoff.cjs` does with the result, because the scan
+// reads the module, not the script the module writes (#3112 §4). This suite closes that
+// specific gap by reading the emitted artifacts back off disk.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => ({ pid: 24680, unref: vi.fn() })),
+}));
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    { spawn: spawnMock as unknown as typeof import("node:child_process").spawn },
+  );
+});
+
+const tempDirs = new Set<string>();
+
+afterEach(async () => {
+  spawnMock.mockClear();
+  await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempDirs.clear();
+});
+
+type EmittedHandoff = {
+  script: string;
+  serviceRecovery: { kind?: string; taskName?: string; runner?: string } | undefined;
+};
+
+async function emitSchtasksHandoff(env: NodeJS.ProcessEnv): Promise<EmittedHandoff> {
+  const { startManagedServiceUpdateHandoff } = await import("./update-managed-service-handoff.js");
+  await startManagedServiceUpdateHandoff({
+    root: os.tmpdir(),
+    timeoutMs: 1_800_000,
+    restartDelayMs: 500,
+    parentPid: process.pid,
+    execPath: "/usr/local/bin/node",
+    argv1: "/opt/remoteclaw/remoteclaw.mjs",
+    supervisor: "schtasks",
+    env,
+    meta: {
+      sessionKey: "agent:test:webchat:dm:user-123",
+      continuationMessage: "continue after restart",
+    },
+  });
+
+  const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+  const scriptPath = args[0] ?? "";
+  const paramsPath = args[1] ?? "";
+  tempDirs.add(path.dirname(scriptPath));
+  const params = JSON.parse(await fs.readFile(paramsPath, "utf-8")) as {
+    serviceRecovery?: EmittedHandoff["serviceRecovery"];
+  };
+  return {
+    script: await fs.readFile(scriptPath, "utf-8"),
+    serviceRecovery: params.serviceRecovery,
+  };
+}
+
+describe("managed service update handoff — Windows schtasks pinning", () => {
+  it("carries an absolute %SystemRoot%-resolved runner into the emitted params", async () => {
+    const { serviceRecovery } = await emitSchtasksHandoff({
+      // A non-default root, so this literal cannot be satisfied by the C:\Windows fallback.
+      SystemRoot: "D:\\WinNT",
+      REMOTECLAW_WINDOWS_TASK_NAME: "RemoteClaw Test Gateway",
+    });
+
+    expect(serviceRecovery).toEqual({
+      kind: "schtasks",
+      taskName: "RemoteClaw Test Gateway",
+      runner: "D:\\WinNT\\System32\\schtasks.exe",
+    });
+  });
+
+  it("names no bare schtasks binary anywhere in the emitted script", async () => {
+    const { script } = await emitSchtasksHandoff({
+      SystemRoot: "D:\\WinNT",
+      REMOTECLAW_WINDOWS_TASK_NAME: "RemoteClaw Test Gateway",
+    });
+
+    // The script must reach for the pinned value it was handed, never a name %PATH%
+    // would have to resolve at run time. The binary NAME is what must be absent; the
+    // bare word `"schtasks"` legitimately survives as the recovery-kind discriminant,
+    // which is not an executable position.
+    expect(script).toContain("runServiceCommand(recovery.runner,");
+    expect(script).not.toContain('"schtasks.exe"');
+    expect(script).not.toContain("'schtasks.exe'");
+  });
+
+  // The runner is written by the parent alongside the script, so it is always present in
+  // practice. Fail closed anyway: silently degrading to a bare name is the whole defect.
+  it("refuses to run a schtasks recovery with no pinned runner", async () => {
+    const { script } = await emitSchtasksHandoff({
+      SystemRoot: "D:\\WinNT",
+      REMOTECLAW_WINDOWS_TASK_NAME: "RemoteClaw Test Gateway",
+    });
+
+    expect(script).toContain('typeof recovery.runner !== "string"');
+    expect(script).toContain("gateway service recovery skipped");
+  });
+
+  it("falls back to the default root when SystemRoot is hostile", async () => {
+    const { serviceRecovery } = await emitSchtasksHandoff({
+      SystemRoot: "\\\\attacker\\share\\Windows",
+      REMOTECLAW_WINDOWS_TASK_NAME: "RemoteClaw Test Gateway",
+    });
+
+    expect(serviceRecovery?.runner).toBe("C:\\Windows\\System32\\schtasks.exe");
+  });
+});

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -17,6 +17,7 @@ import {
 } from "./update-control-plane-sentinel.js";
 import { MANAGED_SERVICE_UPDATE_HANDOFF_TEMP_PREFIX } from "./update-managed-service-handoff-cleanup.js";
 import type { UpdateRestartSentinelMeta } from "./update-restart-sentinel-payload.js";
+import { resolveWindowsSystem32Path } from "./windows-system-paths.js";
 
 const PARENT_EXIT_GRACE_MS = 60_000;
 const SYSTEMD_RUN_CANDIDATE_PATHS = ["/usr/bin/systemd-run", "/bin/systemd-run"] as const;
@@ -217,7 +218,14 @@ function startGatewayServiceBestEffort() {
     }
   } else if (recovery.kind === "schtasks") {
     target = recovery.taskName;
-    status = runServiceCommand("schtasks.exe", ["/Run", "/TN", recovery.taskName]);
+    // recovery.runner is the absolute %SystemRoot%\System32\schtasks.exe pinned by the
+    // parent when it wrote this script. Fail closed rather than degrading to a bare
+    // name: a %PATH% lookup here is exactly the untrusted-search-path this avoids.
+    if (typeof recovery.runner !== "string" || recovery.runner.length === 0) {
+      appendLog("gateway service recovery skipped: schtasks runner path missing target=" + target);
+      return;
+    }
+    status = runServiceCommand(recovery.runner, ["/Run", "/TN", recovery.taskName]);
   } else {
     return;
   }
@@ -365,7 +373,7 @@ export function formatManagedServiceUpdateCommand(params?: {
 type GatewayServiceRecovery =
   | { kind: "systemd"; unit: string }
   | { kind: "launchd"; uid: number; label: string; plistPath: string }
-  | { kind: "schtasks"; taskName: string };
+  | { kind: "schtasks"; taskName: string; runner: string };
 
 function resolveGatewayServiceRecovery(
   supervisor: RespawnSupervisor | null | undefined,
@@ -397,7 +405,10 @@ function resolveGatewayServiceRecovery(
     const taskName =
       env.REMOTECLAW_WINDOWS_TASK_NAME?.trim() ||
       resolveGatewayWindowsTaskName(env.REMOTECLAW_PROFILE);
-    return { kind: "schtasks", taskName };
+    // Resolve here, in the parent, and carry the absolute path into the emitted
+    // handoff script. A binary named inside generated script content is invisible to
+    // every source scan of this repo, so the pinning has to happen at emission time.
+    return { kind: "schtasks", taskName, runner: resolveWindowsSystem32Path("schtasks.exe", env) };
   }
   return undefined;
 }

--- a/src/infra/windows-system-paths.call-sites.test.ts
+++ b/src/infra/windows-system-paths.call-sites.test.ts
@@ -79,7 +79,11 @@ const EXPECTED_CALL_SITES: Readonly<Record<string, readonly string[]>> = {
   "src/infra/update-managed-service-handoff.ts": [`${SYSTEM32}\\schtasks.exe`],
   "src/infra/windows-encoding.ts": [CMD_EXE, POWERSHELL],
   "src/infra/windows-port-pids.ts": [POWERSHELL, `${SYSTEM32}\\netstat.exe`, POWERSHELL, WMIC],
-  "src/infra/windows-task-restart.ts": [CMD_EXE],
+  // The schtasks.exe entry is interpolated into the emitted `.cmd` (both the /Query probe
+  // and the /Run retry), not spawned as argv from this module. CMD_EXE is the argv spawn of
+  // that script. The `powershell.exe`, `findstr` and `cmd.exe` names ALSO inside that
+  // emitted script are still bare — see the scope note below.
+  "src/infra/windows-task-restart.ts": [`${SYSTEM32}\\schtasks.exe`, CMD_EXE],
   "src/node-host/invoke-system-run.ts": [CMD_EXE],
   "src/process/exec.ts": [CMD_EXE],
   "src/process/kill-tree.ts": [`${SYSTEM32}\\taskkill.exe`],
@@ -92,13 +96,36 @@ const EXPECTED_CALL_SITES: Readonly<Record<string, readonly string[]>> = {
 
 // #3088 pinned 27 executable-position sites; #3099 added the 28th — the `rundll32.exe`
 // in `onboard-helpers.ts`, which replaced a `cmd /c start` that re-parsed the URL through
-// the shell. #3112 added the last five: `windows-acl.ts` had a third, unhardened copy of
-// the resolver (whoami + icacls) plus a bare `icacls` on the ACL-reset path, and two
-// `schtasks.exe` spawns named inside *emitted script content* — one in the detached update
-// handoff, one in the update restart helper's PowerShell — were pinned at emission time.
-// Stated independently of the table above so a merge that drops rows cannot quietly shrink
-// the covered surface.
-const EXPECTED_CALL_SITE_COUNT = 33;
+// the shell. #3112 added five more: `windows-acl.ts` had a third, unhardened copy of the
+// resolver (whoami + icacls) plus a bare `icacls` on the ACL-reset path, and `schtasks`
+// named inside *emitted script content* — the detached update handoff and the update
+// restart helper's PowerShell — was pinned at emission time. #3116 added the 34th, the
+// `schtasks` pair inside the scheduled-task restart `.cmd`, which #3112 §4 named alongside
+// the other two and the first pass left bare.
+//
+// SCOPE — what a green run here does and does NOT establish. Covered:
+//   - every argv-position spawn of a Windows system binary under `src/`;
+//   - the `schtasks` invocations inside emitted script content that #3112 §4 NAMED.
+// NOT covered: bare binaries inside emitted script content generally. Known-bare today,
+// deliberately out of scope, and invisible to this suite because it scans for resolver
+// CALLS rather than for binary names in emitted strings:
+//   - `cli/update-cli/restart-helper.ts` — `& netstat.exe -ano -p tcp` (emitted PowerShell)
+//   - `cli/update-cli/restart-helper.ts` — `powershell -NoProfile …` (emitted `.cmd` header)
+//   - `infra/windows-task-restart.ts`    — `powershell.exe …` and `findstr` (emitted `.cmd`)
+//   - `infra/windows-task-restart.ts`    — `start "" /min cmd.exe /d /c …` (startup fallback)
+// So this is an inventory of a covered surface, not a closed class. Do not read it as
+// "emitted scripts are fully pinned".
+//
+// One more limit worth knowing before trusting a green run: this suite scans for resolver
+// CALLS, so for an emitted-script row it proves the parent RESOLVES the path — not that the
+// emitted text still USES it. Reverting an emitted `${quotedSchtasksPath}` to a bare name
+// while leaving the call in place passes here; only the behavioural suite next to each
+// emitter (`windows-task-restart.test.ts`, `restart-helper.test.ts`) fails on that. Verified
+// by mutation, not assumed.
+//
+// The count is stated independently of the table above so a merge that drops rows cannot
+// quietly shrink the covered surface.
+const EXPECTED_CALL_SITE_COUNT = 34;
 
 // `selectWindowsShellPath` is the fifth name because #3100 moved the `%ComSpec%` decision
 // behind it: `exec.ts` and `launchd.ts` used to call `resolveWindowsCmdExePath` directly as

--- a/src/infra/windows-system-paths.call-sites.test.ts
+++ b/src/infra/windows-system-paths.call-sites.test.ts
@@ -33,6 +33,7 @@ import {
   resolveWindowsPowerShellPath,
   resolveWindowsSystem32Path,
   resolveWindowsWmicPath,
+  selectWindowsShellPath,
 } from "./windows-system-paths.js";
 
 const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -57,7 +58,9 @@ const WMIC = `${SYSTEM32}\\wbem\\WMIC.exe`;
 const EXPECTED_CALL_SITES: Readonly<Record<string, readonly string[]>> = {
   "src/agents/date-time.ts": [POWERSHELL],
   "src/cli/ports.ts": [`${SYSTEM32}\\netstat.exe`],
-  "src/cli/update-cli/restart-helper.ts": [CMD_EXE],
+  // The schtasks.exe entry is interpolated into emitted PowerShell, not spawned as argv
+  // from this module — see `selectWindowsShellPath` note below on emitted-script pinning.
+  "src/cli/update-cli/restart-helper.ts": [`${SYSTEM32}\\schtasks.exe`, CMD_EXE],
   "src/commands/onboard-helpers.ts": [`${SYSTEM32}\\rundll32.exe`, `${SYSTEM32}\\where.exe`],
   "src/daemon/launchd.ts": [CMD_EXE],
   "src/daemon/program-args.ts": [`${SYSTEM32}\\where.exe`],
@@ -72,31 +75,48 @@ const EXPECTED_CALL_SITES: Readonly<Record<string, readonly string[]>> = {
     `${SYSTEM32}\\netstat.exe`,
     `${SYSTEM32}\\netstat.exe`,
   ],
+  // The schtasks.exe entry is the runner path carried into the emitted handoff script.
+  "src/infra/update-managed-service-handoff.ts": [`${SYSTEM32}\\schtasks.exe`],
   "src/infra/windows-encoding.ts": [CMD_EXE, POWERSHELL],
   "src/infra/windows-port-pids.ts": [POWERSHELL, `${SYSTEM32}\\netstat.exe`, POWERSHELL, WMIC],
   "src/infra/windows-task-restart.ts": [CMD_EXE],
   "src/node-host/invoke-system-run.ts": [CMD_EXE],
   "src/process/exec.ts": [CMD_EXE],
   "src/process/kill-tree.ts": [`${SYSTEM32}\\taskkill.exe`],
+  "src/security/windows-acl.ts": [
+    `${SYSTEM32}\\whoami.exe`,
+    `${SYSTEM32}\\icacls.exe`,
+    `${SYSTEM32}\\icacls.exe`,
+  ],
 };
 
 // #3088 pinned 27 executable-position sites; #3099 added the 28th — the `rundll32.exe`
 // in `onboard-helpers.ts`, which replaced a `cmd /c start` that re-parsed the URL through
-// the shell. Stated independently of the table above so a merge that drops rows cannot
-// quietly shrink the covered surface.
-const EXPECTED_CALL_SITE_COUNT = 28;
+// the shell. #3112 added the last five: `windows-acl.ts` had a third, unhardened copy of
+// the resolver (whoami + icacls) plus a bare `icacls` on the ACL-reset path, and two
+// `schtasks.exe` spawns named inside *emitted script content* — one in the detached update
+// handoff, one in the update restart helper's PowerShell — were pinned at emission time.
+// Stated independently of the table above so a merge that drops rows cannot quietly shrink
+// the covered surface.
+const EXPECTED_CALL_SITE_COUNT = 33;
 
+// `selectWindowsShellPath` is the fifth name because #3100 moved the `%ComSpec%` decision
+// behind it: `exec.ts` and `launchd.ts` used to call `resolveWindowsCmdExePath` directly as
+// the right-hand side of a `??`, which honoured a set-but-hostile ComSpec unchecked. Listing
+// it here is what keeps both of those spawn sites in the inventory rather than dropping them
+// as "no resolver mentioned" — the failure mode #3112 named for unscanned files.
 const RESOLVER_NAMES = [
   "resolveWindowsSystem32Path",
   "resolveWindowsCmdExePath",
   "resolveWindowsPowerShellPath",
   "resolveWindowsWmicPath",
+  "selectWindowsShellPath",
 ] as const;
 
 // Ordered so `resolveWindowsSystem32Path` (which takes the executable name) is
 // distinguishable from the fixed-target resolvers.
 const CALL_RE =
-  /\bresolveWindows(?:(System32Path)\(\s*"([^"]*)"|(CmdExePath)\(|(PowerShellPath)\(|(WmicPath)\()/gu;
+  /\b(?:resolveWindows(?:(System32Path)\(\s*"([^"]*)"|(CmdExePath)\(|(PowerShellPath)\(|(WmicPath)\()|(selectWindowsShellPath)\()/gu;
 
 /** Drop comments so a commented-out call, or a resolver named in prose, is not scanned. */
 function stripComments(source: string): string {
@@ -133,7 +153,7 @@ function listProductionSources(dir: string): string[] {
 
 /** Resolve the absolute path a single scanned call site produces. */
 function resolveScannedCall(match: RegExpExecArray): string {
-  const [, system32, executableName, cmdExe, powerShell] = match;
+  const [, system32, executableName, cmdExe, powerShell, wmic] = match;
   if (system32) {
     return resolveWindowsSystem32Path(executableName ?? "", TEST_ENV);
   }
@@ -143,7 +163,13 @@ function resolveScannedCall(match: RegExpExecArray): string {
   if (powerShell) {
     return resolveWindowsPowerShellPath(TEST_ENV);
   }
-  return resolveWindowsWmicPath(TEST_ENV);
+  if (wmic) {
+    return resolveWindowsWmicPath(TEST_ENV);
+  }
+  // TEST_ENV carries no ComSpec, so this is the pinned branch. The override branch is
+  // behavioural and lives in `exec.windows.test.ts`; here it would make the inventory
+  // depend on whatever ComSpec the host running the suite happens to have.
+  return selectWindowsShellPath(TEST_ENV).path;
 }
 
 type ScannedFile = { relPath: string; code: string; paths: string[] };

--- a/src/infra/windows-system-paths.call-sites.test.ts
+++ b/src/infra/windows-system-paths.call-sites.test.ts
@@ -81,8 +81,9 @@ const EXPECTED_CALL_SITES: Readonly<Record<string, readonly string[]>> = {
   "src/infra/windows-port-pids.ts": [POWERSHELL, `${SYSTEM32}\\netstat.exe`, POWERSHELL, WMIC],
   // The schtasks.exe entry is interpolated into the emitted `.cmd` (both the /Query probe
   // and the /Run retry), not spawned as argv from this module. CMD_EXE is the argv spawn of
-  // that script. The `powershell.exe`, `findstr` and `cmd.exe` names ALSO inside that
-  // emitted script are still bare — see the scope note below.
+  // that script. Other binary names ALSO inside that emitted script are still bare — the
+  // scope note below enumerates them. Deliberately not re-listed here: this row carried its
+  // own copy of that set and the copy went stale, which is the defect the note now warns about.
   "src/infra/windows-task-restart.ts": [`${SYSTEM32}\\schtasks.exe`, CMD_EXE],
   "src/node-host/invoke-system-run.ts": [CMD_EXE],
   "src/process/exec.ts": [CMD_EXE],
@@ -109,12 +110,22 @@ const EXPECTED_CALL_SITES: Readonly<Record<string, readonly string[]>> = {
 // NOT covered: bare binaries inside emitted script content generally. Known-bare today,
 // deliberately out of scope, and invisible to this suite because it scans for resolver
 // CALLS rather than for binary names in emitted strings:
-//   - `cli/update-cli/restart-helper.ts` — `& netstat.exe -ano -p tcp` (emitted PowerShell)
-//   - `cli/update-cli/restart-helper.ts` — `powershell -NoProfile …` (emitted `.cmd` header)
-//   - `infra/windows-task-restart.ts`    — `powershell.exe …` and `findstr` (emitted `.cmd`)
-//   - `infra/windows-task-restart.ts`    — `start "" /min cmd.exe /d /c …` (startup fallback)
-// So this is an inventory of a covered surface, not a closed class. Do not read it as
-// "emitted scripts are fully pinned".
+//   - `cli/update-cli/restart-helper.ts:193` — `powershell -NoProfile …` (`.cmd` header)
+//   - `cli/update-cli/restart-helper.ts:306` — `& netstat.exe -ano -p tcp` (PowerShell body)
+//   - `infra/windows-task-restart.ts:52`     — `timeout /t … /nobreak` (in the `:retry` loop)
+//   - `infra/windows-task-restart.ts:55`     — `powershell.exe …` and `findstr` (`.cmd`)
+//   - `infra/windows-task-restart.ts:66`     — `start "" /min cmd.exe /d /c …` (fallback)
+//   - `daemon/schtasks.ts:372`               — `start "" /min cmd.exe /d /c …` (login item)
+// `timeout` is the one most easily skipped: it reads like a `cmd.exe` builtin and is not one.
+// It is `%SystemRoot%\System32\timeout.exe`, and it sits BETWEEN the two `schtasks` lines
+// #3116 pinned — same emitted script, same inherited-cwd-then-%PATH% resolution. Line numbers
+// above are a finding aid, not a pin; nothing re-checks them.
+//
+// So this is an inventory of a covered surface, not a closed class — and the bullets are an
+// inventory of what is KNOWN bare at time of writing, not a proof the set is complete. Nothing
+// in CI scans emitted script content for binary names, so a binary added to an emitted script
+// later joins that set without failing anything here. Do not read this as "emitted scripts are
+// fully pinned", and do not read pinning these six as closing the class.
 //
 // One more limit worth knowing before trusting a green run: this suite scans for resolver
 // CALLS, so for an emitted-script row it proves the parent RESOLVES the path — not that the

--- a/src/infra/windows-system-paths.test.ts
+++ b/src/infra/windows-system-paths.test.ts
@@ -1,11 +1,13 @@
 // Covers %SystemRoot% resolution hardening for pinned Windows system binaries.
 import { describe, expect, it } from "vitest";
 import {
+  formatRejectedWindowsShellOverride,
   resolveWindowsCmdExePath,
   resolveWindowsPowerShellPath,
   resolveWindowsSystem32Path,
   resolveWindowsSystemRoot,
   resolveWindowsWmicPath,
+  selectWindowsShellPath,
 } from "./windows-system-paths.js";
 
 const DEFAULT_ROOT = "C:\\Windows";
@@ -14,6 +16,43 @@ const DEFAULT_ROOT = "C:\\Windows";
 function env(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
   return values;
 }
+
+// One table, deliberately shared by the `%SystemRoot%` and `%ComSpec%` suites below.
+// #3100 existed because those two inputs had different amounts of validation; running
+// both against the SAME rows is what makes "one shared predicate" a checked claim rather
+// than a code-review observation. A second copy of this table would re-open the gap.
+const HOSTILE_PATH_SHAPES: readonly (readonly [string, string])[] = [
+  ["NUL byte", "C:\\Win\0dows"],
+  // Embedded, not trailing. A TRAILING CR/LF is removed by the leading `.trim()` and the
+  // value is then accepted — see the "trims" rows in the accept table below. The rows here
+  // used to be `"C:\\Windows\r"`, which asserted nothing: it trims to `C:\Windows`, which
+  // IS the default root, so the expectation held whether or not the guard ran.
+  ["embedded carriage return", "C:\\Win\rdows"],
+  ["embedded line feed", "C:\\Win\ndows"],
+  ["carriage return before a forged second value", "C:\\Windows\r\nC:\\Evil"],
+  ["semicolon (PATH separator injection)", "C:\\Windows;C:\\Evil"],
+  ["relative path", "Windows"],
+  ["dot-relative path", ".\\Windows"],
+  ["UNC path", "\\\\attacker\\share\\Windows"],
+  ["bare drive root with no subdirectory", "C:\\"],
+  ["POSIX absolute path (no drive letter)", "/usr/share/windows"],
+  ["empty string", ""],
+  ["whitespace only", "   "],
+  // `path.win32.normalize` collapses `..` BEFORE the shape checks run, so a
+  // traversal emerges as a clean absolute drive-rooted non-UNC path that
+  // satisfies every other guard. These must be rejected on the raw value.
+  ["parent-segment traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
+  ["forward-slash traversal", "C:/Windows/../Users/pub/evil"],
+  ["mixed-separator traversal", "C:\\Windows/../Users\\pub\\evil"],
+  ["traversal landing beside the drive root", "C:\\Windows\\..\\evil"],
+  ["traversal clamped at the drive root", "C:\\Windows\\..\\..\\..\\..\\Users"],
+  ["traversal with a trailing separator", "C:\\Windows\\..\\Users\\pub\\evil\\"],
+  // Not raw-value cases: these two collapse to shapes the pre-existing checks
+  // already reject (bare drive root, relative path). They pin that overlap, and
+  // would still pass with the raw-value guard removed.
+  ["traversal collapsing to the bare drive root", "C:\\Windows\\.."],
+  ["leading traversal, which stays relative", "..\\Windows"],
+] as const;
 
 describe("resolveWindowsSystemRoot", () => {
   it("accepts a well-formed SystemRoot", () => {
@@ -37,33 +76,7 @@ describe("resolveWindowsSystemRoot", () => {
 
   // Each rejection branch must fall through to the safe default rather than
   // letting an attacker-shaped value reach a spawn.
-  it.each([
-    ["NUL byte", "C:\\Win\0dows"],
-    ["carriage return", "C:\\Windows\r"],
-    ["line feed", "C:\\Windows\n"],
-    ["semicolon (PATH separator injection)", "C:\\Windows;C:\\Evil"],
-    ["relative path", "Windows"],
-    ["dot-relative path", ".\\Windows"],
-    ["UNC path", "\\\\attacker\\share\\Windows"],
-    ["bare drive root with no subdirectory", "C:\\"],
-    ["POSIX absolute path (no drive letter)", "/usr/share/windows"],
-    ["empty string", ""],
-    ["whitespace only", "   "],
-    // `path.win32.normalize` collapses `..` BEFORE the shape checks run, so a
-    // traversal emerges as a clean absolute drive-rooted non-UNC path that
-    // satisfies every other guard. These must be rejected on the raw value.
-    ["parent-segment traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
-    ["forward-slash traversal", "C:/Windows/../Users/pub/evil"],
-    ["mixed-separator traversal", "C:\\Windows/../Users\\pub\\evil"],
-    ["traversal landing beside the drive root", "C:\\Windows\\..\\evil"],
-    ["traversal clamped at the drive root", "C:\\Windows\\..\\..\\..\\..\\Users"],
-    ["traversal with a trailing separator", "C:\\Windows\\..\\Users\\pub\\evil\\"],
-    // Not raw-value cases: these two collapse to shapes the pre-existing checks
-    // already reject (bare drive root, relative path). They pin that overlap, and
-    // would still pass with the raw-value guard removed.
-    ["traversal collapsing to the bare drive root", "C:\\Windows\\.."],
-    ["leading traversal, which stays relative", "..\\Windows"],
-  ])("rejects %s and falls back to the default root", (_label, raw) => {
+  it.each(HOSTILE_PATH_SHAPES)("rejects %s and falls back to the default root", (_label, raw) => {
     expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(DEFAULT_ROOT);
   });
 
@@ -76,6 +89,11 @@ describe("resolveWindowsSystemRoot", () => {
     ["a directory name containing dots", "C:\\Win..dows", "C:\\Win..dows"],
     ["a trailing-dots directory name", "D:\\WinNT..", "D:\\WinNT.."],
     ["a literal three-dot segment", "C:\\Windows\\...", "C:\\Windows\\..."],
+    // Trailing control characters are whitespace to `.trim()`, so the value that reaches
+    // the shape checks — and the spawn — is already clean. Recorded as an ACCEPT with the
+    // trimmed result rather than mislabelled as a rejection.
+    ["a trailing carriage return, trimmed away", "D:\\WinNT\r", "D:\\WinNT"],
+    ["a trailing line feed, trimmed away", "D:\\WinNT\n", "D:\\WinNT"],
   ])("accepts %s", (_label, raw, expected) => {
     expect(resolveWindowsSystemRoot(env({ SystemRoot: raw }))).toBe(expected);
   });
@@ -163,5 +181,104 @@ describe("named binary resolvers", () => {
       "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
     );
     expect(resolveWindowsWmicPath(hostile)).toBe("C:\\Windows\\System32\\wbem\\WMIC.exe");
+  });
+});
+
+// The shell selector is the one input the pinning workstream left unvalidated: the
+// expression it replaces was `process.env.ComSpec ?? resolveWindowsCmdExePath()`, and `??`
+// falls through only on null/undefined — so ANY set value won, however shaped (#3100).
+describe("selectWindowsShellPath", () => {
+  const PINNED = "D:\\WinNT\\System32\\cmd.exe";
+  const ROOT = { SystemRoot: "D:\\WinNT" };
+
+  it("honours a well-formed ComSpec", () => {
+    const override = "E:\\CustomWindows\\System32\\cmd.exe";
+    // Guard: the two branches must be distinguishable, else nothing below is asserted.
+    expect(override).not.toBe(PINNED);
+    expect(selectWindowsShellPath(env({ ...ROOT, ComSpec: override }))).toEqual({
+      path: override,
+    });
+  });
+
+  it("reads ComSpec case-insensitively, as Windows does", () => {
+    const override = "E:\\CustomWindows\\System32\\cmd.exe";
+    expect(selectWindowsShellPath(env({ ...ROOT, COMSPEC: override })).path).toBe(override);
+    expect(selectWindowsShellPath(env({ ...ROOT, comspec: override })).path).toBe(override);
+  });
+
+  it("pins when ComSpec is unset, and reports no refusal", () => {
+    expect(selectWindowsShellPath(env(ROOT))).toEqual({ path: PINNED });
+  });
+
+  // A blank ComSpec is "no override", not an operator mistake worth shouting about.
+  it.each([
+    ["empty", ""],
+    ["whitespace only", "   "],
+  ])("pins a %s ComSpec without reporting a refusal", (_label, raw) => {
+    expect(selectWindowsShellPath(env({ ...ROOT, ComSpec: raw }))).toEqual({ path: PINNED });
+  });
+
+  // The point of the change: every shape `%SystemRoot%` rejects, `%ComSpec%` now rejects
+  // too. Reusing HOSTILE_PATH_SHAPES is what proves the predicate is genuinely shared —
+  // if the two ever diverge, a row here fails without anyone having to notice by eye.
+  it.each(HOSTILE_PATH_SHAPES)("refuses %s and falls back to the pinned cmd.exe", (_label, raw) => {
+    const selection = selectWindowsShellPath(env({ ...ROOT, ComSpec: raw }));
+    expect(selection.path).toBe(PINNED);
+    // Blank values are "unset", not refusals — they are covered by the case above.
+    if (raw.trim()) {
+      expect(selection.rejectedComSpec).toBe(raw);
+    }
+  });
+
+  // The three shapes #3100 called out by name, asserted as literals so the failure
+  // message names the attack rather than a table index.
+  it("refuses a traversal ComSpec", () => {
+    expect(
+      selectWindowsShellPath(env({ ...ROOT, ComSpec: "C:\\Windows\\..\\Users\\pub\\evil.exe" }))
+        .path,
+    ).toBe(PINNED);
+  });
+
+  it("refuses a UNC ComSpec so a remote share cannot supply the shell", () => {
+    expect(
+      selectWindowsShellPath(env({ ...ROOT, ComSpec: "\\\\attacker\\share\\cmd.exe" })).path,
+    ).toBe(PINNED);
+  });
+
+  it("refuses a ComSpec carrying an embedded PATH separator", () => {
+    expect(
+      selectWindowsShellPath(
+        env({ ...ROOT, ComSpec: "C:\\Windows\\System32\\cmd.exe;C:\\Evil\\cmd.exe" }),
+      ).path,
+    ).toBe(PINNED);
+  });
+
+  // Honest boundary: a shape gate equalizes ComSpec with SystemRoot, it does not make an
+  // attacker-controlled environment block safe. Stated as a test so the limit is recorded
+  // where someone reading the guard will see it, not only in a PR description.
+  it("still accepts a well-formed path to an arbitrary executable", () => {
+    const planted = "C:\\Users\\Public\\evil.exe";
+    expect(selectWindowsShellPath(env({ ...ROOT, ComSpec: planted }))).toEqual({ path: planted });
+  });
+
+  it("explains the refusal with both the refused value and the fallback", () => {
+    // A backslash-free refused value keeps this expectation readable: the message renders
+    // the value JSON-escaped, so a Windows path would have to be written with doubled
+    // backslashes here and would restate the implementation rather than assert it.
+    const selection = selectWindowsShellPath(env({ ...ROOT, ComSpec: "/usr/share/windows" }));
+    const message = formatRejectedWindowsShellOverride(selection);
+    expect(message).toContain("/usr/share/windows");
+    expect(message).toContain(PINNED);
+  });
+
+  // The refused value is attacker-shaped by definition and is about to be written to a
+  // log, where a raw CR/LF would forge a second log line.
+  it("neutralizes control characters in the refused value", () => {
+    const message = formatRejectedWindowsShellOverride(
+      selectWindowsShellPath(env({ ...ROOT, ComSpec: "C:\\Win\r\nFORGED LOG LINE" })),
+    );
+    expect(message).not.toContain("\r");
+    expect(message).not.toContain("\n");
+    expect(message).toContain("FORGED LOG LINE");
   });
 });

--- a/src/infra/windows-system-paths.test.ts
+++ b/src/infra/windows-system-paths.test.ts
@@ -281,4 +281,37 @@ describe("selectWindowsShellPath", () => {
     expect(message).not.toContain("\n");
     expect(message).toContain("FORGED LOG LINE");
   });
+
+  // The OTHER half of the same message. `selection.path` is `%SystemRoot%`-derived, and the
+  // shape gate rejects NUL, CR, LF and `;` but NOT ESC — so a hostile SystemRoot is ACCEPTED
+  // and rides into `logError` through the fallback clause (CWE-117). The refused value is
+  // JSON-escaped and the fallback path was not, which is the asymmetry this pins.
+  it("neutralizes terminal escapes in the fallback path", () => {
+    const escape = String.fromCharCode(0x1b);
+    const hostileRoot = `D:\\Win${escape}[31mNT`;
+    // Guard: the gate really does accept this root, so the formatter is what is under test
+    // here rather than a rejection that never reaches it.
+    expect(resolveWindowsSystemRoot(env({ SystemRoot: hostileRoot }))).toBe(hostileRoot);
+
+    const message = formatRejectedWindowsShellOverride(
+      selectWindowsShellPath(env({ SystemRoot: hostileRoot, ComSpec: "evil.exe" })),
+    );
+    expect(message).not.toContain(escape);
+    expect(message).toContain("Using D:\\WinNT\\System32\\cmd.exe instead.");
+  });
+
+  // `JSON.stringify` escapes every C0 control, but leaves DEL (0x7f) and C1 (0x80-0x9f)
+  // raw — so JSON escaping alone is not a log-safety guarantee for the refused value.
+  it("strips the controls JSON escaping leaves raw in the refused value", () => {
+    const del = String.fromCharCode(0x7f);
+    const c1ControlSequenceIntroducer = String.fromCharCode(0x9b);
+    const message = formatRejectedWindowsShellOverride(
+      selectWindowsShellPath(
+        env({ ...ROOT, ComSpec: `evil${del}${c1ControlSequenceIntroducer}31m.exe` }),
+      ),
+    );
+    expect(message).not.toContain(del);
+    expect(message).not.toContain(c1ControlSequenceIntroducer);
+    expect(message).toContain('Refusing ComSpec="evil31m.exe":');
+  });
 });

--- a/src/infra/windows-system-paths.ts
+++ b/src/infra/windows-system-paths.ts
@@ -11,7 +11,13 @@
 // (so it cannot import TypeScript), it lives outside the tsconfig `include`,
 // and `scripts/lib/docker-e2e-package.sh` bind-mounts it into a container as a
 // single standalone file. Keep the two in sync by hand when either changes.
+//
+// What is shared is the RESOLVER family (`resolveWindowsSystemRoot` and the pinned-path
+// helpers built on it). The `%ComSpec%` selector and its operator-facing message below have
+// no counterpart in the `.mjs` — build tooling never reads ComSpec — so the `sanitizeForLog`
+// import they need is not twin drift and nothing is owed to the other copy for it.
 import path from "node:path";
+import { sanitizeForLog } from "../terminal/ansi.js";
 
 const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 const WINDOWS_SYSTEM32_EXE_NAME_RE = /^[A-Za-z0-9_.-]+\.exe$/u;
@@ -148,13 +154,22 @@ export function selectWindowsShellPath(
 /**
  * Operator-facing explanation for a refused `%ComSpec%`. Lives next to the gate so both
  * call sites emit the same wording without either owning a copy of it.
+ *
+ * BOTH interpolated values are sanitized, because both are environment-derived and this
+ * string goes straight to `logError` (CWE-117):
+ *
+ *  - `selection.path` is `%SystemRoot%`-derived, and the shape gate above rejects NUL, CR,
+ *    LF and `;` but NOT ESC — so `SystemRoot=C:\W<ESC>[31mnt` is ACCEPTED and would carry a
+ *    live terminal escape into the log through the fallback path.
+ *  - `rejectedComSpec` is JSON-escaped, which covers ESC and every other C0 control, but
+ *    `JSON.stringify` leaves DEL (0x7f) and C1 (0x80-0x9f) raw.
  */
 export function formatRejectedWindowsShellOverride(selection: WindowsShellSelection): string {
   return [
-    `Refusing ComSpec=${JSON.stringify(selection.rejectedComSpec ?? "")}:`,
+    `Refusing ComSpec=${sanitizeForLog(JSON.stringify(selection.rejectedComSpec ?? ""))}:`,
     "a Windows shell override must be an absolute drive-letter path (not UNC),",
     "with no `..` segment and no NUL, CR, LF or `;` character.",
-    `Using ${selection.path} instead.`,
+    `Using ${sanitizeForLog(selection.path)} instead.`,
   ].join(" ");
 }
 

--- a/src/infra/windows-system-paths.ts
+++ b/src/infra/windows-system-paths.ts
@@ -37,7 +37,15 @@ function hasParentTraversalSegment(rawPath: string): boolean {
   return rawPath.split(/[\\/]/u).includes("..");
 }
 
-function normalizeWindowsSystemRoot(raw: string | undefined): string | null {
+/**
+ * The single shape gate every operator-supplied Windows path in this module passes
+ * through: `%SystemRoot%` / `%WINDIR%` (the install root) and `%ComSpec%` (the shell
+ * override). Returns the normalized path, or null when the value is unusable.
+ *
+ * Deliberately one implementation rather than one per consumer: a second copy of this
+ * predicate is how a hardening pass silently misses a caller.
+ */
+function normalizeAbsoluteWindowsPath(raw: string | undefined): string | null {
   const trimmed = raw?.trim();
   if (
     !trimmed ||
@@ -68,8 +76,8 @@ function normalizeWindowsSystemRoot(raw: string | undefined): string | null {
 /** Resolve the Windows install root, falling back to `C:\Windows` when unusable. */
 export function resolveWindowsSystemRoot(env: NodeJS.ProcessEnv = process.env): string {
   return (
-    normalizeWindowsSystemRoot(getEnvValueCaseInsensitive(env, "SystemRoot")) ??
-    normalizeWindowsSystemRoot(getEnvValueCaseInsensitive(env, "WINDIR")) ??
+    normalizeAbsoluteWindowsPath(getEnvValueCaseInsensitive(env, "SystemRoot")) ??
+    normalizeAbsoluteWindowsPath(getEnvValueCaseInsensitive(env, "WINDIR")) ??
     DEFAULT_WINDOWS_SYSTEM_ROOT
   );
 }
@@ -93,6 +101,61 @@ export function resolveWindowsSystem32Path(
 /** Resolve the absolute path to `cmd.exe`. */
 export function resolveWindowsCmdExePath(env: NodeJS.ProcessEnv = process.env): string {
   return resolveWindowsSystem32Path("cmd.exe", env);
+}
+
+export type WindowsShellSelection = {
+  /** The absolute path the caller must spawn. */
+  path: string;
+  /**
+   * The `%ComSpec%` value that was refused. Present only when ComSpec carried a
+   * non-blank value that failed the shape gate — an unset or blank ComSpec is
+   * "no override", not a refusal, and reports nothing.
+   */
+  rejectedComSpec?: string;
+};
+
+/**
+ * Select the Windows command shell: honour a WELL-FORMED `%ComSpec%`, pin to
+ * `%SystemRoot%\System32\cmd.exe` otherwise.
+ *
+ * `process.env.ComSpec ?? resolveWindowsCmdExePath()` — the expression this replaces —
+ * fell through only on `null`/`undefined`. A set-but-malformed ComSpec therefore skipped
+ * every check the resolver performs, leaving the shell selector as the one unguarded input
+ * in a subsystem that pins every other Windows system-binary spawn. ComSpec now passes the
+ * SAME gate as `%SystemRoot%`.
+ *
+ * Scope, stated plainly: this equalizes ComSpec with SystemRoot, it does not make ComSpec
+ * trustworthy. A caller who controls the environment block can still name a well-formed
+ * absolute path to an executable of their choosing — that is true of `%SystemRoot%` too,
+ * and closing it needs an allowlist or a signature check, not a shape gate.
+ *
+ * Existence is deliberately NOT checked: this module stays free of `node:fs`, the check
+ * would be TOCTOU against the spawn, and a planted `cmd.exe` exists just as much as the
+ * real one.
+ */
+export function selectWindowsShellPath(
+  env: NodeJS.ProcessEnv = process.env,
+): WindowsShellSelection {
+  const raw = getEnvValueCaseInsensitive(env, "ComSpec");
+  const accepted = normalizeAbsoluteWindowsPath(raw);
+  if (accepted) {
+    return { path: accepted };
+  }
+  const pinned = resolveWindowsCmdExePath(env);
+  return raw?.trim() ? { path: pinned, rejectedComSpec: raw } : { path: pinned };
+}
+
+/**
+ * Operator-facing explanation for a refused `%ComSpec%`. Lives next to the gate so both
+ * call sites emit the same wording without either owning a copy of it.
+ */
+export function formatRejectedWindowsShellOverride(selection: WindowsShellSelection): string {
+  return [
+    `Refusing ComSpec=${JSON.stringify(selection.rejectedComSpec ?? "")}:`,
+    "a Windows shell override must be an absolute drive-letter path (not UNC),",
+    "with no `..` segment and no NUL, CR, LF or `;` character.",
+    `Using ${selection.path} instead.`,
+  ].join(" ");
 }
 
 /** Resolve the absolute path to Windows PowerShell (not in System32 directly). */

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -32,6 +32,21 @@ vi.mock("../daemon/schtasks.js", () => ({
     resolveTaskScriptPathMock(env),
 }));
 
+// A non-default install root, so the literal `schtasks.exe` paths asserted below cannot be
+// satisfied by the `C:\Windows` fallback — the emission has to actually read this env. Same
+// rationale as `TEST_ENV` in `windows-system-paths.call-sites.test.ts`.
+const TEST_SYSTEM_ROOT = "D:\\WinNT";
+const PINNED_SCHTASKS = "D:\\WinNT\\System32\\schtasks.exe";
+
+/**
+ * Every `schtasks` line in the emitted script, so the pinning can be asserted as "these
+ * exact lines" rather than "the pinned path appears somewhere". A `toContain` on the pinned
+ * path alone stays green if an unpinned invocation is added next to it.
+ */
+function schtasksLines(script: string): string[] {
+  return script.split(/\r?\n/u).filter((line) => /schtasks/iu.test(line));
+}
+
 type WindowsTaskRestartModule = typeof import("./windows-task-restart.js");
 
 let relaunchGatewayScheduledTask: WindowsTaskRestartModule["relaunchGatewayScheduledTask"];
@@ -100,11 +115,14 @@ describe("relaunchGatewayScheduledTask", () => {
       return { unref };
     });
 
-    const result = relaunchGatewayScheduledTask({ REMOTECLAW_PROFILE: "work" });
+    const result = relaunchGatewayScheduledTask({
+      REMOTECLAW_PROFILE: "work",
+      SystemRoot: TEST_SYSTEM_ROOT,
+    });
 
     expect(result.ok).toBe(true);
     expect(result.method).toBe("schtasks");
-    expect(result.tried).toContain('schtasks /Run /TN "RemoteClaw Gateway (work)"');
+    expect(result.tried).toContain(`${PINNED_SCHTASKS} /Run /TN "RemoteClaw Gateway (work)"`);
     expect(result.tried).toContain(`cmd.exe /d /s /c ${seenCommandArg}`);
     const spawnCall = requireFirstMockCall(spawnMock, "restart helper spawn");
     expect(spawnCall[0]).toBe(resolveWindowsCmdExePath());
@@ -130,10 +148,18 @@ describe("relaunchGatewayScheduledTask", () => {
     expect(script).toContain(
       `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "(Get-ScheduledTask -TaskName 'RemoteClaw Gateway (work)' -ErrorAction SilentlyContinue).State" 2>nul | findstr /I /C:"Running" >nul 2>&1`,
     );
-    expect(script).toContain('schtasks /Run /TN "RemoteClaw Gateway (work)" >>');
+    expect(script).toContain(`${PINNED_SCHTASKS} /Run /TN "RemoteClaw Gateway (work)" >>`);
     expect(script.indexOf("powershell.exe -NoProfile")).toBeLessThan(
-      script.indexOf('schtasks /Run /TN "RemoteClaw Gateway (work)"'),
+      script.indexOf(`${PINNED_SCHTASKS} /Run /TN "RemoteClaw Gateway (work)"`),
     );
+    // EVERY emitted `schtasks` invocation, not just one: a bare name resolves through the
+    // detached script's inherited %PATH% and cwd (CWE-426, #3112 §4). Asserting the whole
+    // set is what makes removing the pinning fail, rather than leaving one occurrence
+    // pinned and the other bare — which is exactly the state #3116 found.
+    expect(schtasksLines(script).map((line) => line.split(" /TN ")[0])).toStrictEqual([
+      `${PINNED_SCHTASKS} /Query`,
+      `${PINNED_SCHTASKS} /Run`,
+    ]);
     expect(script).toContain('del "%~f0" >nul 2>&1');
   });
 
@@ -146,11 +172,34 @@ describe("relaunchGatewayScheduledTask", () => {
     relaunchGatewayScheduledTask({
       REMOTECLAW_PROFILE: "work",
       REMOTECLAW_WINDOWS_TASK_NAME: "RemoteClaw Gateway (custom)",
+      SystemRoot: TEST_SYSTEM_ROOT,
     });
 
     const scriptPath = [...createdScriptPaths][0];
     const script = fs.readFileSync(scriptPath, "utf8");
-    expect(script).toContain('schtasks /Run /TN "RemoteClaw Gateway (custom)" >>');
+    expect(script).toContain(`${PINNED_SCHTASKS} /Run /TN "RemoteClaw Gateway (custom)" >>`);
+  });
+
+  // The pinned path is interpolated into a cmd script, where an unquoted space would split
+  // it into a command plus an argument. `%SystemRoot%` is operator-supplied and the shape
+  // gate accepts spaces, so this is reachable rather than theoretical.
+  it("quotes the pinned schtasks path when SystemRoot contains a space", () => {
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      createdScriptPaths.add(decodeCmdPathArg(args[3]));
+      return { unref: vi.fn() };
+    });
+
+    relaunchGatewayScheduledTask({
+      REMOTECLAW_PROFILE: "work",
+      SystemRoot: "D:\\Win NT",
+    });
+
+    const scriptPath = [...createdScriptPaths][0];
+    const script = fs.readFileSync(scriptPath, "utf8");
+    expect(schtasksLines(script).map((line) => line.split(" /TN ")[0])).toStrictEqual([
+      '"D:\\Win NT\\System32\\schtasks.exe" /Query',
+      '"D:\\Win NT\\System32\\schtasks.exe" /Run',
+    ]);
   });
 
   it("escapes custom task names in the PowerShell running-task probe", () => {
@@ -225,12 +274,15 @@ describe("relaunchGatewayScheduledTask", () => {
       return { unref: vi.fn() };
     });
 
-    const result = relaunchGatewayScheduledTask({ REMOTECLAW_PROFILE: "work" });
+    const result = relaunchGatewayScheduledTask({
+      REMOTECLAW_PROFILE: "work",
+      SystemRoot: TEST_SYSTEM_ROOT,
+    });
 
     expect(result.ok).toBe(true);
     const scriptPath = [...createdScriptPaths][0];
     const script = fs.readFileSync(scriptPath, "utf8");
-    expect(script).toContain(`schtasks /Query /TN`);
+    expect(script).toContain(`${PINNED_SCHTASKS} /Query /TN`);
     expect(script).toContain(":fallback");
     expect(script).toContain(`start "" /min cmd.exe /d /c`);
     expect(script).toContain(taskScriptPath);

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -86,8 +86,15 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
   // already use — rather than a PowerShell literal).
   //
   // Scope, so this is not read as more than it closes: only the two `schtasks` invocations
-  // are pinned. `powershell.exe`, `findstr` and the `cmd.exe` startup fallback further down
-  // the same emitted script are still bare.
+  // are pinned. Still bare in the same emitted script, in emission order: `timeout` in the
+  // `:retry` loop, `powershell.exe` and `findstr` on the task-state probe, and `cmd.exe` in
+  // the startup fallback. `timeout` is the easiest of those to skip — it reads like a
+  // `cmd.exe` builtin and is not one. It is `%SystemRoot%\System32\timeout.exe`, it sits
+  // BETWEEN the two lines pinned here, and it resolves through this detached script's
+  // inherited cwd and %PATH% exactly as they did. Treat that as an inventory of what is
+  // KNOWN bare at time of writing, not a proof the set is closed: nothing scans emitted
+  // script content for binary names, so a binary added to this script later joins the set
+  // without failing anything.
   const schtasksPath = resolveWindowsSystem32Path("schtasks.exe", { ...process.env, ...env });
   const quotedSchtasksPath = quoteCmdScriptArg(schtasksPath);
   const scriptPath = path.join(

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -10,7 +10,7 @@ import { resolveTaskScriptPath } from "../daemon/schtasks.js";
 import { formatErrorMessage } from "./errors.js";
 import type { RestartAttempt } from "./restart.types.js";
 import { resolvePreferredRemoteClawTmpDir } from "./tmp-remoteclaw-dir.js";
-import { resolveWindowsCmdExePath } from "./windows-system-paths.js";
+import { resolveWindowsCmdExePath, resolveWindowsSystem32Path } from "./windows-system-paths.js";
 
 const TASK_RESTART_RETRY_LIMIT = 12;
 const TASK_RESTART_RETRY_DELAY_SEC = 1;
@@ -29,11 +29,12 @@ function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
 
 function buildScheduledTaskRestartScript(params: {
   quotedLogPath: string;
+  quotedSchtasksPath: string;
   setupLines: string[];
   taskName: string;
   taskScriptPath?: string;
 }): string {
-  const { quotedLogPath, setupLines, taskName, taskScriptPath } = params;
+  const { quotedLogPath, quotedSchtasksPath, setupLines, taskName, taskScriptPath } = params;
   const quotedTaskName = quoteCmdScriptArg(taskName);
   const queryTaskStateCommand = `(Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(
     taskName,
@@ -44,7 +45,7 @@ function buildScheduledTaskRestartScript(params: {
     "setlocal",
     ...setupLines,
     `>> ${quotedLogPath} 2>&1 echo [%DATE% %TIME%] remoteclaw restart attempt source=windows-task-handoff target=${quotedTaskName}`,
-    `schtasks /Query /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
+    `${quotedSchtasksPath} /Query /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
     "if errorlevel 1 goto fallback",
     "set /a attempts=0",
     ":retry",
@@ -53,7 +54,7 @@ function buildScheduledTaskRestartScript(params: {
     // Avoid racing with another restart path that already started the scheduled task.
     `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} 2>nul | findstr /I /C:"Running" >nul 2>&1`,
     "if not errorlevel 1 goto cleanup",
-    `schtasks /Run /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
+    `${quotedSchtasksPath} /Run /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
     "if not errorlevel 1 goto cleanup",
     `if %attempts% GEQ ${TASK_RESTART_RETRY_LIMIT} goto fallback`,
     "goto retry",
@@ -75,6 +76,20 @@ function buildScheduledTaskRestartScript(params: {
 export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.env): RestartAttempt {
   const taskName = resolveWindowsTaskName(env);
   const taskScriptPath = resolveTaskScriptPath(env);
+  // Pinned at emission time, for the same reason as every argv site: a binary named inside
+  // generated script content resolves through the *script's* search path when it finally
+  // runs, which no source scan of this repo can see. The helper below is spawned detached
+  // through `cmd.exe` with no `cwd` or `env` override, so it inherits the parent's %PATH%
+  // AND cwd — and `cmd.exe` resolves a bare name against the current directory first.
+  // Identical treatment to `cli/update-cli/restart-helper.ts`; only the substrate differs
+  // (a cmd script, so `quoteCmdScriptArg` — the escape hatch the log path and task name
+  // already use — rather than a PowerShell literal).
+  //
+  // Scope, so this is not read as more than it closes: only the two `schtasks` invocations
+  // are pinned. `powershell.exe`, `findstr` and the `cmd.exe` startup fallback further down
+  // the same emitted script are still bare.
+  const schtasksPath = resolveWindowsSystem32Path("schtasks.exe", { ...process.env, ...env });
+  const quotedSchtasksPath = quoteCmdScriptArg(schtasksPath);
   const scriptPath = path.join(
     resolvePreferredRemoteClawTmpDir(),
     `remoteclaw-schtasks-restart-${randomUUID()}.cmd`,
@@ -86,6 +101,7 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
       scriptPath,
       `${buildScheduledTaskRestartScript({
         quotedLogPath: restartLog.quotedLogPath,
+        quotedSchtasksPath,
         setupLines: restartLog.lines,
         taskName,
         taskScriptPath,
@@ -101,7 +117,9 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
     return {
       ok: true,
       method: "schtasks",
-      tried: [`schtasks /Run /TN "${taskName}"`, `cmd.exe /d /s /c ${quotedScriptPath}`],
+      // Reports the pinned path, not the bare name: an operator reading this after a failed
+      // restart needs to see which binary the emitted script actually invoked.
+      tried: [`${schtasksPath} /Run /TN "${taskName}"`, `cmd.exe /d /s /c ${quotedScriptPath}`],
     };
   } catch (err) {
     try {
@@ -113,7 +131,7 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
       ok: false,
       method: "schtasks",
       detail: formatErrorMessage(err),
-      tried: [`schtasks /Run /TN "${taskName}"`],
+      tried: [`${schtasksPath} /Run /TN "${taskName}"`],
     };
   }
 }

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -9,7 +9,10 @@ import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
-import { resolveWindowsCmdExePath } from "../infra/windows-system-paths.js";
+import {
+  formatRejectedWindowsShellOverride,
+  selectWindowsShellPath,
+} from "../infra/windows-system-paths.js";
 import { logDebug, logError } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
@@ -89,6 +92,20 @@ function resolveCommand(command: string): string {
   });
 }
 
+/**
+ * ComSpec stays the documented Windows override, but it is validated rather than
+ * trusted — an unusable value falls back to the pinned `cmd.exe` and is reported, so
+ * an operator who set it deliberately learns it was refused instead of debugging a
+ * silently-different shell.
+ */
+function resolveCmdWrapperCommand(): string {
+  const selection = selectWindowsShellPath();
+  if (selection.rejectedComSpec !== undefined) {
+    logError(formatRejectedWindowsShellOverride(selection));
+  }
+  return selection.path;
+}
+
 function resolveChildProcessInvocation(params: {
   argv: string[];
   windowsVerbatimArguments?: boolean;
@@ -108,10 +125,7 @@ function resolveChildProcessInvocation(params: {
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
 
   return {
-    // ComSpec stays the primary (it is the documented Windows override), but the
-    // fallback is pinned rather than a bare name so an unset ComSpec cannot fall
-    // through to a %PATH% lookup (CWE-426).
-    command: useCmdWrapper ? (process.env.ComSpec ?? resolveWindowsCmdExePath()) : resolvedCommand,
+    command: useCmdWrapper ? resolveCmdWrapperCommand() : resolvedCommand,
     args: useCmdWrapper
       ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
       : finalArgv.slice(1),

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -28,10 +28,9 @@ const OVERRIDE_COM_SPEC = "E:\\CustomWindows\\System32\\cmd.exe";
  * the pinned absolute path rather than a bare `cmd.exe` %PATH% lookup (CWE-426).
  *
  * `override` pins ComSpec as the documented Windows override. It uses a well-formed
- * path on purpose — that is what #3100's proposed validation would still accept, so
- * this case survives that fix. It deliberately does NOT assert today's *unvalidated*
- * passthrough: a hostile ComSpec is currently honoured too, and #3100 tracks that
- * hole rather than this suite green-lighting it as intended behaviour.
+ * path on purpose: that is the branch the #3100 validation still accepts. The refusal
+ * branch — a set-but-malformed ComSpec, which `??` used to hand straight to `spawn` —
+ * is exercised by `HOSTILE_COM_SPECS` below.
  */
 function stubComSpec(mode: "unset" | "override"): string {
   // `unstubEnvs: true` (vitest.config.ts) restores both after each test.
@@ -43,6 +42,22 @@ function stubComSpec(mode: "unset" | "override"): string {
   vi.stubEnv("ComSpec", OVERRIDE_COM_SPEC);
   return OVERRIDE_COM_SPEC;
 }
+
+/**
+ * Shapes that must NEVER reach `spawn` as argv[0]. Under the old
+ * `process.env.ComSpec ?? resolveWindowsCmdExePath()` every one of these became argv[0]
+ * verbatim, because `??` falls through only on null/undefined — so the NUL/CR/LF/`;`,
+ * absolute-path, UNC, drive-root and `..`-traversal checks the resolver performs were
+ * skipped entirely whenever ComSpec was set at all (#3100).
+ *
+ * These are the three the issue named. Exhaustive shape coverage lives in
+ * `windows-system-paths.test.ts`; this file asserts the *spawn* consequence.
+ */
+const HOSTILE_COM_SPECS: readonly (readonly [string, string])[] = [
+  ["parent-segment traversal", "C:\\Windows\\..\\Users\\pub\\evil.exe"],
+  ["UNC share", "\\\\attacker\\share\\cmd.exe"],
+  ["embedded PATH separator", "C:\\Windows\\System32\\cmd.exe;C:\\Evil\\cmd.exe"],
+] as const;
 
 const { spawnMock, spawnSyncMock, execFileMock, execFilePromisifyMock } = vi.hoisted(() => {
   const execFilePromisifyMockLocal = vi.fn();
@@ -269,6 +284,33 @@ describe("windows command wrapper behavior", () => {
       platformSpy.mockRestore();
     }
   });
+
+  // The branch the `??` could not express. Each of these is a value an attacker with
+  // environment-block control would set, and each used to be spawned verbatim.
+  it.each(HOSTILE_COM_SPECS)(
+    "refuses a ComSpec with a %s and spawns the pinned cmd.exe instead",
+    async (_label, hostile) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      vi.stubEnv("SystemRoot", PINNED_SYSTEM_ROOT);
+      vi.stubEnv("ComSpec", hostile);
+
+      spawnMock.mockImplementation(
+        (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+      );
+
+      try {
+        const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
+        expect(result.code).toBe(0);
+        const captured = requireSpawnCall(0);
+        // Stated twice on purpose: the hostile value must not be spawned, AND the pinned
+        // path must be. Only asserting the second would pass if argv[0] went empty.
+        expect(captured[0]).not.toBe(hostile);
+        expectCmdWrappedInvocation({ captured, expectedComSpec: PINNED_CMD_EXE });
+      } finally {
+        platformSpy.mockRestore();
+      }
+    },
+  );
 
   it("keeps child exitCode when close reports null on Windows npm shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -427,13 +427,24 @@ Successfully processed 1 files`;
         stderr: "",
       });
 
+      // An explicit empty env, not an absent one: it makes the resolved path a literal
+      // this suite can state, rather than whatever %SystemRoot% the host running the
+      // tests happens to export.
       const result = await inspectWindowsAcl("C:\\test\\file.txt", {
         exec: mockExec,
+        env: {},
       });
       expectInspectSuccess(result, 2);
       // /sid is passed so that account names are printed as SIDs, making the
       // audit locale-independent (fixes #35834).
-      expect(mockExec).toHaveBeenCalledWith("icacls.exe", ["C:\\test\\file.txt", "/sid"]);
+      //
+      // Pinned to the default root, NOT bare `icacls.exe`. This file used to carry its
+      // own resolver, which returned the bare name whenever the caller's env had no
+      // SystemRoot — a %PATH% lookup at exactly the moment ACLs are being read (#3112).
+      expect(mockExec).toHaveBeenCalledWith("C:\\Windows\\System32\\icacls.exe", [
+        "C:\\test\\file.txt",
+        "/sid",
+      ]);
     });
 
     it("classifies *S-1-5-18 (SID form of SYSTEM from /sid) as trusted", async () => {
@@ -478,8 +489,18 @@ Successfully processed 1 files`;
       expectInspectSuccess(result, 2);
       expect(result.trusted).toHaveLength(2);
       expect(result.untrustedGroup).toHaveLength(0);
-      expect(mockExec).toHaveBeenNthCalledWith(1, "icacls.exe", ["C:\\test\\file.txt", "/sid"]);
-      expect(mockExec).toHaveBeenNthCalledWith(2, "whoami.exe", ["/user", "/fo", "csv", "/nh"]);
+      // Both pinned to the default root — the env above carries no SystemRoot, and the
+      // pre-#3112 resolver degraded to a bare name in exactly that case.
+      expect(mockExec).toHaveBeenNthCalledWith(1, "C:\\Windows\\System32\\icacls.exe", [
+        "C:\\test\\file.txt",
+        "/sid",
+      ]);
+      expect(mockExec).toHaveBeenNthCalledWith(2, "C:\\Windows\\System32\\whoami.exe", [
+        "/user",
+        "/fo",
+        "csv",
+        "/nh",
+      ]);
     });
 
     it("returns error state on exec failure", async () => {
@@ -540,21 +561,48 @@ Successfully processed 1 files`;
           stderr: "",
         });
 
+      // A NON-default root. This case used to pass `C:\Windows`, which is byte-identical
+      // to the fallback — so it could not tell "read SystemRoot" apart from "used the
+      // default" and would have stayed green with the env lookup deleted.
       const result = await inspectWindowsAcl("C:\\test\\file.txt", {
         exec: mockExec,
-        env: { SystemRoot: "C:\\Windows" },
+        env: { SystemRoot: "D:\\WinNT" },
       });
 
       expectInspectSuccess(result, 1);
-      expect(mockExec).toHaveBeenNthCalledWith(1, "C:\\Windows\\System32\\icacls.exe", [
+      expect(mockExec).toHaveBeenNthCalledWith(1, "D:\\WinNT\\System32\\icacls.exe", [
         "C:\\test\\file.txt",
         "/sid",
       ]);
-      expect(mockExec).toHaveBeenNthCalledWith(2, "C:\\Windows\\System32\\whoami.exe", [
+      expect(mockExec).toHaveBeenNthCalledWith(2, "D:\\WinNT\\System32\\whoami.exe", [
         "/user",
         "/fo",
         "csv",
         "/nh",
+      ]);
+    });
+
+    // The file-local resolver this converged onto had no validation at all: no `..`
+    // rejection, no UNC rejection, no drive-letter-root requirement. Sharing the hardened
+    // resolver is what makes these rows assertable here rather than only in its own suite.
+    it.each([
+      ["a traversal", "C:\\Windows\\..\\Users\\pub\\evil"],
+      ["a UNC share", "\\\\attacker\\share\\Windows"],
+      ["a PATH-separator injection", "C:\\Windows;C:\\Evil"],
+    ])("refuses %s in SystemRoot and falls back to the default root", async (_label, hostile) => {
+      const mockExec = vi.fn().mockResolvedValue({
+        stdout: "C:\\test\\file.txt BUILTIN\\Administrators:(F)",
+        stderr: "",
+      });
+
+      await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+        env: { SystemRoot: hostile },
+      });
+
+      expect(mockExec).toHaveBeenCalledWith("C:\\Windows\\System32\\icacls.exe", [
+        "C:\\test\\file.txt",
+        "/sid",
       ]);
     });
   });
@@ -662,9 +710,32 @@ Successfully processed 1 files`;
         env,
       });
       expect(result).not.toBeNull();
-      expect(result?.command).toBe("icacls");
+      // The env above carries no SystemRoot, so this is the default-root pin. It is the
+      // argv `security/fix.ts` executes while rewriting ACLs — a bare `icacls` here would
+      // hand that spawn to %PATH% at the worst possible moment (#3112).
+      expect(result?.command).toBe("C:\\Windows\\System32\\icacls.exe");
       expect(result?.args).toContain("C:\\test\\file.txt");
       expect(result?.args).toContain("/inheritance:r");
+    });
+
+    it("pins the executed command onto a non-default SystemRoot", () => {
+      const result = createIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env: { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP", SystemRoot: "D:\\WinNT" },
+      });
+      expect(result?.command).toBe("D:\\WinNT\\System32\\icacls.exe");
+    });
+
+    // `display` is copy-paste guidance for an operator's own shell, not an argv this
+    // process spawns, so it deliberately stays bare. Asserted so the split reads as a
+    // decision rather than as a site somebody forgot.
+    it("keeps the display string bare while the executed command is pinned", () => {
+      const result = createIcaclsResetCommand("C:\\test\\file.txt", {
+        isDir: false,
+        env: { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP", SystemRoot: "D:\\WinNT" },
+      });
+      expect(result?.display.startsWith("icacls ")).toBe(true);
+      expect(result?.display).not.toContain("D:\\WinNT");
     });
 
     it("returns command with system username when env is empty (falls back to os.userInfo)", () => {
@@ -676,7 +747,7 @@ Successfully processed 1 files`;
       });
       // Should return a valid command using the system username
       expect(result).not.toBeNull();
-      expect(result?.command).toBe("icacls");
+      expect(result?.command).toBe("C:\\Windows\\System32\\icacls.exe");
       expect(result?.args).toContain(`${MOCK_USERNAME}:F`);
     });
 

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import path from "node:path";
+import { resolveWindowsSystem32Path } from "../infra/windows-system-paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runExec } from "../process/exec.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -114,15 +114,6 @@ function buildTrustedPrincipals(env?: NodeJS.ProcessEnv): Set<string> {
     trusted.add(userSid);
   }
   return trusted;
-}
-
-function resolveWindowsSystemCommand(command: string, env?: NodeJS.ProcessEnv): string {
-  const root =
-    env?.SystemRoot?.trim() ||
-    env?.SYSTEMROOT?.trim() ||
-    env?.windir?.trim() ||
-    env?.WINDIR?.trim();
-  return root ? path.win32.join(root, "System32", command) : command;
 }
 
 function classifyPrincipal(
@@ -300,7 +291,7 @@ async function resolveCurrentUserSid(
   env?: NodeJS.ProcessEnv,
 ): Promise<string | null> {
   try {
-    const { stdout, stderr } = await exec(resolveWindowsSystemCommand("whoami.exe", env), [
+    const { stdout, stderr } = await exec(resolveWindowsSystem32Path("whoami.exe", env), [
       "/user",
       "/fo",
       "csv",
@@ -327,7 +318,7 @@ export async function inspectWindowsAcl(
     // Windows (Russian, Chinese, etc.) where icacls prints Cyrillic / CJK
     // characters that may be garbled when Node reads them in the wrong code
     // page.  Fixes #35834.
-    const { stdout, stderr } = await exec(resolveWindowsSystemCommand("icacls.exe", opts?.env), [
+    const { stdout, stderr } = await exec(resolveWindowsSystem32Path("icacls.exe", opts?.env), [
       targetPath,
       "/sid",
     ]);
@@ -398,7 +389,12 @@ export function createIcaclsResetCommand(
     `*S-1-5-18:${grant}`,
   ];
   return {
-    command: "icacls",
+    // Pinned, not bare: this argv is executed (`security/fix.ts`) while the tool is
+    // rewriting ACLs with `/inheritance:r /grant:r`, so a planted `icacls.exe` earlier
+    // in %PATH% would run at exactly the moment permissions are being handed out.
+    // `display` stays bare on purpose — it is copy-paste guidance for an operator's own
+    // shell, not an argv this process spawns.
+    command: resolveWindowsSystem32Path("icacls.exe", opts.env),
     args,
     display: formatIcaclsResetCommand(targetPath, opts),
   };


### PR DESCRIPTION
Closes #3100. Closes #3112.

One PR, not two, on purpose: both halves add or re-point pinned Windows spawn
sites, and `src/infra/windows-system-paths.call-sites.test.ts` holds an
exhaustive census of those sites. Split, each would be green alone and red
combined — the second to merge would carry a census pinned against a tree the
first already moved.

## Part 1 — #3100: `ComSpec` bypassed the resolver

`src/process/exec.ts:114` and `src/daemon/launchd.ts:111` both read
`process.env.ComSpec ?? resolveWindowsCmdExePath()`. `??` falls through only on
`null`/`undefined`, so a set-but-malformed `ComSpec` skipped every check the
resolver performs: NUL/CR/LF/`;`, `path.win32` absolute, UNC rejection,
drive-letter root, and the `..`-traversal rejection from #3091.

Both sites now call `selectWindowsShellPath()`. It runs `ComSpec` through the
**same** gate as `%SystemRoot%`, falls back to the pinned `cmd.exe` when the
value is unusable, and reports the refusal through `logError` with the refused
value and the path used instead — a silently-ignored `ComSpec` is its own
debugging trap.

The gate is **extracted, not copied**. `normalizeWindowsSystemRoot` became
`normalizeAbsoluteWindowsPath`, and `%SystemRoot%`, `%WINDIR%` and `%ComSpec%`
all pass through that single predicate. To keep it that way,
`windows-system-paths.test.ts` runs the SystemRoot and ComSpec suites against
one shared `HOSTILE_PATH_SHAPES` table — if the two inputs ever diverge again, a
row fails rather than needing to be caught by eye.

`src/infra/npm-install-env.ts:46` was left alone: `"ComSpec"` there is a key
name in `NPM_CONFIG_PATH_PROBE_PARENT_ENV_KEYS`, not a shell-selector read.

**Honest scope.** This equalizes `ComSpec` with `SystemRoot`; it does not make
`ComSpec` trustworthy. The issue's own example, `ComSpec=C:\Users\Public\evil.exe`,
is absolute, drive-rooted, non-UNC and traversal-free — it still passes, exactly
as the same value would in `%SystemRoot%`. Closing that needs an allowlist or a
signature check, not a shape gate. That limit is asserted as a test
(`still accepts a well-formed path to an arbitrary executable`) so it is
recorded where someone reading the guard will find it.

Existence checking (the issue's parenthetical suggestion) was deliberately not
added: it would put `node:fs` into a pure path module, it is TOCTOU against the
spawn, and a planted `cmd.exe` exists just as much as the real one.

## Part 2 — #3112

### 2a. The third resolver — **converged, not hardened in place**

`src/security/windows-acl.ts:119` had no `..` rejection, no UNC rejection, no
NUL/CR/LF/`;` rejection, no drive-letter-root requirement, and returned the
**bare command** when the caller's env carried no SystemRoot. It is deleted; the
two call sites now use `resolveWindowsSystem32Path`.

Evidence for convergence over hardening:

- **No import cycle.** `src/infra/windows-system-paths.ts` imports only
  `node:path`. `src/security/windows-acl.ts` already imports
  `../process/exec.js`, which itself imports the resolver module — so the edge
  already existed in that direction.
- **The env-parameter difference IS the defect, not an obstacle.**
  `resolveWindowsSystemCommand(cmd, env)` returned a bare name when `env` was
  `undefined`; `resolveWindowsSystem32Path(name, env = process.env)` falls back
  to the process environment. Converging changes behaviour precisely where the
  old code degraded.
- **Not reachable on POSIX.** `inspectWindowsAcl` is called only behind
  `platform === "win32"` (`src/security/audit-fs.ts:98`), and
  `createIcaclsResetCommand` only behind `isWindows` (`src/security/fix.ts:434`),
  so no non-Windows path starts producing Windows paths.

As #3112 states: `runSecurityAudit` passes `opts.env ?? process.env`, so on a
real Windows host `SystemRoot` is present and these already landed in System32.
The bare-name degradation was **conditional**; the missing `..`/UNC validation
was not. Both are now closed.

Noted for the record: this file defined its own resolver at `:119` and then did
not use it at `:401` — the bare `icacls` below.

### 2b. Bare `icacls` on the ACL-reset path — pinned

`createIcaclsResetCommand` returned `command: "icacls"`, executed at
`src/security/fix.ts:163` via `safeAclReset`. That is the
`/inheritance:r /grant:r` path: a planted `icacls.exe` earlier in `%PATH%` would
run *while the tool is modifying ACLs*. Now
`resolveWindowsSystem32Path("icacls.exe", opts.env)`.

`formatIcaclsResetCommand`'s `display` string stays bare on purpose — it is
copy-paste guidance for an operator's own shell, not an argv this process
spawns. Asserted as a test so the split reads as a decision rather than a missed
site.

### 2c. Bare `schtasks.exe` in the detached handoff — pinned at emission

The parent now resolves the path and carries it into the emitted script as
`serviceRecovery.runner`. The script uses `recovery.runner` and **fails closed**
— logging and skipping — if it is missing, rather than degrading to a bare name.

### 2d. `restart-helper.ts` — assessed, and **fixed**

Verdict: in scope and fixed properly, not papered.

The substrate does differ — a PowerShell string, not argv — but the escape hatch
was already there: the same template literal interpolates `${quotedLogPath}` and
`${quotedTaskName}` through `powerShellSingleQuote`. The resolved path goes
through that same helper.

Both `schtasks.exe` references in that emitted script are pinned, not just the
one the issue named:

- `:227` `$startInfo.FileName = "schtasks.exe"` (the `/Run` path)
- `:267` `& schtasks.exe /Query /TN $TaskName` (the state-query path)

Pinning only the first would have been the cosmetic change — a planted
`schtasks.exe` would still run from `Get-RemoteClawScheduledTaskState`.

## The census

**28 → 33 sites across 19 files.** No row deleted, no assertion weakened:
`toEqual` and the exact count both stand.

Re-derived independently: `git grep` for every export of the resolver module
across non-test `src/`, each hit classified by hand into a per-file table, and
only then reconciled against the suite's own scan. The two agreed (33), which is
the check — the hand table was not read off the diff's `+` lines.

`selectWindowsShellPath` is added to `RESOLVER_NAMES` / `CALL_RE`. This is a
widening, and it is load-bearing: without it `exec.ts` and `launchd.ts` would
mention no resolver at all and drop out of the inventory as unscanned files —
the exact failure mode #3112 section 4 describes. Both keep their rows, still
pinning `…\System32\cmd.exe`.

New rows: `windows-acl.ts` (whoami + icacls + icacls),
`update-managed-service-handoff.ts` (schtasks), `restart-helper.ts` (schtasks,
alongside its existing cmd.exe).

Because the census reads source text and cannot see *inside* emitted scripts,
the two emitted-script pins get their own tests that read the generated
artifacts back off disk.

## Two vacuous assertions found and fixed

Both were pre-existing, and both surfaced only because this PR made the tables
shared:

1. `windows-system-paths.test.ts` rows `["carriage return", "C:\\Windows\r"]`
   and `["line feed", "C:\\Windows\n"]` asserted nothing. `.trim()` strips a
   *trailing* CR/LF, and the residue `C:\Windows` is byte-identical to
   `DEFAULT_ROOT` — so the expectation held whether or not the guard ran. They
   now carry **embedded** control characters, and the trim behaviour is recorded
   as an explicit accept rather than mislabelled as a rejection.
2. `windows-acl.test.ts`'s `uses SystemRoot … when available` passed
   `SystemRoot: "C:\\Windows"` — also the fallback — so it could not distinguish
   "read the env" from "used the default". Now a non-default `D:\WinNT`.

## Verification

- `pnpm check` — exit 0 (format, typecheck, lint, lobster-leak,
  tooling-config-refs, css-class-drift, scripts-typecheck).
- `./node_modules/.bin/tsgo --noEmit` — exit 0, zero output.
- `oxlint --type-aware` over the 12 touched files — `Found 0 warnings and 0
  errors … on 12 files`.
- `oxfmt --check` over the same 12 — `All matched files use the correct format`.
- Census: 4 passed before the change, 4 passed after, at 33 pinned sites.
- Targeted suites (census, resolver units, exec-windows, windows-acl, handoff,
  restart-helper, launchd-adjacent): **222 passed**.
- Broad slice over `src/{infra,process,daemon,security,cli/update-cli,gateway/server-methods}`:
  **3600 passed, 12 skipped, 0 failed**.
- Fork-integrity gates: zombie-imports, stub-debt, throwing-stub-callers,
  obsolescence-audit, policy-doctor-boundary, no-raw-channel-fetch,
  attestations — all exit 0.
- **Mutation probe**: restoring the old `??` semantics inside
  `selectWindowsShellPath` fails **28 tests**, including all three named hostile
  shapes with the value reaching `spawn` verbatim, e.g.
  `expected 'C:\Windows\..\Users\pub\evil.exe' not to be 'C:\Windows\..\Users\pub\evil.exe'`.
  A guard with no test that fails without it is not a guard.

## Noticed, deliberately NOT changed

- **`src/gateway/server-methods/update-managed-service-handoff.ts` is a stale
  duplicate** of `src/infra/update-managed-service-handoff.ts` (487 vs 612
  lines). It has **zero** `schtasks` references, so it does not carry 2c — but
  it is a divergent second copy of a security-relevant module.
- **Neither handoff module has a production caller.** `startManagedServiceUpdateHandoff`
  is referenced only from tests. The 2c fix is correct for shipped code, but its
  live blast radius today is nil.
- **Remaining bare binaries inside emitted scripts** — #3112 section 4's class,
  left for the class-level decision that issue asks for:
  `restart-helper.ts:182` (`powershell` in the `.cmd` shim),
  `windows-task-restart.ts:47,56` (`schtasks` in generated `.cmd`) and `:54`
  (`powershell.exe`).
- **`resolveWindowsSystemRoot` is not in `RESOLVER_NAMES`.** It returns a
  directory, so a hand-rolled `path.join(resolveWindowsSystemRoot(env),
  "System32", name)` would be invisible to the census — which is exactly the
  shape `windows-acl.ts` had. It has zero non-test callers today; classifying a
  directory-returning resolver needs a different code path in the scan.
- **`.fork-boundary-mock-baseline` reads 139, tree measures 129.** Pre-existing;
  this PR adds no `vi.mock` of `src/agents/` or `src/middleware/`.

## Not merging

Pushed for independent security review. Auto-merge deliberately **not** enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
