### PR TITLE
ci: skip the native locale refresh when no provider secret is set (#3147)

### DIFF
--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -25,8 +25,40 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' }}
 
 jobs:
-  refresh:
+  # The `secrets` context is not available to a job-level `if:`, so the provider
+  # check cannot gate `refresh` directly — it has to read the secrets in a step
+  # and publish the verdict as a job output. Only the boolean is exported; no
+  # secret value ever reaches an output.
+  #
+  # This job's `if:` is deliberately identical to `refresh`'s existing guard.
+  # Keep the two in sync: it is what stops the probe from running on forks or on
+  # the bot's own push, exactly as `refresh` already declines to.
+  preflight:
+    name: Check translation provider secret
     if: github.repository == 'remoteclaw/remoteclaw' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') && (github.event_name != 'push' || github.actor != 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      has-provider-secret: ${{ steps.probe.outputs.has-provider-secret }}
+    steps:
+      - name: Probe for a translation provider secret
+        id: probe
+        env:
+          REMOTECLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.REMOTECLAW_DOCS_I18N_OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${REMOTECLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] || [ -n "${OPENAI_API_KEY:-}" ] || [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "has-provider-secret=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "has-provider-secret=false" >> "${GITHUB_OUTPUT}"
+          echo "::notice::No translation provider secret is configured (REMOTECLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY). Skipping the native locale refresh."
+
+  refresh:
+    needs: preflight
+    if: github.repository == 'remoteclaw/remoteclaw' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') && (github.event_name != 'push' || github.actor != 'github-actions[bot]') && needs.preflight.outputs.has-provider-secret == 'true'
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -68,18 +100,6 @@ jobs:
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
-
-      - name: Ensure translation provider secrets exist
-        env:
-          REMOTECLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.REMOTECLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${REMOTECLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "Missing REMOTECLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY secret."
-            exit 1
-          fi
 
       - name: Refresh native locale artifact
         env:


### PR DESCRIPTION
Closes #3147.

Converts the workflow's **fail-closed** secret guard into a **skip-closed** one. When no
translation-provider secret is configured, `native-app-locale-refresh.yml` now no-ops instead of
failing.

**No secret is configured, and no new secret is referenced** — not in the workflow, not in docs. The
three names the file already used at `origin/main` are the only three it uses now.

## Why this route

The issue framed three options: configure a secret, delete the workflow, or make it skip. This is
the third. It stops the red immediately, it is reversible, it preserves the workflow if a secret is
ever configured, and it commits the repo to no posture on LLM-authored commits landing on `main`.

## What was actually wrong

Nothing in the merged code. The `v2026.7.1-2` sync (`5c244c1a95a`) brought the file in; it fired on
the merge and all 21 matrix jobs died on its own first step, because this repo has none of
`REMOTECLAW_DOCS_I18N_OPENAI_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`. The guard was
fail-closed and it **worked** — no translation ran, nothing was committed, nothing was pushed.

What this PR changes is only *how that case is reported*: from failure to skip.

Those 21 red check-runs are what this retires. They were **never part of the `CI` rollup** — the
sole required status check — so they never blocked a merge. The cost was that `main` carried a
permanent red, and the workflow re-fires on every push touching a native-app source or either i18n
script, so a genuinely broken build is hard to distinguish at a glance.

## Shape

The `secrets` context is **not available to a job-level `if:`** (documented availability for
`jobs.<job_id>.if` is `github, needs, vars, inputs`), so the guard cannot simply move up onto
`refresh`. Instead:

- a `preflight` job reads the three secrets in a *step* and publishes a boolean output;
- `refresh` gains `needs: preflight` and `&& needs.preflight.outputs.has-provider-secret == 'true'`,
  appended to its existing guard, which is otherwise unchanged;
- the now-redundant in-job guard step is removed. The probe's predicate is the exact De Morgan dual
  of the guard it replaces, over the same three secrets.

`preflight` carries the same repository/dispatch/actor guard as `refresh`, so it does not newly run
on forks or on the bot's own push. It runs with `permissions: {}` and never checks out the
repository — strictly tighter isolation than the guard step it replaces, which sat downstream of
both checkout and `setup-node-env`.

Only the boolean is exported. No secret value reaches an output, a log, or an annotation.

## The auto-push path remains unreachable

`finalize` commits with `--no-verify` and force-retries a push straight to the default branch five
times. It is gated on, unchanged from `origin/main`:

```yaml
  finalize:
    needs: refresh
    if: needs.refresh.result == 'success'
```

On the no-secret path that job is skipped for **two independent reasons**, either alone sufficient:

1. **Documented propagation** — *"if a job fails or is skipped, all jobs that need it are skipped
   unless the jobs use a conditional expression that causes the job to continue."* `finalize`'s
   condition contains no `always()` / `!cancelled()` / `failure()`, so nothing causes it to continue.
2. **The condition is false on its own** — `needs.<job_id>.result` is one of `success`, `failure`,
   `cancelled`, `skipped`. A skipped `refresh` yields `'skipped'`, and `'skipped' != 'success'`.

This is **inherited protection, not a new gate**: reachability is logically *equal* before and
after, not merely non-widened. Before, `finalize` required all 21 legs green, and a leg could only
go green if the guard step passed ⟹ ≥1 secret non-empty. After, it requires the same thing, checked
once and earlier. Moving a necessary condition into series can only narrow.

Empirically, `finalize` was **already** unreachable on this path: on the sync merge it reports
`skipped` while the 21 legs report `failure`.

Both translator call sites are inside jobs that skip — the refresh step in `refresh`, and
`sync --write` / `check` in `finalize`.

## Verification

| Gate | Result |
|---|---|
| YAML parses (`yaml.safe_load`) | exit `0` — jobs `['preflight', 'refresh', 'finalize']` |
| `actionlint` 1.7.11 (the version `scripts/check-workflows.mjs` pins) | exit `0`, zero findings — matches the pre-change baseline for this file |
| `finalize` job vs `origin/main` | byte-identical, sha256 `ee2690c4a5ea…` both sides; commit/push block (28 lines) diffs clean |
| New secret names introduced | none — set difference against `origin/main` is empty |
| `pnpm check` | exit `0` (also re-run green by the pre-commit hook) |

`actionlint`'s exit-0 is load-bearing rather than decorative here: it type-checks
`needs.<job>.outputs.<name>` against the declared `outputs:` of jobs in `needs`, so a misdeclared
output would have failed the lint.

Note that `pnpm check` does **not** lint workflow YAML (oxfmt/oxlint are JS/TS only), so it is not a
real gate on this change — `actionlint` is. `scripts/check-workflows.mjs` exists and would be, but
it is wired to no package script and no CI job, and none of its three linter backends is installed
by default. Flagging it, not fixing it here.

## Accepted trade-off

Converting failure to skip also removes the only alarm. If a provider secret is ever configured and
later lost, the workflow would report green while silently refreshing nothing. Recording this as a
deliberate acceptance rather than an oversight.

I kept `::notice::` rather than `::warning::` because the no-secret state here is deliberate and
indefinite — a warning would fire on every qualifying push forever, turning a permanent red into a
permanent amber, which is a smaller instance of the same alarm-fatigue problem this PR exists to
remove. If a secret is ever configured, promoting it to `::warning::` (or warning only on
`workflow_dispatch`, where a human is actively expecting output) becomes the right call. Happy to
make that change now if preferred.

---

Reviewed by an independent fresh-context pass, which returned CLEAR on all four constraints
(validity/context legality, no-secret path reaching neither translation nor `finalize`, `finalize`
unchanged and no more reachable, no new secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
