### PR TITLE
fix(config): write the un-defaulted persist candidate, not the Zod-parsed one (#3163)

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -132,8 +132,8 @@ export type ConfigWriteOptions = {
    */
   expectedConfigPath?: string;
   /**
-   * Paths that must be explicitly removed from the persisted file payload,
-   * even if schema/default normalization reintroduces them.
+   * Paths to remove from the persisted file payload. Applied before validation, so the
+   * object that gets validated is the object that gets written.
    */
   unsetPaths?: string[][];
 };
@@ -319,6 +319,24 @@ function unsetPathForWrite(
     return { changed: true, next: coerceConfig(result.value) };
   }
   return { changed: false, next: root };
+}
+
+/** Applies every `unsetPaths` entry to `root`, skipping malformed and empty ones. */
+function applyUnsetPathsForWrite(
+  root: RemoteClawConfig,
+  unsetPaths: string[][] | undefined,
+): RemoteClawConfig {
+  let next = root;
+  for (const unsetPath of unsetPaths ?? []) {
+    if (!Array.isArray(unsetPath) || unsetPath.length === 0) {
+      continue;
+    }
+    const result = unsetPathForWrite(next, unsetPath);
+    if (result.changed) {
+      next = result.next;
+    }
+  }
+  return next;
 }
 
 export function resolveConfigSnapshotHash(snapshot: {
@@ -1093,13 +1111,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   async function writeConfigFile(cfg: RemoteClawConfig, options: ConfigWriteOptions = {}) {
     clearConfigCache();
-    let persistCandidate: unknown = cfg;
+    let persistCandidate: RemoteClawConfig = cfg;
     const { snapshot } = await readConfigFileSnapshotInternal();
     let envRefMap: Map<string, string> | null = null;
     let changedPaths: Set<string> | null = null;
     if (snapshot.valid && snapshot.exists) {
       const patch = createMergePatch(snapshot.config, cfg);
-      persistCandidate = applyMergePatch(snapshot.resolved, patch);
+      persistCandidate = applyMergePatch(snapshot.resolved, patch) as RemoteClawConfig;
       try {
         const resolvedIncludes = resolveConfigIncludes(snapshot.parsed, configPath, {
           readFile: (candidate) => deps.fs.readFileSync(candidate, "utf-8"),
@@ -1124,6 +1142,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
     }
 
+    // Unset before validating, not after: this used to run at the very end, so validation
+    // inspected one object while a different one reached disk (issue #3163).
+    persistCandidate = applyUnsetPathsForWrite(persistCandidate, options.unsetPaths);
+
     const validated = validateConfigObjectRawWithPlugins(persistCandidate);
     if (!validated.ok) {
       const issue = validated.issues[0];
@@ -1138,6 +1160,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       deps.logger.warn(`Config warnings:\n${details}`);
     }
 
+    // Write persistCandidate, the object validation just inspected — never validated.config,
+    // whose Zod parse has materialized every schema default (issue #3163; see the contract on
+    // validateConfigObjectRaw in ./validation.ts).
+    let cfgToWrite = persistCandidate;
+
     // Restore ${VAR} env var references that were resolved during config loading.
     // Read the current file (pre-substitution) and restore any references whose
     // resolved values match the incoming config — so we don't overwrite
@@ -1145,9 +1172,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     //
     // We use only the root file's parsed content (no $include resolution) to avoid
     // pulling values from included files into the root config on write-back.
-    // Apply env restoration to validated.config (which has runtime defaults stripped
-    // per issue #6070) rather than the raw caller input.
-    let cfgToWrite = validated.config;
     try {
       if (deps.fs.existsSync(configPath)) {
         const currentRaw = await deps.fs.promises.readFile(configPath, "utf-8");
@@ -1176,24 +1200,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       homedir: deps.homedir,
       fsModule: deps.fs,
     });
-    const outputConfigBase =
+    const outputConfig =
       envRefMap && changedPaths
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as RemoteClawConfig)
         : cfgToWrite;
-    let outputConfig = outputConfigBase;
-    if (options.unsetPaths?.length) {
-      for (const unsetPath of options.unsetPaths) {
-        if (!Array.isArray(unsetPath) || unsetPath.length === 0) {
-          continue;
-        }
-        const unsetResult = unsetPathForWrite(outputConfig, unsetPath);
-        if (unsetResult.changed) {
-          outputConfig = unsetResult.next;
-        }
-      }
-    }
-    // Do NOT apply runtime defaults when writing — user config should only contain
-    // explicitly set values. Runtime defaults are applied when loading (issue #6070).
+    // Defaults are applied on load, never on write (issue #6070) — but that only keeps NEW ones
+    // out of the file. A default already on disk is indistinguishable from an authored value, so
+    // it is carried forward verbatim as user intent (issue #3167 tracks whether to repair those).
     const stampedOutputConfig = stampConfigVersion(outputConfig);
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -156,6 +156,44 @@ describe("config io write", () => {
     });
   });
 
+  // Regression for #3163. The sibling test above passes on a `{ gateway: { port } }` fixture, which
+  // reaches no channel schema at all — so it never sees the defaults that actually get injected:
+  // `mode`, `webhookPath`, `groupPolicy`, `dmPolicy` and `userTokenReadOnly` from schema
+  // `.default()`, plus `streaming` / `nativeStreaming`, which carry no `.default()` and are written
+  // in place by the schema's `superRefine` normalizers.
+  it("does not inject channel or account schema defaults into the written config", async () => {
+    await withSuiteHome(async (home) => {
+      // Minimal AUTHORED config. Every key here is explicitly set, so anything the round-trip
+      // adds beyond the caller's own mutation was injected by the write path.
+      const initialConfig: Record<string, unknown> = {
+        gateway: { port: 18790 },
+        channels: {
+          slack: {
+            botToken: "slack-bot-token-placeholder",
+            accounts: { primary: { botToken: "slack-account-token-placeholder" } },
+          },
+          telegram: {
+            botToken: "telegram-bot-token-placeholder",
+            accounts: { primary: { botToken: "telegram-account-token-placeholder" } },
+          },
+        },
+      };
+      const { configPath, io, snapshot } = await writeConfigAndCreateIo({ home, initialConfig });
+
+      // One unrelated mutation, applied to the runtime config the way real callers do.
+      const persisted = await writeTokenAuthAndReadConfig({ io, snapshot, configPath });
+
+      // Exact match: the write may add the caller's mutation and the version stamp, nothing else.
+      // Every authored key must also survive verbatim, so `channels` is spread in rather than
+      // restated — anything the schema injected there shows up as a diff.
+      expect(persisted).toEqual({
+        ...initialConfig,
+        gateway: { port: 18790, auth: { mode: "token" } },
+        meta: { lastTouchedAt: expect.any(String), lastTouchedVersion: expect.any(String) },
+      });
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "tightens world-writable state dir when writing the default config",
     async () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -236,8 +236,16 @@ function validateGatewayTailscaleAuth(config: RemoteClawConfig): ConfigValidatio
 }
 
 /**
- * Validates config without applying runtime defaults.
- * Use this when you need the raw validated config (e.g., for writing back to file).
+ * Validates config without applying the runtime helper defaults in ./defaults.ts.
+ *
+ * "Raw" stops there. The returned config is still `RemoteClawSchema.safeParse` output, so every
+ * schema-level `.default()` has been materialized and every `superRefine` normalizer (e.g.
+ * `normalizeSlackStreamingConfig`) has written into the parsed object.
+ *
+ * Do NOT persist the returned config to the user's config file: it rewrites their file with
+ * settings they never authored, frozen at whatever the default was that day, so a later change to
+ * a default never reaches them (issue #3163). Validate as a gate and write the pre-validation
+ * object — see `writeConfigFile` in ./io.ts.
  */
 export function validateConfigObjectRaw(
   raw: unknown,
@@ -325,6 +333,7 @@ export function validateConfigObjectWithPlugins(
   return validateConfigObjectWithPluginsBase(raw, { applyDefaults: true, env: params?.env });
 }
 
+/** Plugin-aware {@link validateConfigObjectRaw} — the same "do not persist the result" caveat applies. */
 export function validateConfigObjectRawWithPlugins(
   raw: unknown,
   params?: { env?: NodeJS.ProcessEnv },


### PR DESCRIPTION
Fixes #3163.

## What was wrong

`writeConfigFile` already built a clean persist candidate — merge-patching the caller's delta onto
`snapshot.resolved`, the on-disk source after `$include`/`${ENV}` but before defaults — and then
threw it away:

```ts
const patch = createMergePatch(snapshot.config, cfg);
persistCandidate = applyMergePatch(snapshot.resolved, patch);   // correct
...
const validated = validateConfigObjectRawWithPlugins(persistCandidate);
let cfgToWrite = validated.config;                              // ← Zod-parsed; defaults materialized
```

`validated.config` is `RemoteClawSchema.safeParse` output. Zod materializes every `.default()` on
parse, and the schema's `superRefine` normalizers (`normalizeSlackStreamingConfig` and friends) write
into the parsed object in place — which is why `streaming` / `nativeStreaming` were injected too,
despite carrying no `.default()`. A fix targeting only `.default()` would have missed them.

The byte growth (538 B → 1291 B on one write) is cosmetic. **The harm is that an injected default is
indistinguishable from a deliberate setting and is frozen at whatever the default was on the day of
the write** — so a later change to a default, including a security-relevant one like `groupPolicy`,
never reaches an existing config.

## Why it went unnoticed

Three things had to line up:

1. The helper-family defaults (`applyLoggingDefaults`, `applyMessageDefaults`, …) *do* cancel out of
   the merge patch, so the visible symptom looked absent.
2. `io.write-config.test.ts:142` is named "persists caller changes … without leaking runtime
   defaults" — but its fixture is `{ gateway: { port: 18789 } }`, which reaches **no channel schema
   at all**. `config-cli.test.ts:155` mocks `writeConfigFile` outright, and the injection happens
   inside it. A repo-wide grep found no test asserting a schema default *is* present in a written
   file.
3. `validateConfigObjectRaw`'s own JSDoc said it "validates config without applying runtime defaults"
   and recommended its output "for writing back to file". Both halves are false. The defect was
   following its own API's documentation.

## The change

| | |
|---|---|
| `io.ts` | Write `persistCandidate`; validation demoted to a gate whose parsed output is discarded |
| `io.ts` | `unsetPaths` moved ahead of validation (extracted to `applyUnsetPathsForWrite`) |
| `io.ts` | Two false comments corrected; `ConfigWriteOptions.unsetPaths` doc no longer claims defaults get reintroduced |
| `validation.ts` | The load-bearing JSDoc fix — "Raw" excludes only the `./defaults.ts` helper family, never schema defaults, with an explicit do-not-persist |
| `io.write-config.test.ts` | Regression test: exact round-trip match |

The `unsetPaths` move is not just parity. Before it, validation inspected one object while a
different one reached disk — and the pre-fix ordering could write a config that then **fails to
load** (`valid: false`, confirmed empirically).

## Upstream parity

Upstream writes the clean candidate at **all 16 tagged versions this fork has synced from**
(`v2026.4.24` → `v2026.7.1-2`), with its own rationale comment at L2457-2463. The fork's `io.ts` has
never called `resolvePersistCandidateForWrite` nor assigned `cfgToWrite = persistCandidate` — `git
log -S` is empty across the fork's whole history. **This is fork-sync divergence, not an upstream
defect and not a deliberate fork decision.**

Kept minimal on purpose: the four zero-importer modules (`io.write-prepare.ts`,
`runtime-source-projection.ts`, `io.meta.ts`, `io.owner-display-secret.ts`) are **not** wired here —
the inline merge patch already produces a clean candidate. That is #3166. Upstream's
`validationSourceCandidate` / `resolveRuntimePreflightSourceConfig` pair is also deliberately not
ported: it guards a candidate still holding `$include` directives, a state this fork's
`writeConfigFile` has no branch to reach (verified, not assumed — both paths that could smuggle one
in behave identically before and after this change).

## Verification

Test was written **first and confirmed RED**, then mutation-tested after the fix — reverting only the
`cfgToWrite` line turns it red again, naming every injected key with its value.

| | |
|---|---|
| Unit lane (`src/config/` + `src/cli/`) | 141 files / 1122 tests ✅ |
| Gateway lane | 191 files / 2044 tests ✅ |
| Auto-reply lane | 59 files / 687 tests ✅ |
| `pnpm check` | exit 0 — format, tsgo, typecheck:scripts, oxlint type-aware, 6 fork-integrity gates |

Full unit lane: 1142 passed, 1 pre-existing failure
(`npm-install-security-scan.release.test.ts` — `npm pack --dry-run` env issue, verified identical
with this change stashed). No LIVE smoke run: this touches `src/config/`, not `src/middleware/`.

Blast radius checked beyond the AC — the other `writeConfigFile(validated.config)` callers
(Control-UI `config.patch` at `server-methods/config.ts:509`, the auto-reply command paths) all pass
an already-defaulted config in. They stay clean because they build it via
`applyMergePatch(snapshot.config, …)` → the *same* validator that produced `snapshot.config`, so
identical defaults on both sides of `createMergePatch` cancel and never enter `persistCandidate`.

## Out of scope

- Repairing configs already inflated by shipped builds — this stops new injection but does not
  un-inflate. Once on disk a default is authored state. **#3167**
- Adopting upstream's `io.*` module split. **#3166**
- The write-anomaly detector flags a size *drop* only, so a 2.4× inflation was invisible to the very
  telemetry built to notice suspicious writes. **#3164**
- **#3170** — filed from this PR's adversarial review: `writeConfigFile` silently destroys authored
  `$include` directives. Pre-existing, measured identical before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
