### PR TITLE
docs: replace refused @remoteclaw registry install instructions (#3109)

### DIFF
--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -58,8 +58,8 @@ If `plugins.allow` is a non-empty restrictive list, explicitly selecting
 ClickClack in channel setup or running `remoteclaw plugins enable clickclack`
 appends `clickclack` to that list. Onboarding installation uses the same
 explicit-selection behavior. These paths do not override `plugins.deny` or a
-global `plugins.enabled: false` setting. Direct
-`remoteclaw plugins install @remoteclaw/clickclack` follows the normal
+global `plugins.enabled: false` setting. A direct
+`remoteclaw plugins install ./path/to/local/clickclack-plugin` follows the normal
 plugin-install policy and also records ClickClack in an existing allowlist.
 
 ## Access control

--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -5,14 +5,15 @@ read_when:
 title: "Google Chat"
 ---
 
-Status: downloadable plugin for DMs + spaces via Google Chat API webhooks (HTTP only).
+Status: bundled plugin for DMs + spaces via Google Chat API webhooks (HTTP only).
 
 ## Install
 
-Install Google Chat before configuring the channel:
+Google Chat ships as a bundled plugin, so there is nothing to download. Enable it
+before configuring the channel:
 
 ```bash
-remoteclaw plugins install @remoteclaw/googlechat
+remoteclaw plugins enable googlechat
 ```
 
 Local checkout (when running from a git repo):

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -7,14 +7,14 @@ read_when:
 ---
 
 Use IRC when you want RemoteClaw in classic channels (`#room`) and direct messages.
-Install the official IRC plugin, then configure it under `channels.irc`.
+Enable the bundled IRC plugin, then configure it under `channels.irc`.
 
 ## Quick start
 
-1. Install the plugin:
+1. Enable the bundled plugin:
 
 ```bash
-remoteclaw plugins install @remoteclaw/irc
+remoteclaw plugins enable irc
 ```
 
 2. Enable IRC config in `~/.remoteclaw/remoteclaw.json`.

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -11,16 +11,17 @@ LINE connects to RemoteClaw via the LINE Messaging API. The plugin runs as a web
 receiver on the gateway and uses your channel access token + channel secret for
 authentication.
 
-Status: downloadable plugin. Direct messages, group chats, media, locations, Flex
+Status: bundled plugin. Direct messages, group chats, media, locations, Flex
 messages, template messages, and quick replies are supported. Reactions and threads
 are not supported.
 
 ## Install
 
-Install LINE before configuring the channel:
+LINE ships as a bundled plugin, so there is nothing to download. Enable it before
+configuring the channel:
 
 ```bash
-remoteclaw plugins install @remoteclaw/line
+remoteclaw plugins enable line
 ```
 
 Local checkout (when running from a git repo):

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -6,18 +6,17 @@ read_when:
 title: "Matrix"
 ---
 
-Matrix is a downloadable channel plugin for RemoteClaw.
+Matrix is a bundled channel plugin for RemoteClaw.
 It uses the official `matrix-js-sdk` and supports DMs, rooms, threads, media, reactions, polls, location, and E2EE.
 
 ## Install
 
-Install Matrix from ClawHub before configuring the channel:
+Matrix ships as a bundled plugin, so there is nothing to download. Enable it
+before configuring the channel:
 
 ```bash
-remoteclaw plugins install @remoteclaw/matrix
+remoteclaw plugins enable matrix
 ```
-
-Bare plugin specs try ClawHub first, then npm fallback. To force the registry source, use `remoteclaw plugins install clawhub:@remoteclaw/matrix` or `remoteclaw plugins install npm:@remoteclaw/matrix`.
 
 From a local checkout:
 

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -7,16 +7,17 @@ title: "Mattermost"
 sidebarTitle: "Mattermost"
 ---
 
-Status: downloadable plugin (bot token + WebSocket events). Channels, groups, and DMs are supported. Mattermost is a self-hostable team messaging platform; see the official site at [mattermost.com](https://mattermost.com) for product details and downloads.
+Status: bundled plugin (bot token + WebSocket events). Channels, groups, and DMs are supported. Mattermost is a self-hostable team messaging platform; see the official site at [mattermost.com](https://mattermost.com) for product details and downloads.
 
 ## Install
 
-Install Mattermost before configuring the channel:
+Mattermost ships as a bundled plugin, so there is nothing to download. Enable it
+before configuring the channel:
 
 <Tabs>
-  <Tab title="npm registry">
+  <Tab title="Bundled plugin">
     ```bash
-    remoteclaw plugins install @remoteclaw/mattermost
+    remoteclaw plugins enable mattermost
     ```
   </Tab>
   <Tab title="Local checkout">

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -10,19 +10,13 @@ Status: text + DM attachments are supported; channel/group file sending requires
 ## Bundled plugin
 
 Microsoft Teams ships as a bundled plugin in current RemoteClaw releases, so no
-separate install is required in the normal packaged build.
+separate install is required in the normal packaged build. Enable it with
+`remoteclaw plugins enable msteams`.
 
 If you are on an older build or a custom install that excludes bundled Teams,
-install the npm package directly:
-
-```bash
-remoteclaw plugins install @remoteclaw/msteams
-```
-
-Use the bare package to follow the current official release tag. Pin an exact
-version only when you need a reproducible install.
-
-Local checkout (when running from a git repo):
+there is no registry install to fall back to: the `@remoteclaw` npm scope is not
+registered, and RemoteClaw refuses to resolve it. Install from a local checkout
+instead:
 
 ```bash
 remoteclaw plugins install ./path/to/local/msteams-plugin

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -10,21 +10,13 @@ Status: bundled plugin (webhook bot). Direct messages, rooms, reactions, and mar
 ## Bundled plugin
 
 Nextcloud Talk ships as a bundled plugin in current RemoteClaw releases, so
-normal packaged builds do not need a separate install.
+normal packaged builds do not need a separate install. Enable it with
+`remoteclaw plugins enable nextcloud-talk`.
 
 If you are on an older build or a custom install that excludes Nextcloud Talk,
-install the npm package directly:
-
-Install via CLI (npm registry):
-
-```bash
-remoteclaw plugins install @remoteclaw/nextcloud-talk
-```
-
-Use the bare package to follow the current official release tag. Pin an exact
-version only when you need a reproducible install.
-
-Local checkout (when running from a git repo):
+there is no registry install to fall back to: the `@remoteclaw` npm scope is not
+registered, and RemoteClaw refuses to resolve it. Install from a local checkout
+instead:
 
 ```bash
 remoteclaw plugins install ./path/to/local/nextcloud-talk-plugin

--- a/docs/channels/nostr.md
+++ b/docs/channels/nostr.md
@@ -19,16 +19,11 @@ builds do not need a separate install.
 
 - Onboarding (`remoteclaw onboard`) and `remoteclaw channels add` still surface
   Nostr from the shared channel catalog.
-- If your build excludes bundled Nostr, install the npm package directly.
+- If your build excludes bundled Nostr, there is no registry install to fall
+  back to: the `@remoteclaw` npm scope is not registered, and RemoteClaw refuses
+  to resolve it.
 
-```bash
-remoteclaw plugins install @remoteclaw/nostr
-```
-
-Use the bare package to follow the current official release tag. Pin an exact
-version only when you need a reproducible install.
-
-Use a local checkout (dev workflows):
+Use a local checkout instead (dev workflows):
 
 ```bash
 remoteclaw plugins install --link <path-to-local-nostr-plugin>

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -20,10 +20,10 @@ Status: external CLI integration. Gateway talks to `signal-cli` over HTTP — ei
 ## Quick setup (beginner)
 
 1. Use a **separate Signal number** for the bot (recommended).
-2. Install the RemoteClaw plugin:
+2. Enable the bundled RemoteClaw plugin:
 
 ```bash
-remoteclaw plugins install @remoteclaw/signal
+remoteclaw plugins enable signal
 ```
 
 3. Install `signal-cli` (Java required if you use the JVM build).

--- a/docs/channels/sms.md
+++ b/docs/channels/sms.md
@@ -26,7 +26,7 @@ SMS defers sender-initiated self-enrollment — no pairing challenge is sent to 
 
 You need:
 
-- The official SMS plugin installed with `remoteclaw plugins install @remoteclaw/sms`.
+- The bundled SMS plugin enabled with `remoteclaw plugins enable sms`.
 - A Twilio account with an SMS-capable phone number, or a Twilio Messaging Service.
 - The Twilio Account SID and Auth Token.
 - A public HTTPS URL that reaches your RemoteClaw Gateway.
@@ -37,9 +37,9 @@ Use one Twilio number for both SMS and Voice Call if the number has both capabil
 ## Quick Setup
 
 <Steps>
-  <Step title="Install the plugin">
+  <Step title="Enable the bundled plugin">
     ```bash
-    remoteclaw plugins install @remoteclaw/sms
+    remoteclaw plugins enable sms
     ```
   </Step>
   <Step title="Create or choose a Twilio sender">

--- a/docs/channels/tlon.md
+++ b/docs/channels/tlon.md
@@ -15,21 +15,12 @@ image uploads are supported. Reactions and polls are not yet supported.
 ## Bundled plugin
 
 Tlon ships as a bundled plugin in current RemoteClaw releases, so normal packaged
-builds do not need a separate install.
+builds do not need a separate install. Enable it with
+`remoteclaw plugins enable tlon`.
 
-If you are on an older build or a custom install that excludes Tlon, install a
-current npm package:
-
-Install via CLI (npm registry):
-
-```bash
-remoteclaw plugins install @remoteclaw/tlon
-```
-
-Use the bare package to follow the current official release tag. Pin an exact
-version only when you need a reproducible install.
-
-Local checkout (when running from a git repo):
+If you are on an older build or a custom install that excludes Tlon, there is no
+registry install to fall back to: the `@remoteclaw` npm scope is not registered,
+and RemoteClaw refuses to resolve it. Install from a local checkout instead:
 
 ```bash
 remoteclaw plugins install ./path/to/local/tlon-plugin

--- a/docs/channels/twitch.md
+++ b/docs/channels/twitch.md
@@ -14,23 +14,13 @@ Twitch chat support via IRC connection. RemoteClaw connects as a Twitch user (bo
 Twitch ships as a bundled plugin in current RemoteClaw releases, so normal packaged builds do not need a separate install.
 </Note>
 
-If you are on an older build or a custom install that excludes Twitch, install the npm package directly:
+On a normal build, enable it with `remoteclaw plugins enable twitch`.
 
-<Tabs>
-  <Tab title="npm registry">
-    ```bash
-    remoteclaw plugins install @remoteclaw/twitch
-    ```
-  </Tab>
-  <Tab title="Local checkout">
-    ```bash
-    remoteclaw plugins install ./path/to/local/twitch-plugin
-    ```
-  </Tab>
-</Tabs>
+If you are on an older build or a custom install that excludes Twitch, there is no registry install to fall back to: the `@remoteclaw` npm scope is not registered, and RemoteClaw refuses to resolve it. Install from a local checkout instead:
 
-Use the bare package to follow the current official release tag. Pin an exact
-version only when you need a reproducible install.
+```bash
+remoteclaw plugins install ./path/to/local/twitch-plugin
+```
 
 Details: [Plugins](/tools/plugin)
 

--- a/docs/channels/zalo.md
+++ b/docs/channels/zalo.md
@@ -12,11 +12,11 @@ Status: experimental. DMs are supported. The [Capabilities](#capabilities) secti
 Zalo ships as a bundled plugin in current RemoteClaw releases, so normal packaged
 builds do not need a separate install.
 
-If you are on an older build or a custom install that excludes Zalo, install the
-npm package directly:
+If you are on an older build or a custom install that excludes Zalo, there is no
+registry install to fall back to: the `@remoteclaw` npm scope is not registered,
+and RemoteClaw refuses to resolve it.
 
-- Install via CLI: `remoteclaw plugins install @remoteclaw/zalo`
-- Pinned version: `remoteclaw plugins install @remoteclaw/zalo@2026.5.2`
+- Enable the bundled plugin: `remoteclaw plugins enable zalo`
 - Or from a source checkout: `remoteclaw plugins install ./path/to/local/zalo-plugin`
 - Details: [Plugins](/tools/plugin)
 

--- a/docs/channels/zalouser.md
+++ b/docs/channels/zalouser.md
@@ -18,10 +18,10 @@ Zalo Personal ships as a bundled plugin in current RemoteClaw releases, so norma
 packaged builds do not need a separate install.
 
 If you are on an older build or a custom install that excludes Zalo Personal,
-install the npm package directly:
+there is no registry install to fall back to: the `@remoteclaw` npm scope is not
+registered, and RemoteClaw refuses to resolve it.
 
-- Install via CLI: `remoteclaw plugins install @remoteclaw/zalouser`
-- Pinned version: `remoteclaw plugins install @remoteclaw/zalouser@2026.5.2`
+- Enable the bundled plugin: `remoteclaw plugins enable zalouser`
 - Or from a source checkout: `remoteclaw plugins install ./path/to/local/zalouser-plugin`
 - Details: [Plugins](/tools/plugin)
 

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -239,8 +239,8 @@ remoteclaw plugins install ./my-hook-pack
 # Local archive
 remoteclaw plugins install ./my-hook-pack.zip
 
-# NPM package
-remoteclaw plugins install @remoteclaw/my-hook-pack
+# NPM package (any scope you control; the `@remoteclaw` scope is not resolvable)
+remoteclaw plugins install @acme/my-hook-pack
 
 # Link a local directory without copying
 remoteclaw plugins install -l ./my-hook-pack

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -524,11 +524,11 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 
 ### Mattermost
 
-Mattermost ships as a bundled plugin in current RemoteClaw releases. Older or
-custom builds can install a current npm package with
-`remoteclaw plugins install @remoteclaw/mattermost`. Check
-[npmjs.com/package/@remoteclaw/mattermost](https://www.npmjs.com/package/@remoteclaw/mattermost)
-for the current dist-tags before pinning a version.
+Mattermost ships as a bundled plugin in current RemoteClaw releases; enable it
+with `remoteclaw plugins enable mattermost`. There is no npm registry install:
+the `@remoteclaw` scope is not registered, and RemoteClaw refuses to resolve it.
+Older or custom builds that exclude the bundled plugin must install from a local
+checkout with `remoteclaw plugins install ./path/to/local/mattermost-plugin`.
 
 ```json5
 {

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -18,15 +18,23 @@ the default built-in memory store.
 
 ## Installation
 
-Install `memory-lancedb` before setting `plugins.slots.memory = "memory-lancedb"`:
+<Warning>
+`memory-lancedb` has **no working install path in RemoteClaw today**. It is not
+bundled into the runtime image, and it is not installable from npm: the
+`@remoteclaw` scope is not registered, so
+`remoteclaw plugins install @remoteclaw/memory-lancedb` is refused.
+
+The rest of this page documents the plugin's configuration surface. It applies
+only if you build and install the plugin yourself from a local path or tarball:
 
 ```bash
-remoteclaw plugins install @remoteclaw/memory-lancedb
+remoteclaw plugins install ./path/to/local/memory-lancedb-plugin
 ```
 
-The plugin is published to npm and is not bundled into the RemoteClaw runtime image.
-The installer writes the plugin entry and switches the memory slot when no other
-plugin owns it.
+</Warning>
+
+Installing it writes the plugin entry and switches the memory slot when no other
+plugin owns it, before you set `plugins.slots.memory = "memory-lancedb"`.
 
 <Note>
 `memory-lancedb` is an active memory plugin. Enable it by selecting the memory

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -25,24 +25,24 @@ the Gateway, then restart the Gateway to load it.
 ## Quick start
 
 <Steps>
-  <Step title="Install the plugin">
+  <Step title="Enable the plugin">
     <Tabs>
-      <Tab title="From npm">
+      <Tab title="Bundled plugin">
         ```bash
-        openclaw plugins install @remoteclaw/voice-call
+        remoteclaw plugins enable voice-call
         ```
       </Tab>
       <Tab title="From a local folder (dev)">
         ```bash
         PLUGIN_SRC=./path/to/local/voice-call-plugin
-        openclaw plugins install "$PLUGIN_SRC"
+        remoteclaw plugins install "$PLUGIN_SRC"
         cd "$PLUGIN_SRC" && pnpm install
         ```
       </Tab>
     </Tabs>
 
-    Use the bare package to follow the current official release tag. Pin an
-    exact version only when you need a reproducible install.
+    Voice Call ships with RemoteClaw, so there is no separate download and no
+    npm registry install: the `@remoteclaw` scope is not registered.
 
     Restart the Gateway afterwards so the plugin loads.
 

--- a/docs/plugins/zalouser.md
+++ b/docs/plugins/zalouser.md
@@ -26,14 +26,14 @@ No external `zca`/`openzca` CLI binary is required.
 
 ## Install
 
-### Option A: install from npm
+### Option A: enable the bundled plugin
 
 ```bash
-remoteclaw plugins install @remoteclaw/zalouser
+remoteclaw plugins enable zalouser
 ```
 
-Use the bare package to follow the current official release tag. Pin an exact
-version only when you need a reproducible install.
+Zalo Personal ships with RemoteClaw, so there is no separate download. There is
+no npm registry install: the `@remoteclaw` scope is not registered.
 
 Restart the Gateway afterwards.
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -39,15 +39,21 @@ directly to existing RemoteClaw channel conversations, use
 
 ## Does this work out of the box?
 
-Yes, after installing the official ACP runtime plugin:
+Only after the ACP runtime plugin is available locally.
+
+There is currently **no registry install** for it: the `@remoteclaw` npm scope is
+not registered, so `remoteclaw plugins install @remoteclaw/acpx` is refused, and
+`acpx` ships no plugin manifest, so it does not resolve as a bundled plugin
+either.
+
+Source checkouts can use the local `extensions/acpx` workspace plugin after
+`pnpm install`:
 
 ```bash
-remoteclaw plugins install @remoteclaw/acpx
 remoteclaw config set plugins.entries.acpx.enabled true
 ```
 
-Source checkouts can use the local `extensions/acpx` workspace plugin after
-`pnpm install`. Run `/acp doctor` for a readiness check.
+Run `/acp doctor` for a readiness check.
 
 RemoteClaw only teaches agents about ACP spawning when ACP is **truly
 usable**: ACP must be enabled, dispatch must not be disabled, the current

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -23,10 +23,10 @@ with RemoteClaw), others are **external** (published on npm by the community).
     ```
   </Step>
 
-  <Step title="Install a plugin">
+  <Step title="Enable or install a plugin">
     ```bash
-    # From npm
-    remoteclaw plugins install @remoteclaw/voice-call
+    # Enable a plugin that ships with RemoteClaw
+    remoteclaw plugins enable voice-call
 
     # From a local directory or archive
     remoteclaw plugins install ./my-plugin


### PR DESCRIPTION
Closes #3109.

## What I changed

**25 lines across 22 files** (all under `docs/`; no source files touched).

Before: `grep -rn "plugins install @remoteclaw/" docs/` → **30 lines / 25 files**
(the issue body's "17 files / 23 lines" was stale; re-enumerated at `38d7bac24ef`).

After: **7 lines / 5 files**, and **zero of them are still an instruction to run
the command** — breakdown at the bottom.

## The premise needed correcting first

The issue says the CLI refuses `remoteclaw plugins install @remoteclaw/<name>`.
That is true, but **narrower than it reads**, and getting this wrong would have
produced 30 wrong edits.

`runPluginInstallCommand` (`src/cli/plugins-cli.ts:308`) calls
`resolveBundledInstallPlanBeforeNpm` **before** `installPluginFromNpmSpec`
(`:322`). A spec matching a bundled plugin resolves to the image-owned copy and
never reaches the unclaimed-scope guard. `npmSpec` is
`install.npmSpec || packageName`, and every bundled channel's `package.json` is
`@remoteclaw/<name>` — so those installs **succeed today**.

The refusal is terminal only for *non-bundled* specs: the post-failure fallback
(`resolveBundledInstallPlanForNpmFailure`) fires solely on
`NPM_PACKAGE_NOT_FOUND`, never on `UNCLAIMED_NPM_SCOPE`.

Grounded in `src/infra/npm-registry-spec.ts:162,206`,
`src/cli/plugin-install-plan.ts:66-109,160-179`, and the committed tests
`src/plugins/install.test.ts:1135-1160` (refuses `@remoteclaw/discord`) and
`src/cli/plugin-install-plan.test.ts:29,60` (bundled wins for scoped specs;
`@remoteclaw/not-bundled` falls through).

## The replacement I chose, and why it differs per page

**1. Bundled channels → `remoteclaw plugins enable <id>`**
(clickclack, googlechat, irc, line, matrix, mattermost, signal, sms, voice-call,
zalouser, tools/plugin)

The command works, but the docs frame it as an *npm registry* install
("npm registry" tab, "From npm", "Install Matrix from ClawHub", "published to
npm"). That provenance is false — the scope is unregistered — and the bundled
path writes a build-specific absolute path into `plugins.load.paths`.
`plugins enable` is what the guard's own error text prescribes: *"Channels that
ship with RemoteClaw are already bundled — enable the channel in your config
instead of installing it."* I checked none of these are `enabledByDefault`, so
the step is still required, and `enablePluginInConfig` needs no prior install
record.

**2. "Ships bundled; if your build excludes it, install from npm" → honest**
(msteams, nextcloud-talk, nostr, tlon, twitch, zalo, zalouser, gateway/config-channels)

This is the sharpest defect: the fallback is scoped to precisely the case where
bundled resolution *misses*, which is exactly when the refusal fires. These now
state there is no registry route and point at the local checkout, which works.

**3. Genuinely no install path → the page says so** (see below)

## Pages left admitting a gap

- **`docs/plugins/memory-lancedb.md`** — not in the tree at all (only the doc
  page exists) and not installable from npm. Page now opens with a warning that
  there is no working install path, and documents the config surface as
  conditional on building it yourself.
- **`docs/tools/acp-agents.md`** — `extensions/acpx` ships **no
  `remoteclaw.plugin.json`**, and `loadPluginManifest` has no `package.json`
  fallback, so it resolves as neither bundled nor registry. Changed "Yes, after
  installing…" to "Only after the ACP runtime plugin is available locally", and
  kept the existing local-workspace route. I did **not** claim ACP is entirely
  unusable — I did not verify the `plugins.load.paths` loading route.
- **`docs/cli/hooks.md`** — the "NPM package" example used
  `@remoteclaw/my-hook-pack`, which cannot resolve. Switched to `@acme/…`; any
  scope you control works.

## Deliberately left unchanged (accurate as written)

- **`docs/cli/plugins.md:174`** — documents the bundled-before-npm precedence
  itself, including `plugins install @remoteclaw/discord@2026.5.20 --pin`. That
  is a correct description of working behaviour, not an install instruction.
- **`docs/channels/matrix-migration.md:218,240,343`** — repair steps for an
  install record pinned to a custom path. `plugins install @remoteclaw/matrix`
  re-points the record and `load.paths` at the bundled copy, which is exactly
  what "return to the default Matrix plugin" means. `plugins enable` would
  **not** do this, so substituting it would have broken these.

## qqbot split-out

`docs/channels/qqbot.md` is **excluded** from this PR and filed separately as
**#3123**. Verified: the real package is `@tencent-connect/remoteclaw-qqbot`,
already documented in this repo at `docs/plugins/community.md:113-117`. It is a
package-identity bug, not a route bug — and `@tencent-connect` is a different
scope, so it is not refused by the guard.

## Verification

Docs-only, so `pnpm check` does not apply. What I did run:

- **Format** — pinned `oxfmt@0.38.0 --check` on all 22 files:
  `All matched files use the correct format. Finished in 500ms on 22 files`
  (exit 0). The pre-commit hook was bypassed only on that proof, because this
  worktree has no `node_modules`.
- **markdownlint** — compared each touched file against its `origin/main`
  version. Net **−5** violations; the only increase was one `MD033` from the new
  `<Warning>` in `memory-lancedb.md`, and `Warning` is in `allowed_elements` in
  `.markdownlint-cli2.jsonc`, so it does not fire under the repo config.
  (`lint:docs` is red tree-wide on `main` already and runs in no CI job.)
- **`pnpm docs:check-links`** — fails with `missing docs/docs.json` on a clean
  `origin/main` too; that file is not tracked in this fork. Pre-existing, not
  caused by this change, and in no CI workflow.

Final grep, all 7 remaining hits:

```
docs/channels/matrix-migration.md:218,240,343   ← accurate repair steps (kept)
docs/channels/qqbot.md:22                       ← split out to #3123
docs/cli/plugins.md:174                         ← accurate reference doc (kept)
docs/plugins/memory-lancedb.md:25               ← names the command to say it is refused
docs/tools/acp-agents.md:45                     ← names the command to say it is refused
```

## Flagged, not fixed

`docs/cli/plugins.md:172,174,180` document an `npm:<spec>` escape hatch, but I
found no `npm:` prefix handling anywhere in the plugin install CLI path
(`parseRegistryNpmSpec` does not strip it). I did not verify this end-to-end and
did not touch it — flagging as a suspected separate bug. Likewise the
ClawHub-era prose in `docs/tools/plugin.md:57` and `docs/plugins/community.md`
(`clawhub:` is absent from this fork's install CLI); `docs/refactor/docs-gutted-feature-audit.md`
already tracks that debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)