### PR TITLE
fix(test): stop trash.test.ts racing the extension boundary canary (#3143)

### DIFF
--- a/src/infra/trash.test.ts
+++ b/src/infra/trash.test.ts
@@ -4,6 +4,7 @@
 // pinned here because they are separable — the spawn coming back, and the
 // colliding export name coming back so a stray import silently picks it up.
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -12,29 +13,96 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const SCANNED_DIRS = ["src", "extensions"];
 const SKIPPED_DIRS = new Set(["node_modules", "dist", ".git", "coverage"]);
 
-function listSourceFiles(): string[] {
+// `scripts/check-extension-package-tsc-boundary.mjs --mode=canary` writes this
+// exact basename into every extension root and removes it again, concurrently
+// with this lane (#3143). It is never a committed source file — `git ls-files`
+// matches none — so ignoring it hides nothing a twin could be smuggled in.
+// Skipping it by basename ONLY: widening this set would blind the scan.
+const TRANSIENT_BASENAMES = new Set(["__rootdir_boundary_canary__.ts"]);
+
+const SOURCE_FILE_PATTERN = /\.(?:ts|tsx|mts|cts|js|mjs|cjs)$/u;
+
+function isEnoent(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === "ENOENT";
+}
+
+function defaultRoots(): string[] {
+  return SCANNED_DIRS.map((dir) => path.join(repoRoot, dir));
+}
+
+function listSourceFiles(roots: string[] = defaultRoots()): string[] {
   const files: string[] = [];
   const walk = (dir: string) => {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (error) {
+      // Only a directory that vanished after its parent listed it. Anything
+      // else (EACCES, ENOTDIR, ...) is a real fault and must still surface.
+      if (isEnoent(error)) {
+        return;
+      }
+      throw error;
+    }
+    for (const entry of entries) {
       if (entry.isDirectory()) {
         if (!SKIPPED_DIRS.has(entry.name)) {
           walk(path.join(dir, entry.name));
         }
         continue;
       }
-      if (/\.(?:ts|tsx|mts|cts|js|mjs|cjs)$/u.test(entry.name)) {
+      if (TRANSIENT_BASENAMES.has(entry.name)) {
+        continue;
+      }
+      if (SOURCE_FILE_PATTERN.test(entry.name)) {
         files.push(path.join(dir, entry.name));
       }
     }
   };
-  for (const dir of SCANNED_DIRS) {
-    const absolute = path.join(repoRoot, dir);
-    if (fs.existsSync(absolute)) {
-      walk(absolute);
+  for (const root of roots) {
+    if (fs.existsSync(root)) {
+      walk(root);
     }
   }
   return files;
 }
+
+/** Reads `file`, or returns null if it vanished between listing and read.
+ * ENOENT only — every other read fault still throws, so a scan that cannot
+ * actually read the tree fails loudly instead of quietly matching nothing. */
+function readSourceIfPresent(file: string): string | null {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function filesMatching(pattern: RegExp, files: string[]): string[] {
+  return files.filter((file) => {
+    const source = readSourceIfPresent(file);
+    return source !== null && pattern.test(source);
+  });
+}
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "remoteclaw-trash-walk-"));
+}
+
+// Assembled at runtime so THIS file's own source never contains the contiguous
+// declaration the scan searches for. Writing it as a plain literal would make
+// `trash.test.ts` match itself, and the tempting fix — excluding this file from
+// the declaration scan — would carve out exactly the blind spot a twin could
+// hide in. The fixture on disk is byte-identical either way.
+const MOVE_PATH_TO_TRASH_DECLARATION = [
+  "export",
+  "async",
+  "function",
+  "movePathToTrash() {}\n",
+].join(" ");
 
 describe("the PATH-spawning movePathToTrash twin", () => {
   it("no longer exists as a module", () => {
@@ -42,9 +110,10 @@ describe("the PATH-spawning movePathToTrash twin", () => {
   });
 
   it("leaves exactly one declaration of movePathToTrash", () => {
-    const declaring = listSourceFiles()
-      .filter((file) => /export\s+async\s+function\s+movePathToTrash\b/u.test(readSource(file)))
-      .map((file) => path.relative(repoRoot, file));
+    const declaring = filesMatching(
+      /export\s+async\s+function\s+movePathToTrash\b/u,
+      listSourceFiles(),
+    ).map((file) => path.relative(repoRoot, file));
 
     expect(declaring).toEqual(["src/infra/fs-safe-trash.ts"]);
   });
@@ -54,15 +123,69 @@ describe("the PATH-spawning movePathToTrash twin", () => {
     // the bare-name forms that resolve through PATH rather than an absolute path.
     const spawnPattern =
       /(?:runExec|execFile|execFileAsync|spawn|spawnSync|execa)\s*\(\s*(['"`])trash\1|\[\s*(['"`])trash\2\s*,/u;
-    const offenders = listSourceFiles()
-      .filter((file) => !file.endsWith(path.join("infra", "trash.test.ts")))
-      .filter((file) => spawnPattern.test(readSource(file)))
-      .map((file) => path.relative(repoRoot, file));
+    const offenders = filesMatching(
+      spawnPattern,
+      listSourceFiles().filter((file) => !file.endsWith(path.join("infra", "trash.test.ts"))),
+    ).map((file) => path.relative(repoRoot, file));
 
     expect(offenders).toEqual([]);
   });
 });
 
-function readSource(file: string): string {
-  return fs.readFileSync(file, "utf8");
-}
+// The assertion above that matters most — "no caller spawning a trash binary" —
+// expects an EMPTY array, so a scan that silently read nothing would pass it.
+// These pin the scan itself, the same way the discovery canary in
+// `scripts/check-throwing-stub-callers.mjs` pins that gate's file walk (#3138).
+describe("the source scan the twin pins depend on", () => {
+  it("actually reaches both scanned roots", () => {
+    const scanned = listSourceFiles().map((file) => path.relative(repoRoot, file));
+
+    // Content-presence, not a proxy count: a truncated walk satisfies a count.
+    expect(scanned).toContain(path.join("src", "infra", "fs-safe-trash.ts"));
+    expect(scanned.some((file) => file.startsWith(`extensions${path.sep}`))).toBe(true);
+    // Loose floor; the tree holds ~6.2k files, and this fork actively guts code.
+    expect(scanned.length).toBeGreaterThan(1000);
+  });
+
+  it("ignores the extension boundary canary while it is on disk", () => {
+    const dir = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(dir, "real.ts"), "export {};\n", "utf8");
+      fs.writeFileSync(path.join(dir, "__rootdir_boundary_canary__.ts"), "export {};\n", "utf8");
+
+      expect(listSourceFiles([dir]).map((file) => path.basename(file))).toEqual(["real.ts"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips a file that vanishes between listing and read", () => {
+    const dir = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(dir, "kept.ts"), MOVE_PATH_TO_TRASH_DECLARATION, "utf8");
+      fs.writeFileSync(path.join(dir, "vanishing.ts"), MOVE_PATH_TO_TRASH_DECLARATION, "utf8");
+      const listed = listSourceFiles([dir]);
+      expect(listed).toHaveLength(2);
+
+      // Exactly where `cleanupCanaryArtifacts()` lands in CI (#3143).
+      fs.rmSync(path.join(dir, "vanishing.ts"));
+
+      expect(filesMatching(/export\s+async\s+function\s+movePathToTrash\b/u, listed)).toEqual([
+        path.join(dir, "kept.ts"),
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still throws when a read fails for any reason other than ENOENT", () => {
+    const dir = makeTempDir();
+    try {
+      // A directory read as a file yields EISDIR on macOS/Linux — a stand-in for
+      // any non-ENOENT fault. It must NOT be swallowed.
+      expect(() => filesMatching(/anything/u, [dir])).toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/infra/trash.test.ts
+++ b/src/infra/trash.test.ts
@@ -17,10 +17,19 @@ const SKIPPED_DIRS = new Set(["node_modules", "dist", ".git", "coverage"]);
 // exact basename into every extension root and removes it again, concurrently
 // with this lane (#3143). It is never a committed source file — `git ls-files`
 // matches none — so ignoring it hides nothing a twin could be smuggled in.
-// Skipping it by basename ONLY: widening this set would blind the scan.
-const TRANSIENT_BASENAMES = new Set(["__rootdir_boundary_canary__.ts"]);
+const BOUNDARY_CANARY_BASENAME = "__rootdir_boundary_canary__.ts";
 
 const SOURCE_FILE_PATTERN = /\.(?:ts|tsx|mts|cts|js|mjs|cjs)$/u;
+
+/** True only for the transient canary, and only at the path the boundary script
+ * actually writes it to: `extensions/<id>/__rootdir_boundary_canary__.ts`
+ * (`resolveCanaryArtifactPaths`). The location half is load-bearing — skipping
+ * the basename ANYWHERE would let a twin hide at
+ * `src/…/__rootdir_boundary_canary__.ts`, a path nothing creates or cleans up,
+ * which is precisely the blind spot this scan must not have. */
+function isBoundaryCanaryArtifact(dir: string, basename: string): boolean {
+  return basename === BOUNDARY_CANARY_BASENAME && path.basename(path.dirname(dir)) === "extensions";
+}
 
 function isEnoent(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | null)?.code === "ENOENT";
@@ -51,7 +60,7 @@ function listSourceFiles(roots: string[] = defaultRoots()): string[] {
         }
         continue;
       }
-      if (TRANSIENT_BASENAMES.has(entry.name)) {
+      if (isBoundaryCanaryArtifact(dir, entry.name)) {
         continue;
       }
       if (SOURCE_FILE_PATTERN.test(entry.name)) {
@@ -148,14 +157,38 @@ describe("the source scan the twin pins depend on", () => {
   });
 
   it("ignores the extension boundary canary while it is on disk", () => {
-    const dir = makeTempDir();
+    const root = makeTempDir();
     try {
-      fs.writeFileSync(path.join(dir, "real.ts"), "export {};\n", "utf8");
-      fs.writeFileSync(path.join(dir, "__rootdir_boundary_canary__.ts"), "export {};\n", "utf8");
+      // The exact shape the boundary script writes: extensions/<id>/<canary>.
+      const extensionRoot = path.join(root, "extensions", "some-extension");
+      fs.mkdirSync(extensionRoot, { recursive: true });
+      fs.writeFileSync(path.join(extensionRoot, "real.ts"), "export {};\n", "utf8");
+      fs.writeFileSync(path.join(extensionRoot, BOUNDARY_CANARY_BASENAME), "export {};\n", "utf8");
 
-      expect(listSourceFiles([dir]).map((file) => path.basename(file))).toEqual(["real.ts"]);
+      expect(listSourceFiles([root]).map((file) => path.basename(file))).toEqual(["real.ts"]);
     } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still scans that basename outside an extension root", () => {
+    // The skip is scoped to `extensions/<id>/` because that is the only place
+    // the boundary script writes it. A file with the same name anywhere else is
+    // created and cleaned up by nothing, so skipping it by bare basename would
+    // hand a twin a permanent hiding place under `src/`.
+    const root = makeTempDir();
+    try {
+      const nested = path.join(root, "src", "infra");
+      fs.mkdirSync(nested, { recursive: true });
+      const impostor = path.join(nested, BOUNDARY_CANARY_BASENAME);
+      fs.writeFileSync(impostor, MOVE_PATH_TO_TRASH_DECLARATION, "utf8");
+
+      expect(listSourceFiles([root])).toEqual([impostor]);
+      expect(
+        filesMatching(/export\s+async\s+function\s+movePathToTrash\b/u, listSourceFiles([root])),
+      ).toEqual([impostor]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 
@@ -181,9 +214,39 @@ describe("the source scan the twin pins depend on", () => {
   it("still throws when a read fails for any reason other than ENOENT", () => {
     const dir = makeTempDir();
     try {
-      // A directory read as a file yields EISDIR on macOS/Linux — a stand-in for
-      // any non-ENOENT fault. It must NOT be swallowed.
-      expect(() => filesMatching(/anything/u, [dir])).toThrow();
+      // A directory read as a file yields EISDIR — a stand-in for any non-ENOENT
+      // fault. Assert the CODE, not merely that something threw: a bare
+      // `.toThrow()` would also pass on an ENOENT the tolerance failed to catch.
+      let code: string | undefined;
+      try {
+        filesMatching(/anything/u, [dir]);
+      } catch (error) {
+        code = (error as NodeJS.ErrnoException).code;
+      }
+      expect(code).toBeDefined();
+      expect(code).not.toBe("ENOENT");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still throws when the directory walk fails for any reason other than ENOENT", () => {
+    // The read path above has a twin at `readdirSync`; both tolerate ENOENT, so
+    // both need proof they still surface everything else. A plain file used as a
+    // scan root yields ENOTDIR.
+    const dir = makeTempDir();
+    const notADirectory = path.join(dir, "regular-file.ts");
+    try {
+      fs.writeFileSync(notADirectory, "export {};\n", "utf8");
+
+      let code: string | undefined;
+      try {
+        listSourceFiles([notADirectory]);
+      } catch (error) {
+        code = (error as NodeJS.ErrnoException).code;
+      }
+      expect(code).toBeDefined();
+      expect(code).not.toBe("ENOENT");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #3143.

## The race

`src/infra/trash.test.ts` walks `src/` and `extensions/` collecting source files, then reads each
one. `scripts/check-extension-package-tsc-boundary.mjs --mode=canary` — driven by
`test/extension-package-tsc-boundary.test.ts` in the **same** lane — concurrently writes
`__rootdir_boundary_canary__.ts` into every extension root and removes it again. The walk listed a
canary that cleanup deleted before the read:

```
ENOENT: no such file or directory, open '…/extensions/test-utils/__rootdir_boundary_canary__.ts'
```

Worth noting for anyone reproducing it: the walk is **fully synchronous**, so nothing in the same
process can interleave with it. The race is strictly cross-process — one vitest fork running the
walk against the `spawnSync`'d boundary script. An in-process repro cannot fail (confirmed: 200
walks, zero failures) and would have looked like "not reproducible".

## Why option 2 was rejected

The issue suggested checking first whether the canary could simply be written outside the scanned
tree. It cannot — its location is load-bearing three times over:

| Axis | Evidence | Effect of moving it |
|---|---|---|
| `rootDir` semantics | `extensions/*/tsconfig.json` → `"rootDir": "."` | TS6059 is *"file is not under rootDir"*. The canary must be **inside** rootDir so its deep import drags a file **outside** it. Outside, there is nothing to violate. |
| Relative `extends` | generated tsconfig → `extends: "./tsconfig.json"` | TS resolves a relative `extends` against the tsconfig's own directory. Elsewhere it stops inheriting the extension's `rootDir` and the boundary base config entirely. |
| Import depth | `"../../src/plugins/contracts/rootdir-boundary-canary.ts"` | Exactly two `..`, calibrated to `extensions/<id>/` → repo root. |

Moving it leaves the canary passing while asserting nothing. So this is option 1.

## The fix

- Skip `__rootdir_boundary_canary__.ts` **scoped to extension roots** — the skip fires only when the
  basename matches *and* the containing directory's parent is `extensions`, i.e. exactly the
  `extensions/<id>/` shape the boundary script actually writes (`resolveCanaryArtifactPaths`). The
  location half is load-bearing: an unscoped basename skip would ignore that name in *every*
  directory under `src/`. A regression test (`still scans that basename outside an extension root`)
  pins the scoping. **It narrows the hole rather than closing it** — see *Known residual* below.
- Tolerate `ENOENT` — **and only `ENOENT`** — when a file or directory vanishes between listing and
  read. Every other fault (`EACCES`, `EISDIR`, …) still throws.

## The pin is not weakened

The assertion that matters most — "no caller spawning a trash binary off PATH" — expects an **empty
array**, so a scan that silently read nothing would pass it. That is the failure mode a
broadly-swallowing fix would introduce, so the scan itself is now pinned, the same shape as the
discovery canary in `check-throwing-stub-callers.mjs` (#3138):

- reaches both scanned roots, asserted by **content-presence** (`src/infra/fs-safe-trash.ts` is
  present; at least one `extensions/` file is) — a count alone a truncated walk also satisfies —
  **plus** a loose `> 1000` floor, which is complementary rather than redundant: content-presence
  pins only two anchors, so a walk returning just those two passes it and fails the floor
  (measured at head: 6235 files, 4554 `src/` + 1681 `extensions/`);
- ignores the canary basename **only at `extensions/<id>/`**, and still scans it elsewhere;
- skips a file that vanishes between listing and read;
- still **throws** on a non-ENOENT read fault.

Two self-matching wrinkles, handled differently on purpose:

- The vanishing-file fixture needs the literal text `export async function movePathToTrash`, which
  would make `trash.test.ts` match the **declaration** scan. Excluding the file would carve out
  exactly the blind spot a twin could hide in, so instead the fixture is assembled at runtime from
  string fragments and the declaration scan stays **unfiltered**.
- The **PATH-spawn** scan *does* exclude `infra/trash.test.ts` — unavoidably, because this file's own
  explanatory comment contains `runExec("trash", …)` and `["trash", …]` and so matches its own
  detection pattern. Residual, stated rather than hidden: a spawn *call* written inside this one file
  would evade that assertion.

## Evidence

> **Transcript provenance**: the runs quoted below were captured against this branch's **first**
> commit, when the suite held 7 tests (and the co-scheduled lane 8). The scoping commit added a
> sixth test to this file; an independent re-run at head measures **`Tests 9 passed (9)`** and
> `10 passed (10)` co-scheduled. The quotes are left as originally captured rather than restated.


**Red reproduced before fixing** (cross-process harness, canary churn vs. the verbatim pre-fix walk):

```
walks: 2; walks whose listing contained a canary: 1
REPRODUCED on walk 2:
  ENOENT: no such file or directory, open '…/extensions/test-utils/__rootdir_boundary_canary__.ts'
```

**A/B under identical forced churn**, running the real test file in the real unit lane:

```
[baseline] pass=0  fail=15 of 15     ← pre-fix, every run ENOENT
[fixed]    pass=15 fail=0  of 15     ← this branch
```

**Co-scheduled with the boundary test in the real lane**, natural interleaving, no artificial churn:

```
run 1: EXIT=0 -- Tests  8 passed (8)
run 2: EXIT=0 -- Tests  8 passed (8)
run 3: EXIT=0 -- Tests  8 passed (8)
```

**The vanishing-file test fails without the handling** (ENOENT tolerance reverted, everything else
identical):

```
× skips a file that vanishes between listing and read
Error: ENOENT: no such file or directory, open '…/remoteclaw-trash-walk-uaSWlx/vanishing.ts'
Tests  1 failed | 6 passed (7)
```

**The pin still detects what it exists to detect** — re-introducing a PATH-spawning
`movePathToTrash` twin at `src/infra/trash.ts`:

```
× no longer exists as a module
× leaves exactly one declaration of movePathToTrash
× has no caller spawning a trash binary off PATH
Tests  3 failed | 4 passed (7)
```

Removed again → `Tests  7 passed (7)`.

**`pnpm check`** → exit `0`.

## Known residual (independently verified, filed as a follow-up)

The scoping predicate matches lexically on the parent directory *name*, so it still ignores the
canary basename in **any** directory whose parent is called `extensions`. Two reachable variants
were confirmed by planting a real PATH-spawning `movePathToTrash` twin and running the full suite:

| Plant | Result |
|---|---|
| `src/infra/__rootdir_boundary_canary__.ts` | **caught** (control) |
| `src/extensions/<sub>/__rootdir_boundary_canary__.ts` | **hidden** — under `src/` |
| `src/extensions/<sub>/ordinary.ts` | **caught** — isolates the basename as the cause |
| `extensions/<non-opt-in>/__rootdir_boundary_canary__.ts` | **hidden** — one file, no new directory |

The second variant is the cheaper one: only 28 of 36 extension roots opt into the boundary script's
cleanup, so a twin at one of the other 8 is never deleted. The separate trash-containment gate does
not cover this class (verified: exits 0 with the twins planted).

**Not a regression from this PR** — the first commit's bare-basename skip had these holes *plus*
every directory under `src/`; scoping strictly improved matters. Reachable only by deliberately
committing a file with that basename (zero exist today), whereas the pin's actual threat model is
*accidental* reintroduction via fork-sync. Hence a follow-up, not a blocker — and the durable fix is
to enforce in the suite the very property this PR's reasoning rests on: that `git ls-files` reports
zero files with the canary basename.

## Scope

Test-only; one file. `#3145` (the `UI_FAILING_SUITES_DEBT` ledger) is deliberately **not** bundled
here — it is a separate grind and this flake is blocking unrelated PRs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

