### PR TITLE
fix(scripts): make the stub gate's empty scan distinguishable from a broken one (#3138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,12 @@ against regressions specific to the fork-sync lifecycle:
   mocks.
 - **throwing-stub-callers-gate** (`.throwing-stub-callers-allowlist`):
   detects throwing stubs with live non-test callers — see § Fork Stub
-  Conventions.
+  Conventions. The stub population is legitimately empty today, so the gate's
+  healthy output is `0 stubs scanned` — which is also what a broken file walk
+  would print. Every run therefore reports how many production files it walked
+  and fails when that is zero, in every mode (#3138). Verified: with the walk
+  deliberately broken, the pre-canary script printed output byte-identical to a
+  healthy run and exited 0.
 - **obsolescence-audit-gate**: retrospective audit sentinels for gut waves.
 - **raw-channel-fetch-gate** (`pnpm lint:no-raw-channel-fetch`): channel and
   plugin runtime code under `src/channels`, `src/routing`, `src/line`, and
@@ -367,8 +372,17 @@ node scripts/check-throwing-stub-callers.mjs
 # remediation issue, to prove the allowlist line can be removed):
 node scripts/check-throwing-stub-callers.mjs --strict
 
-# Inventory only — never fails, lists every detected stub:
+# Inventory only — lists every detected stub and never fails on a violation.
+# It DOES still fail if the scan walked zero production files: an inventory
+# compiled by an instrument that read nothing is not a shorter inventory, it is
+# a false one.
 node scripts/check-throwing-stub-callers.mjs --inventory
+
+# Exercise the discovery canary by hand — point the walk at a root holding no
+# production TypeScript (here, a missing one, which is what a renamed or removed
+# source root looks like) and confirm the gate fails instead of printing
+# `passed`. `--roots` exists for exactly this; CI runs the gate unflagged.
+node scripts/check-throwing-stub-callers.mjs --roots=src/renamed-away
 ```
 
 ## Fork Context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,10 +372,11 @@ node scripts/check-throwing-stub-callers.mjs
 # remediation issue, to prove the allowlist line can be removed):
 node scripts/check-throwing-stub-callers.mjs --strict
 
-# Inventory only — lists every detected stub and never fails on a violation.
-# It DOES still fail if the scan walked zero production files: an inventory
-# compiled by an instrument that read nothing is not a shorter inventory, it is
-# a false one.
+# Inventory only — lists every stub that has live callers (a caller-less stub is
+# detected and counted, but is not a violation, so it is not listed) and never
+# fails on one. It DOES still fail if the scan walked zero production files: an
+# inventory compiled by an instrument that read nothing is not a shorter
+# inventory, it is a false one.
 node scripts/check-throwing-stub-callers.mjs --inventory
 
 # Exercise the discovery canary by hand — point the walk at a root holding no

--- a/scripts/check-throwing-stub-callers.mjs
+++ b/scripts/check-throwing-stub-callers.mjs
@@ -381,10 +381,18 @@ function summarizeDiscovery(sourceFileIndex, sourceRoots) {
     if (production) {
       productionFiles += 1;
     }
-    // First match wins, so nested roots ("src", "src/plugin-sdk") never double-count.
-    const owner = roots.find(
-      (entry) => normalized === entry.root || normalized.startsWith(`${entry.root}/`),
-    );
+    // Attribute to the MOST SPECIFIC matching root, so overlapping roots
+    // ("src" plus "src/agents") split their files instead of the first-listed one
+    // swallowing all of them — per-root counts then read the same whatever order
+    // the roots were given in. Each file lands in exactly one bucket either way,
+    // so the per-root numbers always sum to the totals below.
+    let owner = null;
+    for (const entry of roots) {
+      const matches = normalized === entry.root || normalized.startsWith(`${entry.root}/`);
+      if (matches && (owner === null || entry.root.length > owner.root.length)) {
+        owner = entry;
+      }
+    }
     if (owner) {
       owner.filesRead += 1;
       if (production) {
@@ -483,15 +491,25 @@ function parseRootsFlag(argv) {
   if (argv.includes("--roots")) {
     return { error: "`--roots` needs a value: --roots=<comma-separated repo-relative paths>" };
   }
-  const flag = argv.find((arg) => arg.startsWith("--roots="));
-  if (!flag) {
+  const flags = argv.filter((arg) => arg.startsWith("--roots="));
+  if (flags.length > 1) {
+    // Taking the first and dropping the rest would silently scan a different
+    // population than the caller asked for — the same class of quiet wrongness
+    // this canary exists to end.
+    return { error: "`--roots=` was given more than once; pass one comma-separated list." };
+  }
+  if (flags.length === 0) {
     return { roots: null };
   }
-  const roots = flag
-    .slice("--roots=".length)
-    .split(",")
-    .map((root) => root.trim())
-    .filter((root) => root.length > 0);
+  const roots = [
+    ...new Set(
+      flags[0]
+        .slice("--roots=".length)
+        .split(",")
+        .map((root) => canonicalizeRoot(root.trim()))
+        .filter((root) => root.length > 0),
+    ),
+  ];
   if (roots.length === 0) {
     return { error: "`--roots=` was given no paths." };
   }
@@ -582,6 +600,17 @@ export async function main(argv = process.argv.slice(2), io) {
     `\nDiscovery: walked ${pluralFiles(result.discovery.productionFiles)} (${formatDiscoveryRoots(result.discovery)}); ${result.discovery.filesRead} read including tests.`,
   );
 
+  // Ahead of BOTH the allowlist sections and the `--inventory` early return, on
+  // purpose. An inventory compiled by an instrument that read nothing is not a
+  // shorter inventory, it is a false one — and "stale" below is derived from the
+  // same empty population the canary is about to declare non-evidence, so
+  // printing it would tell the reader to delete tracked debt-ledger entries on
+  // the strength of a scan that never ran.
+  if (discoveryBroken) {
+    reportBrokenDiscovery(streams, result.discovery);
+    return 1;
+  }
+
   if (result.matched.length > 0) {
     writeLine(streams.stdout, `\nAllowlisted (tracked for remediation): ${result.matched.length}`);
     for (const v of result.matched) {
@@ -599,13 +628,6 @@ export async function main(argv = process.argv.slice(2), io) {
       writeLine(streams.stdout, `  ${key}`);
     }
     writeLine(streams.stdout, "  → remove these lines from .throwing-stub-callers-allowlist");
-  }
-
-  // Ahead of the `--inventory` early return on purpose: an inventory compiled by
-  // an instrument that read nothing is not a shorter inventory, it is a false one.
-  if (discoveryBroken) {
-    reportBrokenDiscovery(streams, result.discovery);
-    return 1;
   }
 
   if (inventoryOnly) {
@@ -767,6 +789,14 @@ const DISCOVERY_SELF_TESTS = [
     expectedStderrIncludes: "the walk reached 0 production files",
   },
   {
+    // `--json` returns before the text path, so it needs its own canary branch and
+    // its own guard: without this case the JSON branch could be deleted in silence.
+    name: "canary FAILS in --json mode too (a machine consumer must not read a broken scan as empty)",
+    argv: [`--roots=${CANARY_MISSING_ROOT}`, "--json"],
+    expectedExitCode: 1,
+    expectedStderrIncludes: "the walk reached 0 production files",
+  },
+  {
     name: "canary stays quiet on a non-empty walk, and the file count is reported",
     argv: [`--roots=${CANARY_POPULATED_ROOT}`],
     expectedExitCode: 0,
@@ -777,6 +807,12 @@ const DISCOVERY_SELF_TESTS = [
     argv: ["--roots"],
     expectedExitCode: 1,
     expectedStderrIncludes: "`--roots` needs a value",
+  },
+  {
+    name: "a repeated --roots= is rejected rather than silently scanning only the first",
+    argv: [`--roots=${CANARY_POPULATED_ROOT}`, "--roots=src"],
+    expectedExitCode: 1,
+    expectedStderrIncludes: "given more than once",
   },
 ];
 

--- a/scripts/check-throwing-stub-callers.mjs
+++ b/scripts/check-throwing-stub-callers.mjs
@@ -26,7 +26,23 @@
  * remediation-issue reference. The check FAILS when a stub+live-caller pair
  * is detected that is not on the allowlist.
  *
- * Reference: issues #2408 (evidence), #2409 (audit), #2410 (this gate).
+ * DISCOVERY CANARY (#3138). The stub population is legitimately empty today, so
+ * the gate's healthy output is `0 stubs scanned`. That is exactly what a gate
+ * whose file walk had broken would print too, and a check whose healthy state
+ * and whose broken state render identically cannot tell you which one you are
+ * in. So every run reports how many production files the walk actually reached
+ * and FAILS when that count is zero — in every mode, `--inventory` included: an
+ * inventory produced by an instrument that read nothing is not a shorter
+ * inventory, it is a false one. `0 files walked` and `0 stubs found in 1200
+ * files` now render differently, and the empty case says why zero is expected.
+ *
+ * `--roots=<comma-separated repo-relative paths>` overrides the walk's roots.
+ * It exists so the canary is demonstrable by hand — point it at a directory
+ * with no production TypeScript and watch the gate fail. CI pins the unflagged
+ * invocation (`.github/workflows/ci.yml`, `throwing-stub-callers-gate`).
+ *
+ * Reference: issues #2408 (evidence), #2409 (audit), #2410 (this gate),
+ * #3138 (this canary).
  */
 
 import { promises as fs } from "node:fs";
@@ -43,7 +59,7 @@ import {
 } from "./lib/ts-guard-utils.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const sourceRoots = ["src", "extensions", "ui"];
+const DEFAULT_SOURCE_ROOTS = ["src", "extensions", "ui"];
 
 // Test-file suffixes beyond the base set in ts-guard-utils. Files matching
 // these are excluded from both stub-detection and caller-detection: mock
@@ -58,11 +74,19 @@ function isProductionFile(filePath) {
   return !isTestLikeTypeScriptFile(filePath, { extraTestSuffixes });
 }
 
+/** Collapse a repo-relative root spec to the canonical form `normalizePath` emits. */
+function canonicalizeRoot(root) {
+  return root
+    .split(/[/\\]/)
+    .filter((segment) => segment.length > 0 && segment !== ".")
+    .join("/");
+}
+
 /**
  * Read source files from all roots once; return a map keyed by canonical
  * normalized path. Avoids re-reading during caller resolution.
  */
-async function loadSourceFiles({ includeTests }) {
+async function loadSourceFiles({ includeTests, sourceRoots }) {
   const roots = resolveSourceRoots(repoRoot, sourceRoots);
   const files = await collectTypeScriptFilesFromRoots(roots, {
     includeTests,
@@ -336,8 +360,45 @@ function formatInventory(violations) {
   return lines.join("\n");
 }
 
-export async function runCheck({ strict = false } = {}) {
-  const sourceFileIndex = await loadSourceFiles({ includeTests: true });
+/**
+ * Account for what the walk actually reached, per root and in total (#3138).
+ * `productionFiles` is the denominator that matters: stub detection and caller
+ * detection both scan production files only, so a run that reached zero of them
+ * has evaluated nothing, whatever its violation count says.
+ */
+function summarizeDiscovery(sourceFileIndex, sourceRoots) {
+  const roots = sourceRoots.map((root) => ({
+    root: canonicalizeRoot(root),
+    filesRead: 0,
+    productionFiles: 0,
+  }));
+  let filesRead = 0;
+  let productionFiles = 0;
+
+  for (const [normalized, record] of sourceFileIndex) {
+    const production = isProductionFile(record.filePath);
+    filesRead += 1;
+    if (production) {
+      productionFiles += 1;
+    }
+    // First match wins, so nested roots ("src", "src/plugin-sdk") never double-count.
+    const owner = roots.find(
+      (entry) => normalized === entry.root || normalized.startsWith(`${entry.root}/`),
+    );
+    if (owner) {
+      owner.filesRead += 1;
+      if (production) {
+        owner.productionFiles += 1;
+      }
+    }
+  }
+
+  return { roots, filesRead, productionFiles };
+}
+
+export async function runCheck({ strict = false, sourceRoots = DEFAULT_SOURCE_ROOTS } = {}) {
+  const sourceFileIndex = await loadSourceFiles({ includeTests: true, sourceRoots });
+  const discovery = summarizeDiscovery(sourceFileIndex, sourceRoots);
 
   // Stub detection scans production files only. A stub declared in a test file is not a concern.
   const stubIndex = new Map(); // canonical file path -> stubs[]
@@ -401,11 +462,80 @@ export async function runCheck({ strict = false } = {}) {
     }
   }
 
-  return { stubs: allStubs, violations, unexpected, stale, matched, allowlist };
+  return { stubs: allStubs, violations, unexpected, stale, matched, allowlist, discovery };
 }
 
 function writeLine(stream, text) {
   stream.write(`${text}\n`);
+}
+
+function pluralFiles(count) {
+  return `${count} production TypeScript file${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Parse `--roots=a,b`. Returns null for "not supplied". A bare `--roots` is an
+ * error rather than a silent fallback to the defaults: silently scanning the
+ * whole repo when the caller asked for a narrower walk is the same
+ * indistinguishable-states failure this canary exists to end.
+ */
+function parseRootsFlag(argv) {
+  if (argv.includes("--roots")) {
+    return { error: "`--roots` needs a value: --roots=<comma-separated repo-relative paths>" };
+  }
+  const flag = argv.find((arg) => arg.startsWith("--roots="));
+  if (!flag) {
+    return { roots: null };
+  }
+  const roots = flag
+    .slice("--roots=".length)
+    .split(",")
+    .map((root) => root.trim())
+    .filter((root) => root.length > 0);
+  if (roots.length === 0) {
+    return { error: "`--roots=` was given no paths." };
+  }
+  return { roots };
+}
+
+/** Render the per-root walk accounting — a root that went to 0 is legible here. */
+function formatDiscoveryRoots(discovery) {
+  return discovery.roots.map((entry) => `${entry.root}=${entry.productionFiles}`).join(", ");
+}
+
+/**
+ * The canary (#3138). Reached-nothing is reported as an instrument failure, not
+ * as an empty result, because the two are not the same claim.
+ */
+function reportBrokenDiscovery(streams, discovery) {
+  writeLine(streams.stderr, "");
+  writeLine(
+    streams.stderr,
+    "FAIL: discovery canary tripped — the walk reached 0 production files.",
+  );
+  writeLine(streams.stderr, "");
+  writeLine(
+    streams.stderr,
+    [
+      "A `0 stubs scanned` result from this run is NOT evidence that the #2408",
+      "regression class is absent — it is evidence that this gate did not run. The",
+      "scan read no production TypeScript, so it evaluated no candidates at all.",
+      "",
+      `Roots searched (${discovery.filesRead} file${discovery.filesRead === 1 ? "" : "s"} read including tests):`,
+      ...discovery.roots.map(
+        (entry) => `  ${entry.root} — ${entry.productionFiles} production, ${entry.filesRead} read`,
+      ),
+      "",
+      "Likely causes:",
+      "  1. A source root was renamed, moved or removed — update DEFAULT_SOURCE_ROOTS",
+      "     in this script to match the tree.",
+      "  2. The walk stopped matching `.ts` files, or every match was classified",
+      "     test-like (see `extraTestSuffixes`).",
+      "  3. `--roots=` pointed the scan at a path holding no production TypeScript.",
+      "     That is the flag's intended use for exercising this canary by hand; CI",
+      "     runs the gate unflagged.",
+    ].join("\n"),
+  );
 }
 
 export async function main(argv = process.argv.slice(2), io) {
@@ -416,13 +546,24 @@ export async function main(argv = process.argv.slice(2), io) {
   const selfTest = argv.includes("--self-test");
 
   if (selfTest) {
-    return runSelfTests(streams);
+    return await runSelfTests(streams);
   }
 
-  const result = await runCheck({ strict });
+  const rootsFlag = parseRootsFlag(argv);
+  if (rootsFlag.error) {
+    writeLine(streams.stderr, `FAIL: ${rootsFlag.error}`);
+    return 1;
+  }
+
+  const result = await runCheck({ strict, sourceRoots: rootsFlag.roots ?? DEFAULT_SOURCE_ROOTS });
+  const discoveryBroken = result.discovery.productionFiles === 0;
 
   if (json) {
     writeLine(streams.stdout, JSON.stringify(result, null, 2));
+    if (discoveryBroken) {
+      reportBrokenDiscovery(streams, result.discovery);
+      return 1;
+    }
     return result.unexpected.length > 0 && !inventoryOnly ? 1 : 0;
   }
 
@@ -435,6 +576,11 @@ export async function main(argv = process.argv.slice(2), io) {
   } else {
     writeLine(streams.stdout, "  (none)");
   }
+
+  writeLine(
+    streams.stdout,
+    `\nDiscovery: walked ${pluralFiles(result.discovery.productionFiles)} (${formatDiscoveryRoots(result.discovery)}); ${result.discovery.filesRead} read including tests.`,
+  );
 
   if (result.matched.length > 0) {
     writeLine(streams.stdout, `\nAllowlisted (tracked for remediation): ${result.matched.length}`);
@@ -453,6 +599,13 @@ export async function main(argv = process.argv.slice(2), io) {
       writeLine(streams.stdout, `  ${key}`);
     }
     writeLine(streams.stdout, "  → remove these lines from .throwing-stub-callers-allowlist");
+  }
+
+  // Ahead of the `--inventory` early return on purpose: an inventory compiled by
+  // an instrument that read nothing is not a shorter inventory, it is a false one.
+  if (discoveryBroken) {
+    reportBrokenDiscovery(streams, result.discovery);
+    return 1;
   }
 
   if (inventoryOnly) {
@@ -491,6 +644,19 @@ export async function main(argv = process.argv.slice(2), io) {
     streams.stdout,
     `\nThrowing-stub-callers check passed (${result.stubs.length} stub${result.stubs.length === 1 ? "" : "s"} scanned, ${result.matched.length} allowlisted, ${result.unexpected.length} unexpected).`,
   );
+  if (result.stubs.length === 0) {
+    writeLine(
+      streams.stdout,
+      [
+        `  0 stubs scanned means the population is empty, not undiscovered: the ${result.discovery.productionFiles}-file`,
+        "  walk above reached production code and found no exported single-throw function",
+        "  carrying a calibration signal (variadic-unknown parameters, a fork-attributed throw",
+        "  message, a `// Gutted in RemoteClaw fork` marker, or a bare `: never` return).",
+        "  Expected today — the #2408 regression class is absent from production code, and",
+        "  that file count is what says so rather than a broken scan (remoteclaw#3138).",
+      ].join("\n"),
+    );
+  }
   return 0;
 }
 
@@ -566,9 +732,113 @@ const SELF_TEST_FIXTURES = [
   },
 ];
 
-function runSelfTests(streams) {
+/**
+ * A root that cannot exist, so the walk returns nothing without any fixture on
+ * disk to set up or tear down.
+ */
+const CANARY_MISSING_ROOT = "scripts/__discovery-canary-missing__";
+
+/**
+ * A single real production file, so the positive half of the canary costs one
+ * parse rather than a second full-tree scan. If this path ever moves, the
+ * discovery self-test below goes red — which is the correct outcome: a canary
+ * pinned to a path that no longer exists is the failure mode being guarded.
+ */
+const CANARY_POPULATED_ROOT = "src/index.ts";
+
+/**
+ * Discovery-canary self-tests (#3138). They drive `main` end to end — exit code
+ * AND message — so the canary cannot be quietly removed later without turning
+ * this step red. The classifier fixtures above can never cover this: they
+ * exercise the AST shape check and never touch the file walk, which is exactly
+ * why `0 stubs scanned` could look healthy while discovery was broken.
+ */
+const DISCOVERY_SELF_TESTS = [
+  {
+    name: "canary FAILS the gate when the walk reaches zero production files",
+    argv: [`--roots=${CANARY_MISSING_ROOT}`],
+    expectedExitCode: 1,
+    expectedStderrIncludes: "the walk reached 0 production files",
+  },
+  {
+    name: "canary FAILS in --inventory mode too (a scan that read nothing is not an inventory)",
+    argv: [`--roots=${CANARY_MISSING_ROOT}`, "--inventory"],
+    expectedExitCode: 1,
+    expectedStderrIncludes: "the walk reached 0 production files",
+  },
+  {
+    name: "canary stays quiet on a non-empty walk, and the file count is reported",
+    argv: [`--roots=${CANARY_POPULATED_ROOT}`],
+    expectedExitCode: 0,
+    expectedStdoutIncludes: "Discovery: walked 1 production TypeScript file",
+  },
+  {
+    name: "bare --roots is rejected rather than silently falling back to the full tree",
+    argv: ["--roots"],
+    expectedExitCode: 1,
+    expectedStderrIncludes: "`--roots` needs a value",
+  },
+];
+
+/** Collect `main`'s output instead of writing it, so a self-test can assert on it. */
+function captureStreams() {
+  const stdout = [];
+  const stderr = [];
+  return {
+    io: {
+      stdout: { write: (chunk) => stdout.push(chunk) },
+      stderr: { write: (chunk) => stderr.push(chunk) },
+    },
+    stdout: () => stdout.join(""),
+    stderr: () => stderr.join(""),
+  };
+}
+
+async function runDiscoverySelfTest(testCase) {
+  const capture = captureStreams();
+  let exitCode;
+  try {
+    exitCode = await main(testCase.argv, capture.io);
+  } catch (error) {
+    return {
+      passed: false,
+      detail: ` — threw ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  if (exitCode !== testCase.expectedExitCode) {
+    return {
+      passed: false,
+      detail: ` — expected exit ${testCase.expectedExitCode}, got ${exitCode}`,
+    };
+  }
+  if (
+    testCase.expectedStderrIncludes &&
+    !capture.stderr().includes(testCase.expectedStderrIncludes)
+  ) {
+    return {
+      passed: false,
+      detail: ` — stderr missing ${JSON.stringify(testCase.expectedStderrIncludes)}`,
+    };
+  }
+  if (
+    testCase.expectedStdoutIncludes &&
+    !capture.stdout().includes(testCase.expectedStdoutIncludes)
+  ) {
+    return {
+      passed: false,
+      detail: ` — stdout missing ${JSON.stringify(testCase.expectedStdoutIncludes)}`,
+    };
+  }
+  return { passed: true, detail: "" };
+}
+
+async function runSelfTests(streams) {
   let failures = 0;
-  writeLine(streams.stdout, `Running ${SELF_TEST_FIXTURES.length} classifier self-tests...\n`);
+  const total = SELF_TEST_FIXTURES.length + DISCOVERY_SELF_TESTS.length;
+  writeLine(
+    streams.stdout,
+    `Running ${total} self-tests (${SELF_TEST_FIXTURES.length} classifier, ${DISCOVERY_SELF_TESTS.length} discovery-canary)...\n`,
+  );
 
   for (const fixture of SELF_TEST_FIXTURES) {
     const stubs = classifyFixture(fixture.source);
@@ -603,9 +873,20 @@ function runSelfTests(streams) {
     }
   }
 
+  for (const testCase of DISCOVERY_SELF_TESTS) {
+    const { passed, detail } = await runDiscoverySelfTest(testCase);
+    writeLine(
+      streams.stdout,
+      `  [${passed ? "PASS" : "FAIL"}] ${testCase.name}${passed ? "" : detail}`,
+    );
+    if (!passed) {
+      failures += 1;
+    }
+  }
+
   writeLine(streams.stdout, "");
   if (failures === 0) {
-    writeLine(streams.stdout, `All ${SELF_TEST_FIXTURES.length} self-tests passed.`);
+    writeLine(streams.stdout, `All ${total} self-tests passed.`);
     return 0;
   }
   writeLine(streams.stderr, `${failures} self-test${failures === 1 ? "" : "s"} failed.`);


### PR DESCRIPTION
Closes #3138.

## The problem, stated precisely

`scripts/check-throwing-stub-callers.mjs` printed an unqualified
`passed (0 stubs scanned)`. That green is **truthful** — the #2408 throwing-stub
class is genuinely absent from production code, and the issue verified that
independently before filing. There is no live defect here and the detector is
not at fault.

The concern is evidentiary: a gate whose healthy state and whose broken state
print the same line cannot tell you which one you are in.

## Proven, not asserted

With the file walk deliberately broken (`endsWith(".ts")` → a non-matching
suffix in `scripts/lib/ts-guard-utils.mjs`), the **pre-change** script:

```console
$ node scripts/check-throwing-stub-callers.mjs   # against a walk that reads nothing
Throwing-stub-with-live-callers inventory (0 violations):
  (none)

Throwing-stub-callers check passed (0 stubs scanned, 0 allowlisted, 0 unexpected).
EXIT=0
```

Byte-identical to its healthy output, exit 0. The **post-change** script, same
break, same unflagged command CI runs: **exit 1**.

## What changed

Every run now reports how many production files the walk actually reached, and
fails when that is zero — in every mode, `--inventory` and `--json` included. An
inventory compiled by an instrument that read nothing is not a shorter
inventory, it is a false one. The empty-population case additionally says *why*
zero is expected instead of leaving the reader to infer it.

```console
$ node scripts/check-throwing-stub-callers.mjs ; echo "EXIT=$?"
Throwing-stub-with-live-callers inventory (0 violations):
  (none)

Discovery: walked 4205 production TypeScript files (src=2868, extensions=1107, ui=230); 6561 read including tests.

Throwing-stub-callers check passed (0 stubs scanned, 0 allowlisted, 0 unexpected).
  0 stubs scanned means the population is empty, not undiscovered: the 4205-file
  walk above reached production code and found no exported single-throw function
  carrying a calibration signal (variadic-unknown parameters, a fork-attributed throw
  message, a `// Gutted in RemoteClaw fork` marker, or a bare `: never` return).
  Expected today — the #2408 regression class is absent from production code, and
  that file count is what says so rather than a broken scan (remoteclaw#3138).
EXIT=0
```

```console
$ node scripts/check-throwing-stub-callers.mjs --roots=src/renamed-away ; echo "EXIT=$?"
Discovery: walked 0 production TypeScript files (src/renamed-away=0); 0 read including tests.

FAIL: discovery canary tripped — the walk reached 0 production files.

A `0 stubs scanned` result from this run is NOT evidence that the #2408
regression class is absent — it is evidence that this gate did not run. ...
EXIT=1
```

**The detector is untouched.** Reviewer-verified against a seeded 3-violation
fixture: `--json` output minus the new `discovery` key is deep-equal to
pre-change, and the failure report is byte-identical.

**Self-tests 10 → 16**, six of them driving `main` end to end (exit code *and*
message) so the canary cannot be silently removed later — deleting it turns
`--self-test` red, verified by doing exactly that. `--roots=` exists so the
canary stays demonstrable by hand; CI keeps running the gate unflagged.

## Second commit — findings from fresh-context review

Review returned `PASS_WITH_FINDINGS`; all five are fixed in `ef40e05`, the
first because it was the canary's own principle left half-applied:

- **[MEDIUM]** Under a broken walk the gate still printed *"Stale allowlist
  entries → remove these lines"* before failing — actionable-but-wrong advice to
  delete tracked debt-ledger entries, derived from the same population the next
  line calls non-evidence. The canary now precedes that block, not just the
  `--inventory` return.
- `--json` returns before the text path and had no self-test, so its canary
  branch could have been deleted in silence. Now guarded.
- Per-root attribution took the *first* matching root, so
  `--roots=src,src/agents` reported `src/agents=0` while its 278 files counted
  under `src`, and the split flipped with argument order. Now most-specific
  match; totals were always correct and are unchanged.
- A repeated `--roots=` was silently ignored in favour of the first. Now an
  error, matching the bare-`--roots` strictness beside it.
- `CLAUDE.md` said `--inventory` "lists every detected stub" — it lists stubs
  that have *live callers*.

## Verification

| Check | Result |
|---|---|
| `node scripts/check-throwing-stub-callers.mjs --self-test` | exit 0 — **16/16** (was 10; issue reported 10, confirmed at baseline) |
| `node scripts/check-throwing-stub-callers.mjs` | exit 0, 4205 files walked |
| Canary vs. genuinely broken walk, unflagged | exit **1** (pre-change: exit 0, identical output) |
| Canary deleted → `--self-test` | exit **1** — the guard works |
| `pnpm check` | exit 0 |
| rebrand / stub-debt / zombie-import / attestation / trash-containment / obsolescence / policy-doctor gates | all exit 0 |

Exit codes captured directly (`cmd; echo $?`), never after a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
