### PR TITLE
fix(cli): render nodes-approve with the real CLI name, and unblind the gate that hid it (#3148)

### DIFF
--- a/scripts/ci/rebrand-allowlist.txt
+++ b/scripts/ci/rebrand-allowlist.txt
@@ -155,12 +155,6 @@ openclaw\
 Cherry-picked-from:
 
 # ---------------------------------------------------------------------------
-# Quoted compat package/binary names
-# ---------------------------------------------------------------------------
-"openclaw"
-'openclaw'
-
-# ---------------------------------------------------------------------------
 # Source files with compat references (CLI command strings, variable names,
 # config fields, import wizard, probe strings, plugin fixtures). These are
 # existing upstream artifacts; new files are NOT exempt and will be caught.
@@ -205,3 +199,53 @@ FILE:src/wizard/onboarding.ts
 FILE:extensions/line/src/channel.ts
 FILE:extensions/mattermost/src/mattermost/monitor.ts
 FILE:extensions/zalouser/src/status-issues.ts
+
+# ---------------------------------------------------------------------------
+# Quoted bare `openclaw` tokens — exempt per path, NEVER by pattern (#3148)
+# ---------------------------------------------------------------------------
+# A quoted bare token is THE shape of a genuine brand leak in TypeScript, so the
+# blanket `"openclaw"` / `'openclaw'` patterns this file used to carry blinded
+# scan 1 to the class it exists to catch: src/cli/nodes-cli/register.status.ts
+# shipped `["openclaw", "nodes", "approve", …]` green, telling operators to run a
+# binary this project does not ship. Dropping them surfaced 27 lines — that one
+# real defect (fixed in #3148) plus the 26 legitimate ones exempted per path
+# below, so a NEW quoted bare `openclaw` anywhere else fails the gate.
+
+# Reads the LEGACY upstream config directory ($XDG_CONFIG_HOME/openclaw/...)
+# alongside the current ~/.remoteclaw-auth-profile-secrets path. The literal
+# names a directory written by upstream OpenClaw, so rebranding it would break
+# the legacy-read path it exists to serve.
+FILE:src/agents/auth-profiles/legacy-oauth-sidecar.ts
+
+# Fork-integrity regression test: asserts the upstream token is ABSENT from the
+# built system prompt (`expect(result).not.toContain("openclaw")`). The token is
+# the assertion SUBJECT — rebranding it would invert what the test proves.
+FILE:src/middleware/system-prompt.test.ts
+
+# Generated npm lockfiles carrying a stale upstream peer-dependency block
+# (`"openclaw": ">=2026.5.28"`, optional), last written by `sync: upstream to
+# v2026.5.28` (#3022). Their own source of truth disagrees — no
+# extensions/*/package.json declares peerDependencies at all — so the correct
+# artifact has NO such block, and hand-editing the token to `remoteclaw` would
+# fabricate a peer dep the manifest never declared. Regenerating them is a
+# dependency-surface change needing explicit approval: deferred to #3151.
+# Nothing reads them today, and the reasons are fragile enough to name:
+# `deps:shrinkwrap:check` is not a package script (its only referrer,
+# scripts/check.mjs, is unreachable from `pnpm check`), and the one live test
+# consumer, test/package-manager-config.test.ts, filters to
+# `publishToNpm === true`, which none of these 12 extensions set. Wire that
+# guard up and these exemptions go stale with nothing to flag it.
+# Listed per file, not as a directory prefix: a 13th extension gaining the block
+# SHOULD fail the gate and get re-reviewed.
+FILE:extensions/discord/npm-shrinkwrap.json
+FILE:extensions/feishu/npm-shrinkwrap.json
+FILE:extensions/googlechat/npm-shrinkwrap.json
+FILE:extensions/line/npm-shrinkwrap.json
+FILE:extensions/matrix/npm-shrinkwrap.json
+FILE:extensions/msteams/npm-shrinkwrap.json
+FILE:extensions/nextcloud-talk/npm-shrinkwrap.json
+FILE:extensions/nostr/npm-shrinkwrap.json
+FILE:extensions/slack/npm-shrinkwrap.json
+FILE:extensions/tlon/npm-shrinkwrap.json
+FILE:extensions/whatsapp/npm-shrinkwrap.json
+FILE:extensions/zalouser/npm-shrinkwrap.json

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -11,6 +11,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../../runtime.js";
 import { shortenHomeInString } from "../../utils.js";
+import { resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { quoteCliArg } from "../quote-cli-arg.js";
@@ -138,7 +139,7 @@ function formatPendingApprovalCommand(raw: unknown, opts: NodesRpcOpts): string 
   if (!requestId) {
     return null;
   }
-  const args = ["openclaw", "nodes", "approve", requestId];
+  const args = [resolveCliName(), "nodes", "approve", requestId];
   const timeout = normalizeOptionalString(opts.timeout);
   if (timeout && timeout !== String(DEFAULT_NODES_RPC_TIMEOUT_MS)) {
     args.push("--timeout", timeout);

--- a/test/scripts/check-rebrand-leakage.test.ts
+++ b/test/scripts/check-rebrand-leakage.test.ts
@@ -183,3 +183,49 @@ describe("check-rebrand-leakage scan 4 (dead openclaw.plugin.json filenames)", (
     expect(output).toContain("No rebrand leakage detected.");
   });
 });
+
+describe("check-rebrand-leakage scan 1 (quoted bare openclaw token)", () => {
+  // Until #3148 the allowlist carried blanket `"openclaw"` / `'openclaw'` content
+  // patterns. scan() drops any hit whose LINE contains an allowlist pattern, so
+  // those two entries exempted every line holding a quoted bare token — precisely
+  // the shape of a real brand leak in TypeScript. The gate could not fail its own
+  // corpse: src/cli/nodes-cli/register.status.ts shipped `["openclaw", "nodes",
+  // "approve", requestId]` green, telling operators to run a binary this package
+  // does not ship. These tests run against the REAL allowlist (copied by
+  // makeRepo), so restoring either blanket entry reddens the case that quotes it
+  // the same way. Package.swift is omitted (null) to isolate scan 1.
+
+  it("fails on the exact defect #3148 fixed — a quoted binary name in a rendered command", () => {
+    const { status, output } = runGate(
+      makeRepo(null, {
+        "src/cli/probe.ts": 'const args = ["openclaw", "nodes", "approve", requestId];\n',
+      }),
+    );
+    expect(status).toBe(1);
+    expect(output).toContain("Rebrand leakage detected");
+    expect(output).toContain("src/cli/probe.ts");
+  });
+
+  it("fails on the single-quoted form too", () => {
+    const { status, output } = runGate(
+      makeRepo(null, { "src/cli/probe.ts": "const bin = 'openclaw';\n" }),
+    );
+    expect(status).toBe(1);
+    expect(output).toContain("Rebrand leakage detected");
+    expect(output).toContain("src/cli/probe.ts");
+  });
+
+  it("still honors per-path exemptions, so legitimate quoted tokens stay green", () => {
+    // The narrow FILE: rows that replaced the blanket patterns must keep working —
+    // otherwise the fix trades a blind gate for an unusable one. Uses a real
+    // exempted path (the legacy upstream config-dir read).
+    const { status, output } = runGate(
+      makeRepo(null, {
+        "src/agents/auth-profiles/legacy-oauth-sidecar.ts":
+          'const legacy = path.join(root, "openclaw", KEY_FILE);\n',
+      }),
+    );
+    expect(status).toBe(0);
+    expect(output).toContain("No rebrand leakage detected.");
+  });
+});


### PR DESCRIPTION
Closes #3148.

Two coupled defects: a user-facing CLI instruction naming a binary this project does not ship,
and the allowlist entry that made the rebrand gate structurally unable to see it.

## 1. The leak

`src/cli/nodes-cli/register.status.ts` rendered `openclaw nodes approve <requestId>` for an
operator with a node pending approval. `package.json` declares `bin: {"remoteclaw": …}` only, so
following that instruction fails with *command not found*.

The binary now comes from `resolveCliName()` — the helper `src/cli/command-format.ts` already
imports — rather than any hardcoded literal, so the rendered command tracks the actual invocation.

**The same line was wrong a second way**, which the issue does not mention. `formatCliCommand`
injects the active `--container` / `--profile` only when the command matches `^remoteclaw\b`; the
`openclaw` prefix never matched, so it returned early and dropped those flags. Verified against
the real modules:

```
[container+profile] OLD("openclaw")     = "openclaw nodes approve req-123"
[container+profile] NEW(resolveCliName) = "remoteclaw --container prod nodes approve req-123"
```

An operator who mentally corrected the binary name would still have approved against the wrong
container.

## 2. The gate hole that hid it

`scan()` greps case-insensitively for `openclaw` and then drops any hit **whose line contains an
allowlist pattern**. The blanket `"openclaw"` / `'openclaw'` entries therefore exempted every line
holding a quoted bare token — precisely the shape of a genuine brand leak in TypeScript. Both are
removed; legitimate sites are re-exempted per path, never by pattern.

**The gate now fails its own corpse** (AC2, both runs on the final tree):

```
$ # defect reintroduced
$ bash scripts/ci/check-rebrand-leakage.sh --all
Rebrand leakage detected (1 violation(s)):
  src/cli/nodes-cli/register.status.ts:142:  const args = ["openclaw", "nodes", "approve", requestId];
exit=1

$ # reverted
$ bash scripts/ci/check-rebrand-leakage.sh --all
No rebrand leakage detected.
exit=0
```

Validation independently reproduced the premise by running the *pre-fix* allowlist against the same
corpse: `EXIT=0`. The old gate passed the defect it exists to catch.

## 3. Triage of what removal surfaced — 27 lines

Re-measured on this branch's base (`b7a6560c8b2`); the issue's "42" is a raw `git grep`, most of
which other `FILE:` rows already covered. **27** is what the gate actually surfaces.

| Disposition | Lines | Detail |
|---|---:|---|
| **Fixed** | 1 | `src/cli/nodes-cli/register.status.ts:141` — the defect above |
| **Kept, re-exempted per path** | 1 | `src/agents/auth-profiles/legacy-oauth-sidecar.ts:200` — reads the LEGACY `$XDG_CONFIG_HOME/openclaw/` dir beside the current `.remoteclaw-auth-profile-secrets` path. Rebranding breaks the read it exists to perform. |
| **Kept, re-exempted per path** | 1 | `src/middleware/system-prompt.test.ts:115` — `expect(result).not.toContain("openclaw")`. The token is the assertion *subject*; rebranding inverts what the test proves. |
| **Deferred → #3151** | 24 | 12 × `extensions/*/npm-shrinkwrap.json`, stale upstream peer-dep block |

No blanket pattern was re-added. 14 per-path `FILE:` rows replace the two removed patterns; each is
load-bearing (every row exempts ≥1 surfaced line).

### Why the shrinkwraps are deferred rather than fixed

Not size — correctness. **No `extensions/*/package.json` declares `peerDependencies` at all**
(0 of 29), so the correctly regenerated artifact has *no* peer-dep block. Rewriting the token to
`"remoteclaw"` would fabricate a dependency the manifest never declared — wrong in the more
damaging direction. Regenerating lockfiles is a dependency-surface change needing explicit approval
per `CLAUDE.md` § Security. Tracked in **#3151** with the closing condition.

They are listed per file rather than as a `FILE:extensions/` prefix: that directory holds 1,836
tracked files and already needs three of its own per-file exemptions, which a prefix would have
swallowed. Per-file also fails loud — planting the block into a 13th extension exits 1.

## 4. Scope bound — the class is not fully closed

This PR closes the **quoted bare token** shape. Four sibling shapes still pass green via other
pre-existing blanket patterns, including a *user-facing error message* (`"Run openclaw. Then
retry."`, exempted by `openclaw.` — a pattern meant for dot-separated identifiers). Those four
patterns exempt **1,289 lines** between them versus the 52 removed here, so triaging them in this
PR would have buried the one-line fix. Enumerated with probes in **#3152**.

Stating this explicitly so the narrow claim is not mistaken for the whole class being closed.

## Tests

New `scan 1 (quoted bare openclaw token)` block in `test/scripts/check-rebrand-leakage.test.ts`,
running against the **real** allowlist via the existing fixture harness. Mutation-tested — each
blanket entry reddens exactly the case that quotes it the same way, and removing a `FILE:` row
reddens the exemption test:

```
append blanket "openclaw"       → × "fails on the exact defect #3148 fixed"   (1 failed | 10 passed)
append blanket 'openclaw'       → × "fails on the single-quoted form too"     (1 failed | 10 passed)
drop legacy-sidecar FILE: row   → × "still honors per-path exemptions"        (1 failed | 10 passed)
```

`formatPendingApprovalCommand` is module-private and has no unit test; the file has no test at all.
Exporting a private helper to assert a one-token substitution was judged not worth it — the
gate-level test covers the actual regression class.

## Verification

```
$ grep -n '"openclaw"' src/cli/nodes-cli/register.status.ts   # exit=1, no match
$ bash scripts/ci/check-rebrand-leakage.sh --all              # exit=0
$ bash scripts/ci/check-rebrand-leakage.sh                    # exit=0 (CI diff-scoped mode)
$ pnpm check                                                  # exit=0
$ node …/vitest.mjs run --config vitest.unit.config.ts src/cli test/scripts
  Test Files  135 passed (135)
       Tests  1188 passed | 3 skipped (1191)
```

Fork-integrity gates (standalone, not in `pnpm check`) all exit 0: rebrand-leakage, zombie-imports,
stub-debt, obsolescence-audit, throwing-stub-callers.

Reviewed in fresh context by an adversarial validation pass (8 claims, all CONFIRMED, verdict
CLEAN) and a separate polish pass; three advisories from validation are addressed here — the scope
bound above, the shrinkwrap rationale, and #3152.
