### PR TITLE
security(gateway): require Control UI device pairing under trusted-proxy auth (#2843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,25 @@
   OpenClaw #78864, dropped by a content-only sync when this fork's resolver had
   structurally diverged.
 
+- **Security — require Control UI device pairing under trusted-proxy auth
+  ([remoteclaw#2843](https://github.com/remoteclaw/remoteclaw/issues/2843)):**
+  Under `gateway.auth.mode: "trusted-proxy"`, a Control UI WebSocket session that
+  presented a device identity was admitted on the strength of proxy auth alone —
+  pairing was skipped outright, so a signed but **never-paired** device connected
+  successfully and received the operator scopes it had declared for itself. Proxy
+  auth establishes who the _user_ is; it does not establish which _device_ is
+  speaking. Such a device is now **rejected** with `pairing required`
+  (`PAIRING_REQUIRED`) and raises a pairing request for approval, and trusted-proxy
+  sessions are no longer issued a device token (a bearer credential that would
+  outlive the proxy-fronted session and authorize a direct connection bypassing the
+  proxy). Connections with **no** device identity at all are unchanged: they still
+  connect with self-declared scopes cleared to an empty set. To keep the prior
+  behavior, set `gateway.controlUi.dangerouslyDisableDeviceAuth: true` — the
+  documented break-glass opt-out, which `remoteclaw security audit` reports as
+  critical. Adopts upstream OpenClaw #81288, which withdrew the permissive
+  short-circuit upstream had added in #25293; this fork inherited the permissive
+  form by sync and four sync batches passed over the reversal.
+
 ### Fixed
 
 - **iMessage — stop leaking the `[[rc:reply:<id>]]` reply tag into delivered text

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -51,23 +51,42 @@ Use `trusted-proxy` auth mode when:
 
 ## Control UI pairing behavior
 
-When `gateway.auth.mode = "trusted-proxy"` is active and the request passes trusted-proxy checks, Control UI WebSocket sessions can connect without device pairing identity.
+When `gateway.auth.mode = "trusted-proxy"` is active, **device pairing is still
+required** for Control UI WebSocket sessions that present a device identity.
+Passing trusted-proxy checks does not skip the pairing gate.
+
+The two are answering different questions, and only one of them is delegated to
+your proxy:
+
+- Trusted-proxy auth establishes **who the user is**.
+- Device pairing establishes **which device** is speaking for that user.
 
 Implications:
 
-- Pairing is no longer the primary gate for Control UI access in this mode.
-- Your reverse proxy auth policy and `allowUsers` become the effective access control.
+- Your reverse proxy auth policy and `allowUsers` gate _who_ may reach the Gateway;
+  pairing remains the gate on _what device_ may act.
 - Keep gateway ingress locked to trusted proxy IPs only (`gateway.trustedProxies` + firewall).
+- A trusted-proxy Control UI session is **not issued a device token**. Device tokens
+  are bearer credentials that would outlive the proxy-fronted session and would
+  authorize a direct connection that never traverses the proxy.
+
+Two cases behave differently, and the difference is deliberate:
+
+**A device identity that is not paired is rejected.** The connect fails with
+`pairing required` (detail code `PAIRING_REQUIRED`) and a pairing request is
+raised for approval, exactly as on any other transport. Previously such a device
+was admitted on the strength of proxy auth alone and received the scopes it had
+declared for itself, without ever having been paired.
 
 **Scope clearing without device identity:** Because the browser over plain HTTP
 cannot create the device identity that RemoteClaw uses to bind operator scopes,
-trusted-proxy WebSocket connections that lack device identity have their
-self-declared scopes cleared to an empty set. The connection is allowed, but
-scope-gated methods (`operator.read`, `operator.write`, etc.) fail with
-`missing scope`.
+trusted-proxy WebSocket connections that lack device identity _entirely_ still
+connect, but have their self-declared scopes cleared to an empty set. Scope-gated
+methods (`operator.read`, `operator.write`, etc.) then fail with `missing scope`.
 
 To preserve operator scopes on trusted-proxy WebSocket connections without
-device identity, set `gateway.controlUi.dangerouslyDisableDeviceAuth: true`.
+device identity — and to opt out of the pairing requirement above — set
+`gateway.controlUi.dangerouslyDisableDeviceAuth: true`.
 This is a break-glass flag (`remoteclaw security audit` reports it as critical).
 Use it only when the reverse proxy is the sole path to the Gateway and device
 identity cannot be established.

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -326,6 +326,117 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  // Companion to the scope-clearing case above. That one connects with NO device
+  // (`device: null`) and proves self-declared scopes are stripped. This one
+  // presents a *signed but unpaired* device over the same trusted-proxy Control
+  // UI path and proves pairing is now REQUIRED: trusted-proxy auth no longer
+  // short-circuits the pairing gate (remoteclaw#2843, adopting upstream #81288).
+  // Before that change `shouldSkipControlUiPairing` returned true purely because
+  // the connection was trusted-proxy authenticated, so this connect succeeded and
+  // the device was handed operator scopes it had never been paired for.
+  //
+  // Uses the same process-global remote-address seam as the case above (the
+  // gateway test transport only dials `ws://127.0.0.1`, which `authorizeTrustedProxy`
+  // rejects as a loopback trusted-proxy source) — so it carries the same `finally`
+  // reset discipline; leaking it would break sibling tests in this worker.
+  test("requires pairing for trusted-proxy control ui device identity", async () => {
+    await configureTrustedProxyControlUiAuth();
+    const { identityPath } = await createOperatorIdentityFixture(
+      "remoteclaw-control-ui-trusted-proxy-pairing-",
+    );
+    setTestUpgradeRemoteAddressOverride(TRUSTED_PROXY_CONTROL_UI_REMOTE_IP);
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, TRUSTED_PROXY_CONTROL_UI_HEADERS);
+        try {
+          const challengeNonce = await readConnectChallengeNonce(ws);
+          expect(challengeNonce).toBeTruthy();
+          // Signed against a fresh identity, so it is a well-formed device that
+          // has never been paired — the exact shape trusted-proxy used to admit.
+          const { device } = await createSignedDevice({
+            token: null,
+            scopes: ["operator.read"],
+            clientId: CONTROL_UI_CLIENT.id,
+            clientMode: CONTROL_UI_CLIENT.mode,
+            identityPath,
+            nonce: String(challengeNonce),
+          });
+          const res = await connectReq(ws, {
+            skipDefaultAuth: true,
+            scopes: ["operator.read"],
+            device,
+            client: { ...CONTROL_UI_CLIENT },
+          });
+          expect(res.ok).toBe(false);
+          expect(res.error?.message ?? "").toContain("pairing required");
+          expect((res.error?.details as { code?: string } | undefined)?.code).toBe(
+            ConnectErrorDetailCodes.PAIRING_REQUIRED,
+          );
+        } finally {
+          ws.close();
+        }
+      });
+    } finally {
+      setTestUpgradeRemoteAddressOverride(undefined);
+    }
+  });
+
+  // The other half of remoteclaw#2843: even once its device IS paired, a
+  // trusted-proxy Control UI session must not be issued a device token. That
+  // token is a bearer credential which would authorize a later *direct*
+  // connection that never traverses the proxy — outliving the proxy-fronted
+  // session that justified it. `payload.auth` is the wire surface carrying it,
+  // so its absence is the observable assertion (the same signal the device-less
+  // case above already uses).
+  test("does not issue a device token for trusted-proxy control ui paired devices", async () => {
+    await configureTrustedProxyControlUiAuth();
+    const { identityPath } = await seedApprovedOperatorReadPairing({
+      identityPrefix: "remoteclaw-control-ui-trusted-proxy-token-",
+      clientId: CONTROL_UI_CLIENT.id,
+      clientMode: CONTROL_UI_CLIENT.mode,
+      displayName: "trusted-proxy-control-ui",
+      platform: CONTROL_UI_CLIENT.platform,
+    });
+    setTestUpgradeRemoteAddressOverride(TRUSTED_PROXY_CONTROL_UI_REMOTE_IP);
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, TRUSTED_PROXY_CONTROL_UI_HEADERS);
+        try {
+          const nonce = await readConnectChallengeNonce(ws);
+          expect(nonce).toBeTruthy();
+          // Signed with `token: null`: trusted-proxy mode has no shared secret,
+          // and the shared token is bound into the device signature — signing
+          // with one here yields DEVICE_AUTH_SIGNATURE_INVALID. (This is why the
+          // suite's `buildSignedDeviceForIdentity` helper, which hardcodes
+          // `token: "secret"`, is not usable on the trusted-proxy path.)
+          const { device } = await createSignedDevice({
+            token: null,
+            scopes: ["operator.read"],
+            clientId: CONTROL_UI_CLIENT.id,
+            clientMode: CONTROL_UI_CLIENT.mode,
+            identityPath,
+            nonce: String(nonce),
+          });
+          const res = await connectReq(ws, {
+            skipDefaultAuth: true,
+            scopes: ["operator.read"],
+            client: { ...CONTROL_UI_CLIENT },
+            device,
+          });
+          // Paired, so pairing itself is satisfied and the connect succeeds...
+          expect(res.error).toBeUndefined();
+          expect(res.ok).toBe(true);
+          // ...but no device token is minted for it.
+          expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+        } finally {
+          ws.close();
+        }
+      });
+    } finally {
+      setTestUpgradeRemoteAddressOverride(undefined);
+    }
+  });
+
   test("allows localhost control ui without device identity when insecure auth is enabled", async () => {
     testState.gatewayControlUi = { allowInsecureAuth: true };
     const { server, ws, prevToken } = await startServerWithClient("secret", {

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -171,7 +171,7 @@ describe("ws connect policy", () => {
     ).toBe("allow");
   });
 
-  test("pairing bypass requires control-ui bypass + shared auth (or trusted-proxy auth)", () => {
+  test("pairing bypass requires control-ui bypass + shared auth, never trusted-proxy auth", () => {
     const bypass = resolveControlUiAuthPolicy({
       isControlUi: true,
       controlUiConfig: { dangerouslyDisableDeviceAuth: true },
@@ -185,7 +185,12 @@ describe("ws connect policy", () => {
     expect(shouldSkipControlUiPairing(bypass, true, false)).toBe(true);
     expect(shouldSkipControlUiPairing(bypass, false, false)).toBe(false);
     expect(shouldSkipControlUiPairing(strict, true, false)).toBe(false);
-    expect(shouldSkipControlUiPairing(strict, false, true)).toBe(true);
+    // Trusted-proxy auth alone must NOT skip pairing (remoteclaw#2843).
+    expect(shouldSkipControlUiPairing(strict, false, true)).toBe(false);
+    // ...and it must not rescue a strict policy even alongside shared auth.
+    expect(shouldSkipControlUiPairing(strict, true, true)).toBe(false);
+    // The break-glass path is unaffected: bypass + shared auth still skips.
+    expect(shouldSkipControlUiPairing(bypass, true, true)).toBe(true);
   });
 
   test("trusted-proxy control-ui bypass only applies to operator + trusted-proxy auth", () => {

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -32,14 +32,21 @@ export function resolveControlUiAuthPolicy(params: {
   };
 }
 
+// Trusted-proxy auth does NOT skip Control UI pairing. Proxy authentication
+// proves *who the user is*; pairing proves *which device* is speaking. A signed
+// but unpaired device presented over a trusted proxy used to be admitted here
+// and handed the scopes it declared for itself. `_trustedProxyAuthOk` is kept in
+// the signature (unused) so call sites stay stable and the parameter's absence
+// is not mistaken for a missing check. Adopts upstream #81288 (remoteclaw#2843).
+//
+// `dangerouslyDisableDeviceAuth` remains the documented break-glass opt-out: it
+// sets `allowBypass`, and under trusted-proxy `sharedAuthOk` is true, so the
+// bypass below still returns true.
 export function shouldSkipControlUiPairing(
   policy: ControlUiAuthPolicy,
   sharedAuthOk: boolean,
-  trustedProxyAuthOk = false,
+  _trustedProxyAuthOk = false,
 ): boolean {
-  if (trustedProxyAuthOk) {
-    return true;
-  }
   return policy.allowBypass && sharedAuthOk;
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1065,9 +1065,16 @@ export function attachGatewayWsMessageHandler(params: {
           }
         }
 
-        const deviceToken = device
-          ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
-          : null;
+        // A trusted-proxy Control UI session is authenticated by the proxy, not by
+        // a paired device, so it must not be issued a device token — that token is
+        // a bearer credential which would outlive the proxy-fronted session and
+        // grant these scopes on a direct connection that never passes the proxy.
+        // Adopts upstream #81288 (remoteclaw#2843).
+        const shouldIssueDeviceToken = !trustedProxyAuthOk;
+        const deviceToken =
+          shouldIssueDeviceToken && device
+            ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
+            : null;
 
         if (role === "node") {
           // Version skew: close the co-located local node host so its OS supervisor


### PR DESCRIPTION
## What

Under `gateway.auth.mode: "trusted-proxy"`, a Control UI WebSocket client presenting a **signed but never-paired** device connected successfully and received the operator scopes it had declared for itself. `shouldSkipControlUiPairing` returned `true` purely because the connection was trusted-proxy authenticated.

Proxy auth establishes who the *user* is. It does not establish which *device* is speaking. This PR restores pairing as the device gate.

## Why this is a fork-inherited defect, not a fork decision

Upstream `20523b918ad` (2026-02-24, `Fixes #25293`) *added* the permissive short-circuit. Upstream then **withdrew** it in `96fba91b3a5` (PR #81288, "Require Control UI pairing before proxy-scoped access"). This fork inherited the permissive form by ordinary sync and never took the reversal — the file carries an `EXTRACT` disposition whose review is manual, so four sync batches passed over it with every gate green.

Verified against `origin/main` of the genuine upstream: `96fba91b3a5` is an ancestor, and `origin/main` contains **zero** occurrences of `if (trustedProxyAuthOk)`.

Boards v0.8.0 as a `### Breaking` entry.

## Changes

- **`connect-policy.ts`** — drop the `if (trustedProxyAuthOk) return true;` early return. The fork's own signature and parameter list are kept; the parameter is renamed `_trustedProxyAuthOk` (as upstream did). Upstream's file was **not** adopted wholesale: its signature has diverged into a 5-parameter form with a live `tailscale` branch (this fork *does* have a `tailscale` auth method, so it would go live) and an `authMode === "none"` branch the fork does not have.
- **`message-handler.ts`** — do not issue a device token for trusted-proxy sessions. That token is a bearer credential which would outlive the proxy-fronted session and authorize a later **direct** connection that never traverses the proxy.
- **Docs** (`docs/gateway/trusted-proxy-auth.md`) — the section stated the exact opposite of the new behaviour. Rewritten to describe pairing as required and to name `gateway.controlUi.dangerouslyDisableDeviceAuth` as the opt-out. `gateway.auth.trustedProxy.allowLoopback` deliberately untouched (separate track owns it).
- **CHANGELOG** — 4th `### Breaking` entry under `## Unreleased` (= v0.8.0).

## Deliberately NOT changed

**`shouldClearUnboundScopesForMissingDeviceIdentity`** — left alone. Upstream HEAD drops the `!controlUiAuthPolicy.allowBypass` conjunct this fork keeps, *while keeping* the `trustedProxyAuthOk === true` disjunct. The two forms are therefore **incomparable**, not superset/subset: the fork is stricter on the `trustedProxyAuthOk` axis, upstream is stricter on the `allowBypass` axis. The fork's `!allowBypass` conjunct is load-bearing for the documented break-glass scope-preservation behaviour (pinned by *"preserves requested control ui scopes when dangerouslyDisableDeviceAuth bypasses device identity"*), so adopting upstream's form would be an out-of-scope behaviour change.

**`evaluateMissingDeviceIdentity`'s `isControlUi && trustedProxyAuthOk -> allow` exemption** — untouched. Upstream carries it verbatim today, so removing it would make this fork *stricter than upstream*, which needs its own ADR.

Connections with **no** device identity at all are therefore unchanged: they still connect with self-declared scopes cleared to an empty set.

## Tests — two oracles, each proven in both directions

**1. `requires pairing for trusted-proxy control ui device identity`** (ported from upstream #81288, rewritten in the fork's idiom — upstream's version does not compile here).

Before the source change:
```
× requires pairing for trusted-proxy control ui device identity
AssertionError: expected true to be false
  - Expected: false
  + Received: true
```
`res.ok === true` — the unpaired device was admitted. After: passes (`pairing required` / `PAIRING_REQUIRED`).

**2. `does not issue a device token for trusted-proxy control ui paired devices`** (added — the device-token half otherwise had no direct coverage).

With the gate neutralised, a real bearer credential is returned over the wire:
```
AssertionError: expected { …(4) } to be undefined
+ Received:
{
  "deviceToken": "pJL3eZw8rymTghhGBUArJEiSxihMoejwPC1wNNGqRQQ",
  "issuedAtMs": 1785963788407,
  "role": "operator",
  "scopes": [ "operator.read" ]
}
```
With the gate in place, `payload.auth` is `undefined`.

`connect-policy.test.ts` — the assertion pinning the permissive path was inverted, the test **name** corrected (it asserted "or trusted-proxy auth"), and two cases added covering trusted-proxy alongside shared auth plus the break-glass path.

## Break-glass verified intact

`gateway.controlUi.dangerouslyDisableDeviceAuth` sets `allowBypass`, and `sharedAuthOk` is true under trusted-proxy, so `policy.allowBypass && sharedAuthOk` still returns true. Both covering tests pass:

```
✓ allows control ui with stale device identity when device auth is disabled 24ms
✓ preserves requested control ui scopes when dangerouslyDisableDeviceAuth bypasses device identity 25ms
```

## Verification

```
pnpm check                                   → exit 0 (format, tsgo, scripts typecheck, oxlint + 7 fork gates)
vitest run --config vitest.gateway.config.ts → Test Files 185 passed (185)
                                               Tests 1976 passed | 3 skipped (1979)
```
The 3 skips are pre-existing `test.skip` at HEAD, unrelated to this change.

Fork-integrity gates run locally, all exit 0: rebrand-leakage, zombie-import, stub-debt, throwing-stub-callers, obsolescence-audit.

> **Do not merge** — an independent security review runs first. Auto-merge deliberately not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
