### PR TITLE
fix(discord): repair the test-helper find-replace that made the worker timeout unobservable

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -91,43 +91,6 @@ function installDefaultDiscordPreflight() {
   );
 }
 
-function createAbortOnTimeoutProcessImplementation() {
-  return async (ctx: { abortSignal?: AbortSignal }) => {
-    await new Promise<void>((resolve) => {
-      if (ctx.abortSignal?.aborted) {
-        resolve();
-        return;
-      }
-      ctx.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
-    });
-  };
-}
-
-async function queueTimedMessages(params?: {
-  workerRunTimeoutMs?: number;
-  beforeCreateHandler?: () => void;
-}) {
-  preflightDiscordMessageMock.mockReset();
-  processDiscordMessageMock.mockReset();
-  deliverDiscordReplyMock.mockClear();
-
-  processDiscordMessageMock
-    .mockImplementationOnce(createAbortOnTimeoutProcessImplementation())
-    .mockImplementationOnce(async () => undefined);
-  installDefaultDiscordPreflight();
-  params?.beforeCreateHandler?.();
-
-  const handlerParams = createDiscordHandlerParams({
-    workerRunTimeoutMs: params?.workerRunTimeoutMs ?? 50,
-  });
-  const handler = createDiscordMessageHandler(handlerParams);
-
-  await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
-  await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();
-
-  return { handlerParams };
-}
-
 async function runSingleMessageTimeout(params: {
   processImpl: Parameters<typeof processDiscordMessageMock.mockImplementationOnce>[0];
   workerRunTimeoutMs?: number;
@@ -259,79 +222,12 @@ describe("createDiscordMessageHandler queue behavior", () => {
 
   // The inbound replay-guard dedup cases that used to live here were re-homed to
   // message-handler.dedupe.test.ts (un-quarantined, gates CI) once the guard was wired in
-  // (#2968). This file stays quarantined ONLY on its timeout-fallback-reply cases below,
-  // which assert a user-facing "timed out" channel reply that is a separate,
-  // ratification-pending maintainer decision (onTimeout is still log-only). See
-  // vitest.quarantine.ts.
-
-  it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {
-    vi.useFakeTimers();
-    try {
-      const { handlerParams } = await queueTimedMessages();
-
-      await vi.advanceTimersByTimeAsync(60);
-      await vi.waitFor(() => {
-        expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
-      });
-
-      const firstCtx = processDiscordMessageMock.mock.calls[0]?.[0] as
-        | { abortSignal?: AbortSignal }
-        | undefined;
-      expect(firstCtx?.abortSignal?.aborted).toBe(true);
-      expect(handlerParams.runtime.error).toHaveBeenCalledWith(
-        expect.stringContaining("discord inbound worker timed out after"),
-      );
-      expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
-      expect(deliverDiscordReplyMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: "channel:ch-1",
-          token: "test-token",
-          replies: [
-            expect.objectContaining({
-              isError: true,
-              text: "Discord inbound worker timed out.",
-            }),
-          ],
-        }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("waits for the timeout fallback reply before starting the next queued run", async () => {
-    vi.useFakeTimers();
-    try {
-      const deliverTimeoutReply = createDeferred();
-      const { handlerParams } = await queueTimedMessages({
-        beforeCreateHandler: () => {
-          deliverDiscordReplyMock.mockReset();
-          deliverDiscordReplyMock.mockImplementationOnce(async () => {
-            await deliverTimeoutReply.promise;
-          });
-        },
-      });
-
-      await vi.advanceTimersByTimeAsync(60);
-      await vi.waitFor(() => {
-        expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
-      });
-
-      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
-      expect(handlerParams.runtime.error).toHaveBeenCalledWith(
-        expect.stringContaining("discord inbound worker timed out after"),
-      );
-
-      deliverTimeoutReply.resolve();
-      await deliverTimeoutReply.promise;
-
-      await vi.waitFor(() => {
-        expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
-      });
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+  // (#2968). The timeout-fallback-REPLY cases were likewise re-homed to
+  // message-handler.timeout-fallback-reply.test.ts (#2998) — they assert a user-facing
+  // "timed out" channel reply that is a separate, ratification-pending maintainer decision
+  // (onTimeout is still log-only), so only that focused file stays quarantined. The
+  // negative timeout cases below stay here: they assert the fallback is NOT sent, which
+  // holds under today's log-only behavior. See vitest.quarantine.ts.
 
   it("does not send the timeout fallback when a final reply already went out", async () => {
     vi.useFakeTimers();
@@ -354,51 +250,6 @@ describe("createDiscordMessageHandler queue behavior", () => {
       });
 
       expect(deliverDiscordReplyMock).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("routes the timeout fallback to the created auto-thread target", async () => {
-    vi.useFakeTimers();
-    try {
-      await runSingleMessageTimeout({
-        processImpl: async (
-          ctx: { abortSignal?: AbortSignal },
-          observer?: {
-            onReplyPlanResolved?: (params: {
-              createdThreadId?: string;
-              sessionKey?: string;
-            }) => void;
-          },
-        ) => {
-          observer?.onReplyPlanResolved?.({
-            createdThreadId: "thread-1",
-            sessionKey: "agent:main:discord:channel:thread-1",
-          });
-          await new Promise<void>((resolve) => {
-            if (ctx.abortSignal?.aborted) {
-              resolve();
-              return;
-            }
-            ctx.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
-          });
-        },
-      });
-
-      expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
-      expect(deliverDiscordReplyMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: "channel:thread-1",
-          sessionKey: "agent:main:discord:channel:thread-1",
-          replies: [
-            expect.objectContaining({
-              isError: true,
-              text: "Discord inbound worker timed out.",
-            }),
-          ],
-        }),
-      );
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/message-handler.test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.test-helpers.ts
@@ -48,7 +48,7 @@ export function createDiscordHandlerParams(overrides?: {
     threadBindings: createNoopThreadBindingManager("default"),
     setStatus: overrides?.setStatus,
     abortSignal: overrides?.abortSignal,
-    // workerRunTimeoutMs: overrides?.// workerRunTimeoutMs,
+    workerRunTimeoutMs: overrides?.workerRunTimeoutMs,
   };
 }
 

--- a/extensions/discord/src/monitor/message-handler.timeout-fallback-reply.test.ts
+++ b/extensions/discord/src/monitor/message-handler.timeout-fallback-reply.test.ts
@@ -1,0 +1,243 @@
+// The inbound-worker timeout-fallback-reply cases, re-homed out of
+// message-handler.queue.test.ts (#2998) so that file's remaining queue-behavior coverage
+// gates CI on its own. Mirrors the #2953/#2970 focused-spec re-homing precedent (and the
+// #2968 dedupe re-home before it).
+//
+// These three assert a user-facing "Discord inbound worker timed out." channel reply.
+// `onTimeout` in inbound-worker.ts is deliberately still log-only, pending a separate,
+// ratification-pending maintainer decision on whether that fallback reply should exist at
+// all (#2998). They fail for that reason and that reason alone — this whole file is
+// quarantined until the decision lands. See vitest.quarantine.ts.
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDiscordMessageHandler,
+  deliverDiscordReplyMock,
+  preflightDiscordMessageMock,
+  processDiscordMessageMock,
+} from "./message-handler.module-test-helpers.js";
+import {
+  createDiscordHandlerParams,
+  createDiscordPreflightContext,
+} from "./message-handler.test-helpers.js";
+
+function createDeferred<T = void>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function createMessageData(messageId: string, channelId = "ch-1") {
+  return {
+    channel_id: channelId,
+    author: { id: "user-1" },
+    message: {
+      id: messageId,
+      author: { id: "user-1", bot: false },
+      content: "hello",
+      channel_id: channelId,
+      attachments: [{ id: `att-${messageId}` }],
+    },
+  };
+}
+
+function createPreflightContext(channelId = "ch-1") {
+  return {
+    ...createDiscordPreflightContext(channelId),
+    accountId: "default",
+    token: "test-token",
+    textLimit: 2_000,
+    replyToMode: "off" as const,
+    discordConfig: {
+      enabled: true,
+      token: "test-token",
+      groupPolicy: "allowlist" as const,
+    },
+  };
+}
+
+function installDefaultDiscordPreflight() {
+  preflightDiscordMessageMock.mockImplementation(async (params: { data: { channel_id: string } }) =>
+    createPreflightContext(params.data.channel_id),
+  );
+}
+
+function createAbortOnTimeoutProcessImplementation() {
+  return async (ctx: { abortSignal?: AbortSignal }) => {
+    await new Promise<void>((resolve) => {
+      if (ctx.abortSignal?.aborted) {
+        resolve();
+        return;
+      }
+      ctx.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+    });
+  };
+}
+
+async function queueTimedMessages(params?: {
+  workerRunTimeoutMs?: number;
+  beforeCreateHandler?: () => void;
+}) {
+  preflightDiscordMessageMock.mockReset();
+  processDiscordMessageMock.mockReset();
+  deliverDiscordReplyMock.mockClear();
+
+  processDiscordMessageMock
+    .mockImplementationOnce(createAbortOnTimeoutProcessImplementation())
+    .mockImplementationOnce(async () => undefined);
+  installDefaultDiscordPreflight();
+  params?.beforeCreateHandler?.();
+
+  const handlerParams = createDiscordHandlerParams({
+    workerRunTimeoutMs: params?.workerRunTimeoutMs ?? 50,
+  });
+  const handler = createDiscordMessageHandler(handlerParams);
+
+  await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
+  await expect(handler(createMessageData("m-2") as never, {} as never)).resolves.toBeUndefined();
+
+  return { handlerParams };
+}
+
+async function runSingleMessageTimeout(params: {
+  processImpl: Parameters<typeof processDiscordMessageMock.mockImplementationOnce>[0];
+  workerRunTimeoutMs?: number;
+}) {
+  preflightDiscordMessageMock.mockReset();
+  processDiscordMessageMock.mockReset();
+  deliverDiscordReplyMock.mockClear();
+  processDiscordMessageMock.mockImplementationOnce(params.processImpl);
+  installDefaultDiscordPreflight();
+
+  const handlerParams = createDiscordHandlerParams({
+    workerRunTimeoutMs: params.workerRunTimeoutMs ?? 50,
+  });
+  const handler = createDiscordMessageHandler(handlerParams);
+
+  await expect(handler(createMessageData("m-1") as never, {} as never)).resolves.toBeUndefined();
+  await vi.advanceTimersByTimeAsync(60);
+  await Promise.resolve();
+
+  expect(handlerParams.runtime.error).toHaveBeenCalledWith(
+    expect.stringContaining("discord inbound worker timed out after"),
+  );
+
+  return handlerParams;
+}
+
+describe("createDiscordMessageHandler timeout fallback reply", () => {
+  it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {
+    vi.useFakeTimers();
+    try {
+      const { handlerParams } = await queueTimedMessages();
+
+      await vi.advanceTimersByTimeAsync(60);
+      await vi.waitFor(() => {
+        expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      });
+
+      const firstCtx = processDiscordMessageMock.mock.calls[0]?.[0] as
+        | { abortSignal?: AbortSignal }
+        | undefined;
+      expect(firstCtx?.abortSignal?.aborted).toBe(true);
+      expect(handlerParams.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord inbound worker timed out after"),
+      );
+      expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
+      expect(deliverDiscordReplyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: "channel:ch-1",
+          token: "test-token",
+          replies: [
+            expect.objectContaining({
+              isError: true,
+              text: "Discord inbound worker timed out.",
+            }),
+          ],
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for the timeout fallback reply before starting the next queued run", async () => {
+    vi.useFakeTimers();
+    try {
+      const deliverTimeoutReply = createDeferred();
+      const { handlerParams } = await queueTimedMessages({
+        beforeCreateHandler: () => {
+          deliverDiscordReplyMock.mockReset();
+          deliverDiscordReplyMock.mockImplementationOnce(async () => {
+            await deliverTimeoutReply.promise;
+          });
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(60);
+      await vi.waitFor(() => {
+        expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
+      });
+
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+      expect(handlerParams.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("discord inbound worker timed out after"),
+      );
+
+      deliverTimeoutReply.resolve();
+      await deliverTimeoutReply.promise;
+
+      await vi.waitFor(() => {
+        expect(processDiscordMessageMock).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("routes the timeout fallback to the created auto-thread target", async () => {
+    vi.useFakeTimers();
+    try {
+      await runSingleMessageTimeout({
+        processImpl: async (
+          ctx: { abortSignal?: AbortSignal },
+          observer?: {
+            onReplyPlanResolved?: (params: {
+              createdThreadId?: string;
+              sessionKey?: string;
+            }) => void;
+          },
+        ) => {
+          observer?.onReplyPlanResolved?.({
+            createdThreadId: "thread-1",
+            sessionKey: "agent:main:discord:channel:thread-1",
+          });
+          await new Promise<void>((resolve) => {
+            if (ctx.abortSignal?.aborted) {
+              resolve();
+              return;
+            }
+            ctx.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+      });
+
+      expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
+      expect(deliverDiscordReplyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: "channel:thread-1",
+          sessionKey: "agent:main:discord:channel:thread-1",
+          replies: [
+            expect.objectContaining({
+              isError: true,
+              text: "Discord inbound worker timed out.",
+            }),
+          ],
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/vitest.quarantine.ts
+++ b/vitest.quarantine.ts
@@ -60,19 +60,32 @@ export const EXTENSIONS_QUARANTINE: string[] = [
   "extensions/discord/src/monitor.tool-result.sends-status-replies-responseprefix.test.ts",
   "extensions/discord/src/monitor/auto-presence.test.ts",
   "extensions/discord/src/monitor/message-handler.preflight.test.ts",
-  // #2968 (discord): the inbound message-ID replay guard is now wired into
-  // inbound-worker.ts / message-handler.ts, and this file's 3 dedup cases were re-homed to
-  // message-handler.dedupe.test.ts (un-quarantined, so the dedup behavior gates CI) — the
-  // #2953/#2970 focused-spec re-homing precedent. message-handler.queue.test.ts STAYS
-  // quarantined ONLY on its 3 timeout-fallback-reply cases ("applies explicit inbound worker
-  // timeout ...", "waits for the timeout fallback reply before starting the next queued run",
-  // "routes the timeout fallback to the created auto-thread target"): they assert a
-  // user-facing "Discord inbound worker timed out." channel reply, but onTimeout is
-  // deliberately still log-only pending a separate, ratification-pending maintainer decision
-  // on whether that fallback reply should exist. (The file's remaining queue-behavior cases
-  // pass, but file-level quarantine is all-or-nothing.) Un-quarantine when the timeout-reply
-  // decision lands.
-  "extensions/discord/src/monitor/message-handler.queue.test.ts",
+  // #2998 (discord): message-handler.queue.test.ts is UN-quarantined; only the three
+  // timeout-fallback-reply cases re-homed here stay out of CI.
+  //
+  // This entry previously claimed the queue file failed on exactly 3 cases. That was wrong:
+  // it failed on 5, because message-handler.test-helpers.ts had a botched find-replace
+  // (`// workerRunTimeoutMs: overrides?.// workerRunTimeoutMs,`) that never threaded
+  // workerRunTimeoutMs into the handler params, so the worker timeout never fired and
+  // runtime.error was called 0 times. Two cases failed on that harness bug alone —
+  // "does not send the timeout fallback when a final reply already went out" and "does not
+  // send the timeout fallback when final reply delivery is already in flight", both of which
+  // assert runtime.error fires and the fallback is NOT sent. Repairing the helper dropped the
+  // queue file from 5 failures to 3, and those two now pass and gate CI in place.
+  //
+  // The 3 that remain are re-homed into message-handler.timeout-fallback-reply.test.ts (the
+  // #2953/#2970 focused-spec precedent, as with the #2968 dedup re-home to
+  // message-handler.dedupe.test.ts):
+  //   - "applies explicit inbound worker timeout to queued runs so stalled runs do not block
+  //     the queue"
+  //   - "waits for the timeout fallback reply before starting the next queued run"
+  //   - "routes the timeout fallback to the created auto-thread target"
+  // All three assert a user-facing "Discord inbound worker timed out." channel reply. The
+  // timeout now fires and is observable (runtime.error), but onTimeout in inbound-worker.ts is
+  // deliberately still log-only, pending a separate, ratification-pending maintainer decision
+  // on whether that fallback reply should exist at all (#2998 — still open). Un-quarantine
+  // when that decision lands.
+  "extensions/discord/src/monitor/message-handler.timeout-fallback-reply.test.ts",
   "extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts",
   "extensions/discord/src/voice-message.test.ts",
   // #2782 (feishu): monitor.reaction remains — needs a separate SOURCE change


### PR DESCRIPTION
## The corpse

`extensions/discord/src/monitor/message-handler.test-helpers.ts:51` carried a botched find-replace:

```ts
    // workerRunTimeoutMs: overrides?.// workerRunTimeoutMs,
```

It commented out the whole assignment **and** left a nested `//` mid-line. `workerRunTimeoutMs` was
therefore never threaded from the test harness into the handler params, so the Discord inbound-worker
timeout was **unreachable from tests** — `runtime.error` fired 0 times no matter what a test passed.

Repaired to the intended form, mirroring the sibling lines. No source change was needed:
`DiscordMessageHandlerParams` already declares `workerRunTimeoutMs?: number`
(`message-handler.ts:32`) and forwards it as the worker's `runTimeoutMs` (`message-handler.ts:56`).

## Evidence the timeout became observable

**Before** — every failure is on the `runtime.error` assertion, `Number of calls: 0`:

```
 FAIL ... > does not send the timeout fallback when a final reply already went out
AssertionError: expected "vi.fn()" to be called with arguments: [ StringContaining{…} ]
Number of calls: 0
 ❯ runSingleMessageTimeout .../message-handler.queue.test.ts:150:39
    150|   expect(handlerParams.runtime.error).toHaveBeenCalledWith(
    151|     expect.stringContaining("discord inbound worker timed out after"),

 Test Files  1 failed (1)
      Tests  5 failed | 9 passed (14)
```

**After** — the failure point moved *past* `runtime.error` onto `deliverDiscordReplyMock`, i.e. the
timeout now fires and is observed; what is left is only the absent user-facing reply:

```
 FAIL ... > applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ .../message-handler.queue.test.ts:284:39
    281|       expect(handlerParams.runtime.error).toHaveBeenCalledWith(   <- now satisfied
    282|         expect.stringContaining("discord inbound worker timed out afte…
    283|       );
    284|       expect(deliverDiscordReplyMock).toHaveBeenCalledTimes(1);
       |                                       ^

 Test Files  1 failed (1)
      Tests  3 failed | 11 passed (14)
```

Stable across 3 consecutive runs (`3 failed | 11 passed` each time).

## The ledger comment was wrong — corrected

`vitest.quarantine.ts` claimed `message-handler.queue.test.ts` stayed quarantined on **3**
timeout-fallback-reply cases. It actually failed on **5**. The true before-list:

1. `applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue`
2. `waits for the timeout fallback reply before starting the next queued run`
3. `does not send the timeout fallback when a final reply already went out` ← harness bug only
4. `routes the timeout fallback to the created auto-thread target`
5. `does not send the timeout fallback when final reply delivery is already in flight` ← harness bug only

(3) and (5) are *negative* cases: they assert `runtime.error` fires and the fallback is **not** sent.
They were failing purely because the harness never made the timeout fire — they hold fine under
today's log-only `onTimeout`. Repairing the helper flipped both to passing; only 1, 2 and 4 remain.
The ledger comment now records the real count, the real names, and why the two extra ones were there.

## Re-homed rather than left quarantined

Everything except the genuinely-deferred cases passes, so this follows the #2953/#2970 focused-spec
precedent the ledger itself cites (and the #2968 dedup re-home): the 3 deferred cases move to
`message-handler.timeout-fallback-reply.test.ts`, which takes over the quarantine entry.

`message-handler.queue.test.ts` is **un-quarantined** and now gates CI on its 11 queue-behaviour
cases. Confirmed non-degenerately — `vitest list --config vitest.extensions.config.ts` shows the lane
now includes `message-handler.queue.test.ts` and excludes the new focused file, and the lane run is
green (67 files / 465 tests passed).

No assertion was weakened and no test was deleted.

## 🔴 The timeout-reply decision is untouched and still open

This PR does **not** answer whether the Discord inbound-worker timeout should deliver a user-facing
reply instead of being log-only. `onTimeout` in `inbound-worker.ts` is unchanged and remains
log-only. That decision needs a new observer contract spanning 7-9 files, is ratification-pending
with the maintainer, and **#2998 stays open for it** — hence `Refs`, not `Closes`. This PR only
repairs the thing that made the question un-investigable.

## Verification

- `pnpm check` — green (format, `tsgo`, `typecheck:scripts`, `oxlint --type-aware`, all fork-integrity gates)
- `pnpm vitest run extensions/discord/src/monitor/` — `4 failed | 36 passed (40)` files. The 4 failing
  are all quarantined: the 3 pre-existing separate entries (`auto-presence`,
  `message-handler.preflight`, `native-command.commands-allowfrom`) plus the new
  `message-handler.timeout-fallback-reply`. `message-handler.queue.test.ts` is fully green.
- `vitest.extensions.config.ts` scoped to `extensions/discord/` — `67 passed (67)` files, `465 passed | 3 skipped`.

Refs #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)