### PR TITLE
fix(sessions): fail closed on the ambiguous delivery-route grammar collision (#3139)

### DIFF
--- a/src/sessions/session-key-utils.delivery-route.test.ts
+++ b/src/sessions/session-key-utils.delivery-route.test.ts
@@ -1,0 +1,140 @@
+// Delivery-route parsing pins BOTH session-key grammars and the collision
+// between them (remoteclaw/remoteclaw#3139): `parts[2]` is the DM marker in the
+// 4-segment account-scoped grammar but the first peer-id segment in the
+// 3-segment one, so a channel-kind peer whose id starts with `direct:`/`dm:`
+// used to be re-parsed as a DM with the peer-kind token lifted into accountId.
+import { describe, expect, it } from "vitest";
+import { buildAgentPeerSessionKey } from "../routing/session-key.js";
+import { parseSessionDeliveryRoute } from "./session-key-utils.js";
+
+describe("parseSessionDeliveryRoute — 3-segment grammar {channel}:{peerKind}:{peerId}", () => {
+  it("parses every peer kind", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:channel:c123")).toEqual({
+      channel: "slack",
+      peerId: "c123",
+      peerKind: "channel",
+    });
+    expect(parseSessionDeliveryRoute("agent:main:slack:group:g123")).toEqual({
+      channel: "slack",
+      peerId: "g123",
+      peerKind: "group",
+    });
+    expect(parseSessionDeliveryRoute("agent:main:slack:direct:u123")).toEqual({
+      channel: "slack",
+      peerId: "u123",
+      peerKind: "direct",
+    });
+    expect(parseSessionDeliveryRoute("agent:main:slack:dm:u123")).toEqual({
+      channel: "slack",
+      peerId: "u123",
+      peerKind: "dm",
+    });
+  });
+
+  it("keeps colons inside an opaque peer id (Matrix room)", () => {
+    expect(
+      parseSessionDeliveryRoute("agent:main:matrix:channel:!MixedRoomAbCdEf:example.org"),
+    ).toEqual({
+      channel: "matrix",
+      peerId: "!MixedRoomAbCdEf:example.org",
+      peerKind: "channel",
+    });
+  });
+
+  it("splits off a thread suffix", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:channel:c123:thread:t9")).toEqual({
+      channel: "slack",
+      peerId: "c123",
+      peerKind: "channel",
+      threadId: "t9",
+    });
+  });
+
+  it("rejects an unknown peer kind", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:bogus:c123")).toBeNull();
+  });
+});
+
+describe("parseSessionDeliveryRoute — 4-segment grammar {channel}:{accountId}:{direct|dm}:{peerId}", () => {
+  it("parses an account-scoped DM for both markers", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:acct-1:direct:u123")).toEqual({
+      accountId: "acct-1",
+      channel: "slack",
+      peerId: "u123",
+      peerKind: "direct",
+    });
+    expect(parseSessionDeliveryRoute("agent:main:slack:acct-1:dm:u123")).toEqual({
+      accountId: "acct-1",
+      channel: "slack",
+      peerId: "u123",
+      peerKind: "dm",
+    });
+  });
+
+  // The grammar has a real producer, so the branch cannot simply be deleted:
+  // buildAgentPeerSessionKey emits exactly this shape under
+  // `session.dmScope: "per-account-channel-peer"` (src/routing/session-key.ts).
+  it("round-trips the per-account-channel-peer builder output", () => {
+    const sessionKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "slack",
+      accountId: "acct-1",
+      peerKind: "direct",
+      peerId: "U123",
+      dmScope: "per-account-channel-peer",
+    });
+    expect(sessionKey).toBe("agent:main:slack:acct-1:direct:u123");
+    expect(parseSessionDeliveryRoute(sessionKey)).toEqual({
+      accountId: "acct-1",
+      channel: "slack",
+      peerId: "u123",
+      peerKind: "direct",
+    });
+  });
+
+  it("carries a thread suffix on the account-scoped form", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:acct-1:direct:u123:thread:t9")).toEqual({
+      accountId: "acct-1",
+      channel: "slack",
+      peerId: "u123",
+      peerKind: "direct",
+      threadId: "t9",
+    });
+  });
+});
+
+describe("parseSessionDeliveryRoute — grammar collision (#3139)", () => {
+  // Both readings are structurally valid and nothing in the key distinguishes
+  // them, so the parser fails closed instead of guessing. Account ids are
+  // free-form (`/^[a-z0-9][a-z0-9_-]{0,63}$/i`), so an account literally named
+  // `channel`/`group`/`direct`/`dm` is representable — the ambiguity is real in
+  // both directions, not merely hypothetical.
+  it("does not lift the peer-kind token into accountId for a `direct:`-prefixed peer id", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:channel:direct:C123")).toBeNull();
+  });
+
+  it("does the same for a `dm:`-prefixed peer id", () => {
+    expect(parseSessionDeliveryRoute("agent:main:slack:channel:dm:C123")).toBeNull();
+  });
+
+  it("covers every peer-kind token in the accountId position", () => {
+    for (const ambiguous of [
+      "agent:main:slack:group:direct:g1",
+      "agent:main:slack:direct:direct:u1",
+      "agent:main:slack:dm:dm:u1",
+      "agent:main:slack:channel:direct:c1:thread:t9",
+    ]) {
+      expect(parseSessionDeliveryRoute(ambiguous)).toBeNull();
+    }
+  });
+
+  it("still parses an account-scoped DM whose accountId is not a peer kind", () => {
+    // The guard is scoped to the genuinely ambiguous case only.
+    expect(parseSessionDeliveryRoute("agent:main:slack:channels:direct:u1")).toEqual({
+      accountId: "channels",
+      channel: "slack",
+      peerId: "u1",
+      peerKind: "direct",
+    });
+  });
+});

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -411,6 +411,15 @@ export function parseSessionDeliveryRoute(
   }
 
   if (parts.length >= 4 && (parts[2] === "direct" || parts[2] === "dm")) {
+    // `parts[1]` is the accountId in the 4-segment account-scoped DM grammar but
+    // the peerKind in the 3-segment one, so when it is itself a valid peer kind
+    // both readings are structurally valid and nothing in the key tells them
+    // apart. Fail closed rather than guess: picking the DM branch would deliver
+    // to a channel peer as if it were a DM, with the peer-kind token silently
+    // lifted into accountId (remoteclaw/remoteclaw#3139).
+    if (SESSION_DELIVERY_PEER_KINDS.has(parts[1] as ParsedSessionDeliveryRoute["peerKind"])) {
+      return null;
+    }
     const accountId = normalizeOptionalString(parts[1]);
     const firstPeerIdSegment = normalizeOptionalString(parts[3]);
     const peerId = normalizeOptionalString(parts.slice(3).join(":"));


### PR DESCRIPTION
Fixes #3139.

## Which option, and the evidence that decided it

**Option 2 — reject the ambiguous input and fail closed.** The issue left this open pending
a check for a real producer of the 4-segment account-scoped DM form. There is one, so
option 3 (delete the branch) is ruled out positively — not as a fallback.

The issue established there are no *consumers* (definition + one re-export, still true at
`4055ed09061`). It did not establish whether there is a *producer*. There is:

| # | Evidence | Where |
|---|---|---|
| 1 | `buildAgentPeerSessionKey` emits `agent:{agentId}:{channel}:{accountId}:direct:{peerId}` when `dmScope === "per-account-channel-peer"` | `src/routing/session-key.ts:220-224` |
| 2 | `DmScope` is a public, user-settable config union including `"per-account-channel-peer"` | `src/config/types.base.ts:6` |
| 3 | That exact key shape is documented | `docs/concepts/session.md:196` |
| 4 | A **live consumer** reads the 4-segment shape back off persisted keys (`hasAccountScopedPeerShape`) | `src/sessions/send-policy.ts:47-54` |

```ts
// src/routing/session-key.ts:220
if (dmScope === "per-account-channel-peer" && peerId) {
  const channel = normalizeLowercaseStringOrEmpty(params.channel) || "unknown";
  const accountId = normalizeAccountId(params.accountId);
  return `agent:${normalizeAgentId(params.agentId)}:${channel}:${accountId}:direct:${peerId}`;
}
```

So the grammar is live and persisted. Option 1 (escaping) was rejected because it changes
the persisted session-key format — the builder emits unescaped ids on both branches, so
every key already on disk would desync. Disproportionate for a parser with no consumers.

That leaves option 2.

## The fix

`parts[1]` is the accountId in the 4-segment grammar but the peerKind in the 3-segment one.
When it is *itself* a valid peer kind, both readings are structurally valid and nothing in
the key tells them apart — so return `null` instead of guessing.

Worth noting the ambiguity is real in **both** directions, not just hypothetically: account
ids are free-form (`normalizeAccountId`, `/^[a-z0-9][a-z0-9_-]{0,63}$/i`), so an account
literally named `channel` / `group` / `direct` / `dm` is representable. Neither reading
dominates, which is exactly when failing closed is right.

The guard is scoped to the genuinely ambiguous case only — `slack:acct-1:direct:u1` still
parses as an account-scoped DM.

## Test — it fails the corpse

`src/sessions/session-key-utils.delivery-route.test.ts` is the first coverage this parser
has had. Against the **unfixed** parser it reproduces the issue's reported output verbatim:

```
FAIL … does not lift the peer-kind token into accountId for a `direct:`-prefixed peer id
AssertionError: expected { accountId: 'channel', …(4) } to be null
+ Received: { "accountId": "channel", "channel": "slack", "peerId": "c123",
              "peerKind": "direct", "threadId": undefined }

 Test Files  1 failed (1)
      Tests  3 failed | 8 passed (11)
```

After the fix: `Tests 11 passed (11)`.

Both grammars stay pinned, not just the collision: every peer kind on the 3-segment form,
colons inside an opaque Matrix peer id, thread suffixes on both forms, an unknown peer kind,
and a **round-trip against the `per-account-channel-peer` builder** — so the branch this
change preserves is exercised by the producer that justifies keeping it.

## Verification

- Session-key scopes named in the issue (`src/sessions/`, `src/config/sessions/`,
  `src/routing/session-key.test.ts`): **25 files / 284 tests, 0 failures** — of which 24
  files / 273 tests pre-date this PR. The issue cited 286 across 22 files; `main` has moved
  since it was filed, so these are re-measured numbers, not that figure.
- `pnpm check` → exit `0` (also re-run green by the pre-commit hook).
- Full unit lane: `1143 passed | 1 failed`. The single failure is
  `src/plugins/npm-install-security-scan.release.test.ts`, which is **pre-existing and
  environmental**: it asserts `npm pack --dry-run --json` returns a one-element array, but
  local npm 12.0.2 returns an object keyed by package name (verified by running the command
  directly). It imports only `security/skill-scanner` and node builtins — no causal path to
  this change. CI's npm is the authority here.
- Adjacent-instance sweep: `parseDirectAgentSessionTarget`
  (`src/infra/event-session-routing.ts:69`) uses the same `direct`/`dm` token scan but is
  not affected — `deriveSessionChatTypeFromScopedKey` tests `channel` before `direct`
  (`src/sessions/session-chat-type-shared.ts:33`), so the collision key classifies as
  `channel` and it returns `null` early.

## Acceptance criteria

- [x] `agent:main:slack:channel:direct:C123` no longer parses to `accountId: "channel"` — returns `null`
- [x] Same for the `dm:` prefix
- [x] A test pins both grammars, including the collision case
- [x] Existing session-key tests still pass
