### PR TITLE
fix(acp): stop reporting success for no-op /new and /reset on ACP sessions (#2929)

### DIFF
--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -285,7 +285,10 @@ Fast operator flow:
 
 - Run `/acp spawn codex --bind here` inside the DM or allowed group chat.
 - Future messages in that same BlueBubbles conversation route to the spawned ACP session.
-- `/new` and `/reset` reset the same bound ACP session in place.
+- `/new` and `/reset` target the bound ACP session rather than rotating the local
+  RemoteClaw session. Resetting an ACP session in place is **not yet implemented**
+  in this fork, so both commands reply that the reset did not take effect and leave
+  the conversation running (#2929).
 - `/acp close` closes the ACP session and removes the binding.
 
 Configured persistent bindings are also supported through top-level `bindings[]` entries with `type: "acp"` and `match.channel: "bluebubbles"`.

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -556,7 +556,10 @@ Fast operator flow:
 - Run `/acp spawn codex --bind here` inside the Matrix DM, room, or existing thread you want to keep using.
 - In a top-level Matrix DM or room, the current DM/room stays the chat surface and future messages route to the spawned ACP session.
 - Inside an existing Matrix thread, `--bind here` binds that current thread in place.
-- `/new` and `/reset` reset the same bound ACP session in place.
+- `/new` and `/reset` target the bound ACP session rather than rotating the local
+  RemoteClaw session. Resetting an ACP session in place is **not yet implemented**
+  in this fork, so both commands reply that the reset did not take effect and leave
+  the conversation running (#2929).
 - `/acp close` closes the ACP session and removes the binding.
 
 Notes:

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -267,8 +267,10 @@ For operators, the practical rule is:
 `/acp spawn <harness> --bind here` pins the current conversation to the
 spawned ACP session - no child thread, same chat surface. RemoteClaw keeps
 owning transport, auth, safety, and delivery. Follow-up messages in that
-conversation route to the same session; `/new` and `/reset` reset the
-session in place; `/acp close` removes the binding.
+conversation route to the same session; `/new` and `/reset` target the bound ACP
+session instead of rotating the local session, but resetting an ACP session in
+place is **not yet implemented** in this fork, so they reply that the reset did
+not take effect (#2929); `/acp close` removes the binding.
 
 Examples:
 
@@ -455,7 +457,12 @@ Use `agents.list[].runtime` to define ACP defaults once per agent:
 
 - RemoteClaw ensures the configured ACP session exists before use.
 - Messages in that channel or topic route to the configured ACP session.
-- In bound conversations, `/new` and `/reset` reset the same ACP session key in place.
+- In bound conversations, `/new` and `/reset` target the bound ACP session key
+  instead of rotating the local RemoteClaw session. In-place ACP session reset is
+  **not yet implemented** in this fork: both commands reply that the reset did not
+  take effect and leave the existing conversation running (#2929). Only a
+  genuinely-bound conversation takes this path — an unbound ACP-shaped session key
+  still gets a normal local reset.
 - Temporary runtime bindings (for example created by thread-focus flows) still apply where present.
 - For cross-agent ACP spawns without an explicit `cwd`, RemoteClaw inherits the target agent workspace from agent config.
 - Missing inherited workspace paths fall back to the backend default cwd; non-missing access failures surface as spawn errors.

--- a/src/acp/conversation-id.ts
+++ b/src/acp/conversation-id.ts
@@ -14,6 +14,54 @@ export function normalizeConversationText(value: unknown): string {
   return "";
 }
 
+function normalizeOptionalConversationText(value: unknown): string | undefined {
+  return normalizeConversationText(value) || undefined;
+}
+
+/**
+ * Resolve the conversation id a message belongs to from its delivery targets.
+ *
+ * Restored in the fork: the upstream home (`src/infra/outbound/conversation-id.ts`)
+ * was already a `() => undefined` stub when the gut wave deleted it (#2374), and
+ * its single caller in `session.ts` inherited that stub inline. With the resolver
+ * inert, every ACP binding lookup fell back to "conversation unidentifiable", so
+ * `/new` and `/reset` were suppressed for *every* ACP-shaped session key instead
+ * of only genuinely-bound ones (#2929).
+ */
+export function resolveConversationIdFromTargets(params: {
+  threadId?: string | number;
+  targets: Array<string | undefined | null>;
+}): string | undefined {
+  const threadId =
+    params.threadId != null ? normalizeOptionalConversationText(params.threadId) : undefined;
+  if (threadId) {
+    return threadId;
+  }
+
+  for (const rawTarget of params.targets) {
+    const target = normalizeOptionalConversationText(rawTarget);
+    if (!target) {
+      continue;
+    }
+    if (target.startsWith("channel:")) {
+      const channelId = normalizeOptionalConversationText(target.slice("channel:".length));
+      if (channelId) {
+        return channelId;
+      }
+      continue;
+    }
+    const mentionMatch = target.match(/^<#(\d+)>$/);
+    if (mentionMatch?.[1]) {
+      return mentionMatch[1];
+    }
+    if (/^\d{6,}$/.test(target)) {
+      return target;
+    }
+  }
+
+  return undefined;
+}
+
 export function parseTelegramChatIdFromTarget(raw: unknown): string | undefined {
   const text = normalizeConversationText(raw);
   if (!text) {

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -7,7 +7,6 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveConfiguredAcpBindingSpecBySessionKey } from "./persistent-bindings.resolve.js";
 import {
   buildConfiguredAcpSessionKey,
-  normalizeText,
   type ConfiguredAcpBindingSpec,
 } from "./persistent-bindings.types.js";
 import { readAcpSessionEntry } from "./runtime/session-meta.js";
@@ -48,6 +47,23 @@ function sessionMatchesConfiguredBinding(params: {
   return true;
 }
 
+/**
+ * The ACP session manager (`initializeSession` / `closeSession` /
+ * `updateSessionRuntimeOptions`) is gutted in the RemoteClaw fork — the Pi-era
+ * implementation was removed and AgentRuntime does not own ACP session
+ * lifecycle yet. Anything that needs it to have *acted* must report that it
+ * could not, instead of resolving as though it had (#2929).
+ */
+export const ACP_SESSION_LIFECYCLE_UNAVAILABLE =
+  "ACP session lifecycle is not available in RemoteClaw fork";
+
+/**
+ * Route-readiness gate: `ok` means "this bound route may carry traffic", NOT
+ * "a session was (re)initialized". Callers drop inbound messages when this is
+ * not ok (see extensions/discord message-handler.preflight.ts), so it must stay
+ * permissive while the session manager is gutted. It is deliberately NOT
+ * evidence that a reset happened — see `resetAcpSessionInPlace`.
+ */
 export async function ensureConfiguredAcpBindingSession(params: {
   cfg: RemoteClawConfig;
   spec: ConfiguredAcpBindingSpec;
@@ -106,6 +122,21 @@ export async function ensureConfiguredAcpBindingSession(params: {
   }
 }
 
+/**
+ * Reset actuator for `/new` and `/reset` on a bound ACP session.
+ *
+ * `ok: true` means the ACP runtime was actually closed and re-initialized. It
+ * MUST NOT be returned for a no-op: `session.ts` suppresses the normal session
+ * rotation whenever a conversation resolves to a bound ACP session, so a
+ * falsely-successful result here is exactly what let the user be told the reset
+ * worked while nothing happened (#2929).
+ *
+ * Restoring a working reset means driving the gutted session manager:
+ * `closeSession` (reason `${reason}-in-place-reset`, `clearMeta: false`) then
+ * `initializeSession` with the stored agent/mode/cwd/backend, then re-applying
+ * `meta.runtimeOptions` via `updateSessionRuntimeOptions`. Until that manager
+ * exists, report the failure so callers can surface it.
+ */
 export async function resetAcpSessionInPlace(params: {
   cfg: RemoteClawConfig;
   sessionKey: string;
@@ -127,71 +158,23 @@ export async function resetAcpSessionInPlace(params: {
     cfg: params.cfg,
     sessionKey,
   })?.acp;
-  if (!meta) {
-    if (configuredBinding) {
-      const ensured = await ensureConfiguredAcpBindingSession({
-        cfg: params.cfg,
-        spec: configuredBinding,
-      });
-      if (ensured.ok) {
-        return { ok: true };
-      }
-      return {
-        ok: false,
-        error: ensured.error,
-      };
-    }
+  if (!meta && !configuredBinding) {
+    // Nothing addressed by this key — there is no ACP session to reset.
     return {
       ok: false,
       skipped: true,
     };
   }
 
-  const agent =
-    normalizeText(meta.agent) ??
-    configuredBinding?.acpAgentId ??
-    configuredBinding?.agentId ??
-    undefined;
-  const mode = meta.mode === "oneshot" ? "oneshot" : "persistent";
-  const runtimeOptions = { ...meta.runtimeOptions };
-  const cwd = normalizeText(runtimeOptions.cwd ?? meta.cwd);
-
-  try {
-    await (undefined as any)?.closeSession({
-      cfg: params.cfg,
-      sessionKey,
-      reason: `${params.reason}-in-place-reset`,
-      clearMeta: false,
-      allowBackendUnavailable: true,
-      requireAcpSession: false,
-    });
-
-    await (undefined as any)?.initializeSession({
-      cfg: params.cfg,
-      sessionKey,
-      agent,
-      mode,
-      cwd,
-      backendId: normalizeText(meta?.backend) ?? normalizeText((params.cfg.acp as any)?.backend),
-    });
-
-    const runtimeOptionsPatch = Object.fromEntries(
-      Object.entries(runtimeOptions).filter(([, value]) => value !== undefined),
-    ) as SessionAcpMeta["runtimeOptions"];
-    if (runtimeOptionsPatch && Object.keys(runtimeOptionsPatch).length > 0) {
-      await (undefined as any)?.updateSessionRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        patch: runtimeOptionsPatch,
-      });
-    }
-    return { ok: true };
-  } catch (error) {
-    const message = formatErrorMessage(error);
-    logVerbose(`acp-persistent-binding: failed reset for ${sessionKey}: ${message}`);
-    return {
-      ok: false,
-      error: message,
-    };
-  }
+  // There IS an ACP session (or a configured binding for one) that should have
+  // been reset, and no session manager to do it with. Note this is deliberately
+  // not delegated to ensureConfiguredAcpBindingSession: that gate answers
+  // "may this route carry traffic", never "was this session reset".
+  logVerbose(
+    `acp-persistent-binding: cannot ${params.reason}-in-place-reset ${sessionKey}: ${ACP_SESSION_LIFECYCLE_UNAVAILABLE}`,
+  );
+  return {
+    ok: false,
+    error: ACP_SESSION_LIFECYCLE_UNAVAILABLE,
+  };
 }

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -16,6 +16,7 @@ vi.mock("./runtime/session-meta.js", () => ({
 }));
 
 import {
+  ACP_SESSION_LIFECYCLE_UNAVAILABLE,
   buildConfiguredAcpSessionKey,
   ensureConfiguredAcpBindingSession,
   resetAcpSessionInPlace,
@@ -501,8 +502,11 @@ describe("ensureConfiguredAcpBindingSession", () => {
   });
 });
 
+// #2929: these previously asserted `{ ok: true }` for every path, which is what
+// let `/new` and `/reset` report success while resetting nothing. A no-op must
+// now report itself so the caller can tell the user.
 describe("resetAcpSessionInPlace", () => {
-  it("returns ok when ACP metadata is missing but configured binding exists (gutted)", async () => {
+  it("reports failure when ACP metadata is missing but configured binding exists", async () => {
     const cfg = {
       ...baseCfg,
       bindings: [
@@ -536,11 +540,12 @@ describe("resetAcpSessionInPlace", () => {
       reason: "new",
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ error: ACP_SESSION_LIFECYCLE_UNAVAILABLE });
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
 
-  it("returns ok when meta is present (gutted; no manager calls happen)", async () => {
+  it("reports failure when meta is present but no session manager can reset it", async () => {
     const sessionKey = "agent:claude:acp:binding:discord:default:9373ab192b2317f4";
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
       acp: {
@@ -557,12 +562,13 @@ describe("resetAcpSessionInPlace", () => {
       reason: "reset",
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ error: ACP_SESSION_LIFECYCLE_UNAVAILABLE });
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
 
-  it("returns ok during in-place reset when agent id is not in agents.list (gutted)", async () => {
+  it("reports failure during in-place reset when agent id is not in agents.list", async () => {
     const cfg = {
       ...baseCfg,
       agents: {
@@ -584,7 +590,20 @@ describe("resetAcpSessionInPlace", () => {
       reason: "reset",
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ error: ACP_SESSION_LIFECYCLE_UNAVAILABLE });
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
+
+  it("skips without an error when the key addresses no ACP session at all", async () => {
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue(undefined);
+
+    const result = await resetAcpSessionInPlace({
+      cfg: baseCfg,
+      sessionKey: "agent:main:discord:channel:24680",
+      reason: "new",
+    });
+
+    expect(result).toEqual({ ok: false, skipped: true });
   });
 });

--- a/src/acp/persistent-bindings.ts
+++ b/src/acp/persistent-bindings.ts
@@ -10,6 +10,7 @@ export {
   type ResolvedConfiguredAcpBinding,
 } from "./persistent-bindings.types.js";
 export {
+  ACP_SESSION_LIFECYCLE_UNAVAILABLE,
   ensureConfiguredAcpBindingSession,
   resetAcpSessionInPlace,
 } from "./persistent-bindings.lifecycle.js";

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
 import { isSessionRunActive, killSessionRun } from "../../agents/session-run-registry.js";
 import type { RemoteClawConfig } from "../../config/config.js";
 import {
@@ -27,6 +28,7 @@ import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
 import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
+import type { SessionInitResult } from "./session.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
@@ -105,6 +107,75 @@ async function sendResetSessionNotice(params: {
   });
 }
 
+function buildAcpResetNoticeText(params: {
+  reason: "new" | "reset";
+  ok: boolean;
+  error?: string;
+}): string {
+  const action = params.reason === "reset" ? "/reset" : "/new";
+  if (params.ok) {
+    return "✅ New session started";
+  }
+  const detail = params.error ? ` — ${params.error}` : "";
+  return (
+    `⚠️ ${action} did not take effect${detail}. This conversation is bound to an ACP ` +
+    `agent that owns its own session, so the previous conversation is still active.`
+  );
+}
+
+/**
+ * Apply a `/new` or `/reset` that `initSessionState` handed off because the
+ * conversation is bound to an ACP session, and tell the user what happened.
+ *
+ * The local session was deliberately NOT rotated, so this is the only thing
+ * standing between the user and a silent no-op — never return early without
+ * either resetting or reporting (#2929).
+ */
+async function applyAcpInPlaceReset(params: {
+  ctx: MsgContext;
+  command: ReturnType<typeof buildCommandContext>;
+  cfg: RemoteClawConfig;
+  acpInPlaceReset: NonNullable<SessionInitResult["acpInPlaceReset"]>;
+  accountId: string | undefined;
+  threadId: string | number | undefined;
+}): Promise<void> {
+  const { reason, sessionKey } = params.acpInPlaceReset;
+  const outcome = await resetAcpSessionInPlace({
+    cfg: params.cfg,
+    sessionKey,
+    reason,
+  });
+  if (!outcome.ok) {
+    logVerbose(
+      `acp in-place ${reason} reset not applied for ${sessionKey}: ${
+        outcome.error ?? (outcome.skipped ? "no ACP session to reset" : "unknown error")
+      }`,
+    );
+  }
+  const route = resolveResetSessionNoticeRoute({
+    ctx: params.ctx,
+    command: params.command,
+  });
+  if (!route) {
+    return;
+  }
+  await routeReply({
+    payload: {
+      text: buildAcpResetNoticeText({
+        reason,
+        ok: outcome.ok,
+        error: outcome.ok ? undefined : outcome.error,
+      }),
+    },
+    channel: route.channel,
+    to: route.to,
+    sessionKey,
+    accountId: params.accountId,
+    threadId: params.threadId,
+    cfg: params.cfg,
+  });
+}
+
 type RunPreparedReplyParams = {
   ctx: MsgContext;
   sessionCtx: TemplateContext;
@@ -148,6 +219,7 @@ type RunPreparedReplyParams = {
   timeoutMs: number;
   isNewSession: boolean;
   resetTriggered: boolean;
+  acpInPlaceReset?: SessionInitResult["acpInPlaceReset"];
   systemSent: boolean;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
@@ -188,6 +260,7 @@ export async function runPreparedReply(
     timeoutMs,
     isNewSession,
     resetTriggered,
+    acpInPlaceReset,
     systemSent,
     sessionKey,
     sessionId,
@@ -354,6 +427,17 @@ export async function runPreparedReply(
       model,
       defaultProvider,
       defaultModel,
+    });
+  } else if (acpInPlaceReset && command.isAuthorizedSender) {
+    // The local session was intentionally left alone because this conversation
+    // is bound to an ACP session. Actuate that reset and report the outcome.
+    await applyAcpInPlaceReset({
+      ctx,
+      command,
+      cfg,
+      acpInPlaceReset,
+      accountId: ctx.AccountId,
+      threadId: ctx.MessageThreadId,
     });
   }
   const sessionIdFinal = sessionId ?? crypto.randomUUID();

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -149,6 +149,7 @@ export async function getReplyFromConfig(
     isGroup,
     triggerBodyNormalized,
   } = sessionState;
+  const { acpInPlaceReset } = sessionState;
 
   const directiveResult = await resolveReplyDirectives({
     ctx: finalized,
@@ -304,6 +305,7 @@ export async function getReplyFromConfig(
     timeoutMs,
     isNewSession,
     resetTriggered,
+    acpInPlaceReset,
     systemSent,
     sessionEntry,
     sessionStore,

--- a/src/auto-reply/reply/session.acp-reset.test.ts
+++ b/src/auto-reply/reply/session.acp-reset.test.ts
@@ -1,0 +1,517 @@
+// Focused ACP reset-suppression specs for initSessionState (#2929).
+//
+// These 6 cases were re-homed VERBATIM from session.test.ts, which stays in
+// vitest.quarantine.ts on an unrelated webchat-routing cluster (#47745). Keeping
+// them here means the /new and /reset behavior gates CI instead of riding along
+// with a quarantined file — the #2953/#2970 focused-spec re-homing precedent.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { buildConfiguredAcpSessionKey } from "../../acp/persistent-bindings.js";
+import type { RemoteClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  __testing as sessionBindingTesting,
+  registerSessionBindingAdapter,
+} from "../../infra/outbound/session-binding-service.js";
+import { initSessionState } from "./session.js";
+
+// Perf: session-store locks are exercised elsewhere; most session tests don't need FS lock files.
+vi.mock("../../agents/session-write-lock.js", () => ({
+  acquireSessionWriteLock: async () => ({ release: async () => {} }),
+}));
+
+let suiteRoot = "";
+let suiteCase = 0;
+
+beforeAll(async () => {
+  suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "remoteclaw-acp-reset-suite-"));
+});
+
+afterAll(async () => {
+  await fs.rm(suiteRoot, { recursive: true, force: true });
+  suiteRoot = "";
+  suiteCase = 0;
+});
+
+async function makeCaseDir(prefix: string): Promise<string> {
+  const dir = path.join(suiteRoot, `${prefix}${++suiteCase}`);
+  await fs.mkdir(dir);
+  return dir;
+}
+
+async function writeSessionStoreFast(
+  storePath: string,
+  store: Record<string, SessionEntry | Record<string, unknown>>,
+): Promise<void> {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(store), "utf-8");
+}
+
+describe("initSessionState ACP reset suppression", () => {
+  it("does not rotate local session state for /new on bound ACP sessions", async () => {
+    const root = await makeCaseDir("remoteclaw-rawbody-acp-reset-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: "1478836151241412759" },
+          },
+          acp: { mode: "persistent" },
+        },
+      ],
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        CommandBody: "/new",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: "1478836151241412759",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+    expect(result.isNewSession).toBe(false);
+  });
+
+  it("does not rotate local session state for ACP /new when conversation IDs are unavailable", async () => {
+    const root = await makeCaseDir("remoteclaw-rawbody-acp-reset-no-conversation-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        CommandBody: "/new",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: "user:12345",
+        OriginatingTo: "user:12345",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).toBe(existingSessionId);
+    expect(result.isNewSession).toBe(false);
+  });
+
+  it("keeps custom reset triggers working on bound ACP sessions", async () => {
+    const root = await makeCaseDir("remoteclaw-rawbody-acp-custom-reset-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/fresh"],
+      },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: "1478836151241412759" },
+          },
+          acp: { mode: "persistent" },
+        },
+      ],
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/fresh",
+        CommandBody: "/fresh",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: "1478836151241412759",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+  });
+
+  it("keeps normal /new behavior for unbound ACP-shaped session keys", async () => {
+    const root = await makeCaseDir("remoteclaw-rawbody-acp-unbound-reset-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        CommandBody: "/new",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: "1478836151241412759",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+  });
+
+  it("does not suppress /new when active conversation binding points to a non-ACP session", async () => {
+    const root = await makeCaseDir("remoteclaw-rawbody-acp-nonacp-binding-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+    const channelId = "1478836151241412759";
+    const nonAcpFocusSessionKey = "agent:main:discord:channel:focus-target";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: channelId },
+          },
+          acp: { mode: "persistent" },
+        },
+      ],
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as RemoteClawConfig;
+
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: "default",
+      capabilities: { bindSupported: false, unbindSupported: false, placements: ["current"] },
+      listBySession: () => [],
+      resolveByConversation: (ref) => {
+        if (ref.conversationId !== channelId) {
+          return null;
+        }
+        return {
+          bindingId: "focus-binding",
+          targetSessionKey: nonAcpFocusSessionKey,
+          targetKind: "session",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: channelId,
+          },
+          status: "active",
+          boundAt: now,
+        };
+      },
+    });
+    try {
+      const result = await initSessionState({
+        ctx: {
+          RawBody: "/new",
+          CommandBody: "/new",
+          Provider: "discord",
+          Surface: "discord",
+          SenderId: "12345",
+          From: "discord:12345",
+          To: channelId,
+          SessionKey: sessionKey,
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.resetTriggered).toBe(true);
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionId).not.toBe(existingSessionId);
+    } finally {
+      sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    }
+  });
+
+  it("does not suppress /new when active target session key is non-ACP even with configured ACP binding", async () => {
+    const root = await makeCaseDir("remoteclaw-rawbody-acp-configured-fallback-target-");
+    const storePath = path.join(root, "sessions.json");
+    const channelId = "1478836151241412759";
+    const fallbackSessionKey = "agent:main:discord:channel:focus-target";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+
+    await writeSessionStoreFast(storePath, {
+      [fallbackSessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: channelId },
+          },
+          acp: { mode: "persistent" },
+        },
+      ],
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as RemoteClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        CommandBody: "/new",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: channelId,
+        SessionKey: fallbackSessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+  });
+});
+
+// Authored for #2929: the specs above only pin WHEN the local reset is
+// suppressed. These pin that a suppressed reset is handed off rather than
+// dropped — without the handoff the command is a silent no-op.
+describe("initSessionState hands a suppressed reset to the ACP runtime", () => {
+  async function runBoundAcpReset(
+    trigger: string,
+  ): Promise<Awaited<ReturnType<typeof initSessionState>>> {
+    const root = await makeCaseDir("remoteclaw-acp-handoff-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:codex:acp:binding:discord:default:feedface";
+    const channelId = "1478836151241412759";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "session-existing",
+        updatedAt: Date.now(),
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: channelId },
+          },
+          acp: { mode: "persistent" },
+        },
+      ],
+      channels: { discord: { allowFrom: ["*"] } },
+    } as RemoteClawConfig;
+
+    return initSessionState({
+      ctx: {
+        RawBody: trigger,
+        CommandBody: trigger,
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: channelId,
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+  }
+
+  // The handoff must target the CONFIGURED binding's canonical session key, not
+  // whatever arbitrary ACP-shaped key the turn arrived on.
+  const boundSessionKey = buildConfiguredAcpSessionKey({
+    channel: "discord",
+    accountId: "default",
+    conversationId: "1478836151241412759",
+    agentId: "codex",
+    mode: "persistent",
+  });
+
+  it("reports the bound ACP session key and reason for /new", async () => {
+    const result = await runBoundAcpReset("/new");
+
+    expect(result.resetTriggered).toBe(false);
+    expect(result.acpInPlaceReset).toEqual({
+      sessionKey: boundSessionKey,
+      reason: "new",
+    });
+  });
+
+  it("reports the bound ACP session key and reason for /reset", async () => {
+    const result = await runBoundAcpReset("/reset");
+
+    expect(result.resetTriggered).toBe(false);
+    expect(result.acpInPlaceReset).toEqual({
+      sessionKey: boundSessionKey,
+      reason: "reset",
+    });
+  });
+
+  it("does not claim a handoff when the local session was reset normally", async () => {
+    const root = await makeCaseDir("remoteclaw-acp-handoff-none-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:24680";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "session-existing",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "/new",
+        CommandBody: "/new",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: "24680",
+        SessionKey: sessionKey,
+      },
+      cfg: {
+        session: { store: storePath },
+        channels: { discord: { allowFrom: ["*"] } },
+      } as RemoteClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.acpInPlaceReset).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   buildTelegramTopicConversationId,
   parseTelegramChatIdFromTarget,
+  resolveConversationIdFromTargets,
 } from "../../acp/conversation-id.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
@@ -28,9 +29,6 @@ import {
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
-// Outbound conversation-id resolver was gutted — always returns undefined.
-// oxlint-disable-next-line typescript/no-explicit-any
-const resolveConversationIdFromTargets = (..._args: unknown[]) => undefined as any;
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -68,6 +66,17 @@ export type SessionInitResult = {
   isGroup: boolean;
   bodyStripped?: string;
   triggerBodyNormalized: string;
+  /**
+   * Set when a `/new` or `/reset` was NOT applied to the local session because
+   * the conversation resolves to a bound ACP session, which owns its own
+   * runtime lifecycle. The caller must actuate that reset and report the
+   * outcome to the user — resolving silently here is what made the command a
+   * silent no-op (#2929).
+   */
+  acpInPlaceReset?: {
+    sessionKey: string;
+    reason: "new" | "reset";
+  };
 };
 
 function normalizeSessionText(value: unknown): string {
@@ -265,15 +274,25 @@ export async function initSessionState(params: {
   const strippedForReset = isGroup
     ? stripMentions(triggerBodyNormalized, ctx, cfg, agentId)
     : triggerBodyNormalized;
-  const shouldUseAcpInPlaceReset = Boolean(
-    resolveBoundAcpSessionForReset({
-      cfg,
-      ctx: sessionCtxForState,
-    }),
-  );
+  // Only a genuinely-bound ACP session may take over `/new` and `/reset`. When
+  // this is undefined the local session is reset normally.
+  const boundAcpResetSessionKey = resolveBoundAcpSessionForReset({
+    cfg,
+    ctx: sessionCtxForState,
+  });
+  let acpInPlaceReset: SessionInitResult["acpInPlaceReset"];
   const shouldBypassAcpResetForTrigger = (triggerLower: string): boolean =>
-    shouldUseAcpInPlaceReset &&
+    Boolean(boundAcpResetSessionKey) &&
     DEFAULT_RESET_TRIGGERS.some((defaultTrigger) => defaultTrigger.toLowerCase() === triggerLower);
+  const deferResetToBoundAcpSession = (triggerLower: string): void => {
+    if (!boundAcpResetSessionKey) {
+      return;
+    }
+    acpInPlaceReset = {
+      sessionKey: boundAcpResetSessionKey,
+      reason: triggerLower === "/reset" ? "reset" : "new",
+    };
+  };
 
   // Reset triggers are configured as lowercased commands (e.g. "/new"), but users may type
   // "/NEW" etc. Match case-insensitively while keeping the original casing for any stripped body.
@@ -290,9 +309,11 @@ export async function initSessionState(params: {
     const triggerLower = trigger.toLowerCase();
     if (trimmedBodyLower === triggerLower || strippedForResetLower === triggerLower) {
       if (shouldBypassAcpResetForTrigger(triggerLower)) {
-        // ACP-bound conversations handle /new and /reset in command handling
-        // so the bound ACP runtime can be reset in place without rotating the
-        // normal RemoteClaw session/transcript.
+        // The conversation resolves to a bound ACP session, which owns its own
+        // runtime lifecycle — rotating the local session/transcript here would
+        // desync the two. Hand the reset to the caller via `acpInPlaceReset`;
+        // it must actuate it and tell the user if it could not be applied.
+        deferResetToBoundAcpSession(triggerLower);
         break;
       }
       isNewSession = true;
@@ -306,6 +327,7 @@ export async function initSessionState(params: {
       strippedForResetLower.startsWith(triggerPrefixLower)
     ) {
       if (shouldBypassAcpResetForTrigger(triggerLower)) {
+        deferResetToBoundAcpSession(triggerLower);
         break;
       }
       isNewSession = true;
@@ -648,5 +670,6 @@ export async function initSessionState(params: {
     isGroup,
     bodyStripped,
     triggerBodyNormalized,
+    acpInPlaceReset,
   };
 }

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -222,5 +222,18 @@ export const AUTO_REPLY_QUARANTINE: string[] = [
   "src/auto-reply/reply/followup-runner.channel-bridge.test.ts", // #2782: premise gutted in #2377 (followup-runner is a no-op; ChannelBridge wiring moved to agent-runner-execution.ts) — port the assertions there
   "src/auto-reply/reply/reply-media-paths.test.ts", // #2782: not triaged (delegated agent aborted mid-run) — left quarantined pending investigation
   "src/auto-reply/reply/reply-plumbing.test.ts", // #2782: SOURCE bug — subagents-utils.ts formatRunLabel missing stripInternalRuntimeContext → internal runtime-context info leak into user-facing subagent labels
-  "src/auto-reply/reply/session.test.ts", // #2782: SOURCE bug — session.ts resolveConversationIdFromTargets gutted to ()=>undefined → /new silently suppressed for all ACP-shaped session keys
+  // #2929: the named ACP SOURCE bug is FIXED — session.ts no longer stubs
+  // resolveConversationIdFromTargets to ()=>undefined, so /new and /reset are suppressed only
+  // for genuinely-bound ACP sessions. Its 6 ACP-reset specs were re-homed verbatim to
+  // session.acp-reset.test.ts (un-quarantined, so that behavior gates CI) — the #2953/#2970
+  // focused-spec re-homing precedent. This file stays quarantined on an UNRELATED cluster: 3
+  // "internal channel routing preservation" cases ("lets direct webchat turns override persisted
+  // external routes for per-channel-peer sessions", "does not reuse stale external lastTo for
+  // webchat/main turns without destination", "prefers webchat route over persisted external route
+  // for main session turns") assert that a webchat turn OVERRIDES a persisted external route,
+  // which session-delivery.ts resolveLastChannelRaw/resolveLastToRaw deliberately refuse to do
+  // per #47745 (overwriting the route delivers subagent completion events to the dashboard
+  // instead of the originating channel). Which semantic wins is a delivery-routing product
+  // decision, not a test fix — un-quarantine once it is settled.
+  "src/auto-reply/reply/session.test.ts",
 ];


### PR DESCRIPTION
## Problem

`/new` and `/reset` were a **silent no-op for every ACP-shaped session key**, while three shipped docs positively asserted they worked. A user ran `/reset`, nothing happened, and nothing said so.

Three defects compounded:

1. **Root cause — the gutted resolver.** `session.ts` inlined a `() => undefined` stub for the outbound `resolveConversationIdFromTargets`; its module (`src/infra/outbound/conversation-id.ts`) was *already* a stub when the #2374 gut wave deleted it, and the single caller inherited that stub inline. With the resolver inert, `resolveAcpResetBindingContext` could never identify a conversation, so `resolveEffectiveResetTargetSessionKey` always took its `!channel || !conversationId` path and fell back to the active ACP session key — **never reaching** the `fallbackToActiveAcpWhenUnbound: false` guard the caller explicitly passes. Every ACP-shaped key therefore looked "bound", and the reset was suppressed.
2. **The suppression's promise was never kept.** `resetAcpSessionInPlace` has *no production caller*, and its body awaited `(undefined as any)?.closeSession(…)` / `?.initializeSession(…)` — optional-chaining on `undefined` short-circuits — before resolving `{ ok: true }`. Success reported for work that never happened.
3. **The branch was silent.** `initSessionState` just `break`ed, so no failure surfaced either.

## Remedy

**1 — Suppression constrained to genuinely-bound sessions.** The resolver is restored in the fork's own `src/acp/conversation-id.ts`. The branch is narrowed, not deleted: an unbound ACP-shaped key, or one whose conversation binding points at a non-ACP session, now gets a normal local reset. A genuinely-bound conversation still defers.

**2 — No more `ok: true` for a no-op.** `resetAcpSessionInPlace` returns `ok: false` with `ACP_SESSION_LIFECYCLE_UNAVAILABLE`, or `{ ok: false, skipped: true }` when the key addresses no ACP session at all.

> **Scoping note (deliberate):** it does **not** flip `ensureConfiguredAcpBindingSession`. That is a *route-readiness* gate — `extensions/discord/src/monitor/message-handler.preflight.ts:772` and three peers **drop the inbound message** when it is not ok, so flipping it would silence every configured-ACP conversation. Its `ok` means "may this route carry traffic", never "was this session reset"; the reset path no longer infers success from it. Both contracts are now documented at their definitions.

**3 — Honest notification.** `initSessionState` hands the suppressed reset to the caller via `acpInPlaceReset`; `get-reply-run.ts` actuates it and replies with the real outcome, alongside the existing reset notice.

## Oracle evidence (not authored here)

`src/auto-reply/reply/session.test.ts` — quarantined at `vitest.quarantine.ts` naming this exact source bug.

**Before** — `Tests 5 failed | 42 passed (47)`:
```
× keeps normal /new behavior for unbound ACP-shaped session keys
    AssertionError: expected false to be true   (result.resetTriggered)
× does not suppress /new when active conversation binding points to a non-ACP session
    AssertionError: expected false to be true   (result.resetTriggered)
```
**After** — `Tests 3 failed | 44 passed (47)`. Both ACP cases pass; no assertion was weakened.

## Quarantine: honestly NOT removed

The 3 remaining failures are an **unrelated cluster** — "internal channel routing preservation" cases asserting a webchat turn *overrides* a persisted external route (`expected 'imessage' to be 'webchat'`). `session-delivery.ts:101-109` **deliberately refuses** this, citing #47745 ("overwriting the route delivers subagent completion events to the dashboard instead of the original channel"). Which semantic wins is a delivery-routing product decision, not a test fix — and making them pass would mean reverting a documented guard.

So the entry **stays**, with its comment corrected to reality. Per the #2953/#2970 precedent the 6 ACP specs are re-homed **verbatim** to `session.acp-reset.test.ts` (un-quarantined), so this behavior actually gates CI. 3 further handoff specs there are newly authored.

## Verification

| Check | Result |
|---|---|
| `pnpm check` | ✅ green (also re-run by pre-commit hook) |
| `pnpm build` | ✅ green |
| `vitest src/acp/` | ✅ 139 passed \| 1 skipped |
| `vitest src/auto-reply/reply/` | ✅ 427 passed |
| `test-auto-reply` lane | ✅ 663 passed (58 files) |
| `test-extensions` lane | ✅ 4816 passed \| 31 skipped (503 files) |
| `test-gateway` lane | ✅ 1974 passed \| 3 skipped (185 files) |
| unit lane (`test:macmini`) | ✅ 10502 passed \| 42 skipped (1065 files) |
| attestations / raw-fetch / zombie-import / obsolescence / policy-doctor / stub-debt / throwing-stub-callers | ✅ all exit 0 |

Docs corrected at all four shipped sites (`grep` found one beyond the three cited): `docs/channels/bluebubbles.md`, `docs/channels/matrix.md`, `docs/tools/acp-agents.md` ×2.

## Premise corrections

- **`acp-reset-target.ts:71` does not defeat the caller.** It is correct and, in the defective path, **unreachable** — the `!channel || !conversationId` early return at line 28-30 short-circuits first. It is left intact.
- **The stale comment was at `session.ts:293-295`, not 292-297** — "ACP-bound conversations handle /new and /reset in command handling". `commands-session.ts` contains no ACP handling and `resetAcpSessionInPlace` had zero production callers, so the claim was false. Rewritten.

Closes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
