### PR TITLE
feat(ci): gate Control-UI docs affordances against the docs tree (#3160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,46 @@ jobs:
       - name: Check generated plugin inventory
         run: pnpm plugins:inventory:check
 
+  control-ui-docs-affordance-gate:
+    # Every docs target the Control UI hands a user — DOCS_SHORTLINK_PATHS and
+    # DOCS_ROOT_SEGMENTS in ui/src/components/markdown.ts — must resolve to a
+    # real page under docs/, directly or through the redirects map in
+    # docs/astro.config.mjs.
+    #
+    # This is the *links* third of the defect class #3156-#3159 shared: the
+    # Control UI rendering an affordance for a subsystem this fork gutted. #3157
+    # was its instance — 13 shortlinks naming gutted subsystems, sending a
+    # RemoteClaw user to documentation for features RemoteClaw does not have.
+    # #3160 asked for a gate covering the whole class; the script's header
+    # records why the broader shape is not buildable here and what was measured
+    # to establish that.
+    #
+    # STANDALONE rather than inside `pnpm check`: it is a fork-lifecycle gate
+    # like rebrand-gate and plugin-inventory-gate, its input is a table upstream
+    # sync re-applies wholesale, and it spans ui/ <-> docs/ — neither of which
+    # `pnpm check`'s lint scope owns. A named job also makes a sync-carried
+    # regression legible in the checks list instead of buried inside `lint`.
+    # Runnable locally as `pnpm lint:ui:no-dangling-docs-affordances`.
+    #
+    # Its canary lives in test/scripts/check-control-ui-docs-affordances.test.ts
+    # and runs in the `test` lane: a seeded leak the gate is required to fail on,
+    # plus a zero-cardinality floor, so a broken scan is loud rather than green.
+    # See #3160 and § Fork-integrity gates.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+
+      - name: Check Control UI docs affordances
+        run: pnpm lint:ui:no-dangling-docs-affordances
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -518,6 +558,7 @@ jobs:
         policy-doctor-boundary-gate,
         raw-channel-fetch-gate,
         plugin-inventory-gate,
+        control-ui-docs-affordance-gate,
         lint,
         build,
         packaged-boot-smoke,
@@ -532,7 +573,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.trash-containment-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.policy-doctor-boundary-gate.result }}" != "success" || "${{ needs.raw-channel-fetch-gate.result }}" != "success" || "${{ needs.plugin-inventory-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-extensions.result }}" != "success" || "${{ needs.test-auto-reply.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" || "${{ needs.test-windows.result }}" != "success" ]]; then
+          if [[ "${{ needs.rebrand-gate.result }}" != "success" || "${{ needs.zombie-import-gate.result }}" != "success" || "${{ needs.stub-debt-gate.result }}" != "success" || "${{ needs.throwing-stub-callers-gate.result }}" != "success" || "${{ needs.trash-containment-gate.result }}" != "success" || "${{ needs.obsolescence-audit-gate.result }}" != "success" || "${{ needs.policy-doctor-boundary-gate.result }}" != "success" || "${{ needs.raw-channel-fetch-gate.result }}" != "success" || "${{ needs.plugin-inventory-gate.result }}" != "success" || "${{ needs.control-ui-docs-affordance-gate.result }}" != "success" || "${{ needs.lint.result }}" != "success" || "${{ needs.build.result }}" != "success" || "${{ needs.packaged-boot-smoke.result }}" != "success" || "${{ needs.test.result }}" != "success" || "${{ needs.test-gateway.result }}" != "success" || "${{ needs.test-extensions.result }}" != "success" || "${{ needs.test-auto-reply.result }}" != "success" || "${{ needs.test-ui-smoke.result }}" != "success" || "${{ needs.test-windows.result }}" != "success" ]]; then
             echo "::error::One or more required jobs failed"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,52 @@ against regressions specific to the fork-sync lifecycle:
   than replaces, so prefer real markers). `plugin-inventory.md` itself has **no**
   manual-marker facility — every line of it is generated, so fork-authored prose
   belongs in the generator template, not the doc. Wired in #3084.
+- **control-ui-docs-affordance-gate**
+  (`pnpm lint:ui:no-dangling-docs-affordances`): every docs target the Control
+  UI hands a user — `DOCS_SHORTLINK_PATHS` and `DOCS_ROOT_SEGMENTS` in
+  `ui/src/components/markdown.ts` — must resolve to a real page under `docs/`,
+  directly or through the `redirects` map in `docs/astro.config.mjs` (which
+  `markdown.ts` already names as authoritative). Standalone job, because it is
+  a fork-lifecycle gate whose input is a table upstream sync re-applies
+  wholesale, and it spans `ui/` ↔ `docs/` — neither of which `pnpm check`'s
+  lint scope owns.
+
+  This is the **links** third of a wider defect class: the Control UI rendering
+  an affordance, link, or string for a subsystem this fork gutted (#3156-#3159;
+  #3157 was the links instance, sending users to docs for features RemoteClaw
+  does not have). It does **not** detect #3156's rendered affordance or #3158's
+  orphan i18n strings, and must not be read as covering them. #3160 asked for a
+  gate over the whole class; the header of
+  `scripts/check-control-ui-docs-affordances.mjs` records why that is not
+  buildable — `ui/` has no static edge to the gutted `src/` subsystems, so
+  there is no vocabulary to derive — and what was measured to establish it.
+
+  The false-positive boundary is satisfied by construction rather than by
+  tuning: the gate matches link targets, never concept words, so live
+  homographs (`resolveEmbedSandbox`, `bg-elevated`, `thinking`, `provider`) are
+  outside what it looks at instead of being allowlisted. Reviewed exceptions
+  live on `KNOWN_DANGLING_UI_DOCS_TARGETS`, pinned to `file:line` so a moved
+  entry re-fails and gets re-reviewed, and a paid-off entry fails as STALE so
+  the ledger drains (#3180 and #3211 own the 47 birth entries). Two extra
+  modes: `--strict` fails even on ledgered entries, to prove a line can be
+  removed before closing its issue; `--inventory` reports every dangling target
+  and fails on no *finding* — but it still fails the cardinality floor below,
+  which is the one thing no mode is exempt from. A third flag, `--repo-root`,
+  exists so the CLI itself can be tested against a fixture; CI runs the gate
+  unflagged.
+
+  Its canary is `test/scripts/check-control-ui-docs-affordances.test.ts`,
+  running in the `test` lane — a seeded leak restoring four gutted-subsystem
+  targets that the gate is *required* to fail on (three shortlinks #3157
+  actually removed, plus the `clawhub` root segment), alongside a
+  zero-cardinality floor. The floor matters as much as the seed: a seeded leak proves the
+  matcher works but says nothing about the vocabulary, and a gate whose
+  shortlink table or redirects map parses to zero entries checks nothing while
+  printing a healthy pass. So the gate reports how many shortlinks, root
+  segments, and redirects it read, and fails when any of those is zero — in
+  every mode, per #3138. Verified by mutation: stubbing the resolver to always
+  resolve turns 5 canary tests red, and emptying the derivation makes the gate
+  exit 1 naming the empty table rather than reporting clean. Wired in #3160.
 - **css-class-drift-gate** (`pnpm lint:ui:no-css-class-drift`, part of
   `pnpm check`): cross-references `class="..."` tokens in
   `ui/src/**/*.{ts,tsx,html}` against the CSS rule definitions reachable

--- a/package.json
+++ b/package.json
@@ -336,6 +336,8 @@
     "lint:swift": "swiftlint lint --config .swiftlint.yml && (cd apps/ios && swiftlint lint --config .swiftlint.yml)",
     "lint:tmp:no-random-messaging": "node scripts/check-no-random-messaging-tmp.mjs",
     "lint:ui:no-css-class-drift": "node scripts/audit-css-class-drift.mjs",
+    "lint:ui:no-dangling-docs-affordances": "node scripts/check-control-ui-docs-affordances.mjs",
+    "lint:ui:no-dangling-docs-affordances:inventory": "node scripts/check-control-ui-docs-affordances.mjs --inventory",
     "lint:ui:no-raw-window-open": "node scripts/check-no-raw-window-open.mjs",
     "mac:open": "open dist/RemoteClaw.app",
     "mac:package": "bash scripts/package-mac-app.sh",

--- a/scripts/check-control-ui-docs-affordances.mjs
+++ b/scripts/check-control-ui-docs-affordances.mjs
@@ -1,0 +1,609 @@
+#!/usr/bin/env node
+// Fails when the Control UI hands a user a docs target that does not resolve.
+//
+// WHY THIS GATE EXISTS, AND WHY IT IS NARROWER THAN #3160 ASKED FOR
+//
+// #3156-#3159 were four instances of one defect class: the Control UI rendering
+// an affordance, link, or string for a subsystem this fork gutted. Nothing in CI
+// failed on any of them, and five separate `gut(ui)` waves each removed 0 lines
+// of the /agents Model Selection UI before #3156 did.
+//
+// #3160 proposed deriving a "gutted concept" vocabulary from the fork's own gut
+// markers (`grep -rn "Gutted in RemoteClaw fork" src/`) and flagging `ui/` code
+// that renders an affordance for one. That shape was measured against this tree
+// and does not work — not because the boundary is hard to tune, but because
+// there is no signal to derive:
+//
+//   - `ui/` has NO static edge to the gutted `src/` subsystems. Its 48
+//     `ui/ -> src/` import statements reach 34 distinct modules — mostly
+//     `shared/*` and `gateway/protocol/*`, but also `agents/`, `talk/`,
+//     `config/`, `cron/` — and NOT ONE of the 34 carries a `Gutted in
+//     RemoteClaw fork` marker. The Control UI talks to the gateway over RPC, so
+//     a gut in `src/` leaves no trace in `ui/` to find. That absent edge is
+//     precisely WHY five gut waves missed the Model Selection UI. (Reproduce:
+//     list the modules, then grep each for the marker.)
+//   - Symbol-derived vocabulary: extracting the symbols a gut marker governs
+//     yields 2 hits in `ui/`, both false positives (`AgentContext`, a type
+//     declared in `ui/src/lib/agents/display.ts` itself). Recall on all four
+//     siblings: zero. An independent re-measurement with a stricter extraction
+//     found 0 hits and likewise 0 recall — the conclusion is not sensitive to
+//     how the vocabulary is extracted.
+//   - Prose-derived vocabulary: 39 words -> 944 hits, led by `export` (218),
+//     `state` (104), `index` (87), `test` (80), then the homographs #3160 itself
+//     predicted: `model` (51), `provider` (33), `runtime` (37).
+//
+// Two adjacent mechanisms were measured and also rejected, so this file is the
+// residue of a search rather than a first guess:
+//
+//   - Orphan UI module detection: 69 of 220 production files flagged, dominated
+//     by dynamically-registered Lit elements. Same mis-tuning that keeps knip
+//     out of CI (CLAUDE.md § Dead-code detection).
+//   - Orphan i18n key detection: all 33 strict orphans are dynamic-composition
+//     false positives (`t(`tabs.${id}`)`, 5 such call sites). That surface is
+//     owned by #3208 regardless.
+//
+// What DOES hold is resolution, not classification. Every docs target the
+// Control UI hands a user is a concrete path, and whether it resolves is a fact
+// about the repo rather than a judgement about a word. So this gate checks
+// exactly that, and claims exactly that: the *links* third of the defect class,
+// which is #3157's instance. It does not detect #3156's rendered affordance or
+// #3158's orphan strings, and it must not be read as covering them.
+//
+// The false-positive boundary #3160 worried about is satisfied by construction
+// rather than by tuning: this gate never matches a concept word, so
+// `resolveEmbedSandbox`, `ControlUiEmbedSandboxMode`, `bg-elevated`, and the
+// live `thinking` / `provider` identifiers are not merely allowlisted — they are
+// outside what it looks at.
+//
+// Reviewed exceptions live on KNOWN_DANGLING_UI_DOCS_TARGETS below, pinned to
+// `file:line` so a moved entry re-fails the gate and gets re-reviewed rather
+// than silently inheriting its exception, and so a paid-off entry fails as STALE
+// and drains the ledger (same discipline as scripts/check-tooling-config-refs.mjs
+// and scripts/check-no-raw-channel-fetch.mjs).
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** This gate, as every message that asks a contributor to edit it should name it. */
+const SELF_PATH = "scripts/check-control-ui-docs-affordances.mjs";
+
+/** The Control UI module that decides which links are rewritten to the docs site. */
+export const MARKDOWN_SOURCE = "ui/src/components/markdown.ts";
+
+/** The Astro config whose `redirects` map decides which docs slugs resolve. */
+export const ASTRO_CONFIG_SOURCE = "docs/astro.config.mjs";
+
+/** Root of the docs content tree. */
+export const DOCS_ROOT = "docs";
+
+const PAGE_EXTENSIONS = ["md", "mdx"];
+
+/**
+ * Reviewed exceptions: Control UI docs targets that do not resolve today.
+ *
+ * Every entry is pinned to `file:line` and carries a tracking issue. Removing a
+ * dangling target — or making it resolve — makes its entry STALE and fails the
+ * gate, so the ledger cannot outlive its debt.
+ *
+ * This is a birth ledger, not a permanent one. It exists because #3160 is
+ * explicitly scoped to the gate and NOT to the remediation: #3180 owns clearing
+ * the 404ing shortlinks, and #3211 owns the residue #3180 does not name. Wiring
+ * the gate green on a hand-fixed tree would have meant absorbing both.
+ */
+export const KNOWN_DANGLING_UI_DOCS_TARGETS = [
+  // ---------------------------------------------------------------------
+  // #3180 — DOCS_SHORTLINK_PATHS entries with no page and no redirect.
+  //
+  // These are the 38 slugs #3180 measured as 404ing on docs.remoteclaw.org
+  // after #3157 re-pointed DOCS_ORIGIN. The population is dominated by gutted
+  // subsystems — the model-provider slugs (/anthropic, /openai, /azure,
+  // /openrouter, /glm, /qianfan, /zai, /xiaomi), the Pi-era subsystems
+  // (/thinking, /elevated, /agent-loop, /context-engine, /lore, /wizard), the
+  // skills marketplace (/clawdhub, /mac/skills), and the template system
+  // (/templates/*) — which is what makes this gate a real detector for the
+  // #3157 defect class rather than a generic link linter. A few (/cron, /mcp,
+  // /opencode) name subsystems this fork DOES have; those dangle because the
+  // docs page is absent, not because the subsystem is. Either way the user gets
+  // a 404, and #3180 decides per slug whether to drop it or write the page.
+  { file: MARKDOWN_SOURCE, line: 219, value: "/agent-loop", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 223, value: "/anthropic", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 227, value: "/azure", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 236, value: "/clawdhub", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 240, value: "/context-engine", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 242, value: "/cron", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 251, value: "/duckduckgo-search", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 252, value: "/elevated", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 253, value: "/exa-search", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 259, value: "/gemini-search", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 261, value: "/glm", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 262, value: "/gmail-pubsub", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 263, value: "/grammy", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 264, value: "/grok-search", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 273, value: "/kimi-search", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 278, value: "/lore", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 292, value: "/mac/skills", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 299, value: "/mcp", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 308, value: "/oauth", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 309, value: "/openai", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 310, value: "/opencode", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 311, value: "/opencode-go", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 312, value: "/openrouter", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 319, value: "/qianfan", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 331, value: "/showcase", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 339, value: "/templates/AGENTS", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 340, value: "/templates/BOOT", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 341, value: "/templates/BOOTSTRAP", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 342, value: "/templates/HEARTBEAT", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 343, value: "/templates/IDENTITY", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 344, value: "/templates/SOUL", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 345, value: "/templates/TOOLS", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 346, value: "/templates/USER", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 348, value: "/thinking", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 355, value: "/web-fetch", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 360, value: "/wizard", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 361, value: "/xiaomi", issue: "#3180" },
+  { file: MARKDOWN_SOURCE, line: 362, value: "/zai", issue: "#3180" },
+
+  // ---------------------------------------------------------------------
+  // #3211 — the residue #3180 does not name.
+  //
+  // Three shortlinks resolve to a redirect whose TARGET has no page, so they
+  // 404 one hop later than the 38 above and #3180's count excludes them.
+  { file: MARKDOWN_SOURCE, line: 302, value: "/minimax", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 303, value: "/mistral", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 304, value: "/moonshot", issue: "#3211" },
+
+  // Six DOCS_ROOT_SEGMENTS entries with no page, no directory, and no redirect
+  // under that prefix. `clawhub` is the gutted skills marketplace and
+  // `openclaw-agent-runtime` is both an upstream brand leak and a gutted Pi-era
+  // subsystem — neither is caught by rebrand-gate, which is changed-files-only.
+  // Deliberately NOT repaired here: #3157 audited DOCS_ROOT_SEGMENTS and left it
+  // unmodified on purpose, and dropping a segment changes link-rewriting
+  // behaviour for every path under it. Reversing that scoping decision belongs
+  // to a review of its own.
+  { file: MARKDOWN_SOURCE, line: 173, value: "agent-runtime-architecture", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 174, value: "announcements", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 180, value: "clawhub", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 191, value: "maturity-scorecard", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 194, value: "openclaw-agent-runtime", issue: "#3211" },
+  { file: MARKDOWN_SOURCE, line: 204, value: "specs", issue: "#3211" },
+];
+
+/**
+ * Scans from the delimiter at `openIndex` to the one that matches it, reporting
+ * the comment spans skipped along the way.
+ *
+ * Both declarations this gate reads were first parsed by searching for a literal
+ * terminator (`]);` and `\n};`). That works only for the shape those files
+ * happen to have today: running `pnpm format` over a fixture collapsed
+ * `const redirects = {\n};` to `const redirects = {};`, the `\n};` search
+ * missed, and the gate threw on a file that was perfectly well-formed. The same
+ * reformat of the real docs/astro.config.mjs would have done the same thing.
+ * Counting delimiters is not defensive polish here — it removes a dependency on
+ * a formatting choice nothing guarantees.
+ *
+ * Comments are tracked for the same reason. A `//` note inside either table is
+ * an edit waiting to happen — #3180 and #3211 drain the ledger by editing this
+ * exact table, and upstream sync re-applies it wholesale — and every character
+ * class in a comment is load-bearing to a scanner that cannot see it:
+ * `// see #3180]` ends the block early and silently drops every entry after it;
+ * `// it's gutted` opens a quote that swallows the terminator; and a slug quoted
+ * in prose (`// #3157 dropped "/skill-workshop"`) becomes a phantom target the
+ * gate then reports as dangling. Returning the spans lets the callers blank them
+ * before matching, so all three collapse into one mechanism.
+ *
+ * `closeIndex` is -1 when the delimiter is unbalanced. Still not a JS parser:
+ * quotes and comments are enough for two data-only literals, and a regex literal
+ * or a division would confuse it.
+ */
+function scanDelimitedBlock(source, openIndex, open, close) {
+  const comments = [];
+  let depth = 0;
+  let quote = null;
+  let comment = null;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (comment) {
+      if (comment.kind === "line") {
+        if (character === "\n") {
+          // Ends *before* the newline, so blanking leaves the newline in place
+          // and the line numbers the callers derive stay put.
+          comments.push([comment.start, index]);
+          comment = null;
+        }
+        continue;
+      }
+      if (character === "*" && source[index + 1] === "/") {
+        index += 1;
+        comments.push([comment.start, index + 1]);
+        comment = null;
+      }
+      continue;
+    }
+    if (quote) {
+      if (character === "\\") {
+        index += 1;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === "/" && (source[index + 1] === "/" || source[index + 1] === "*")) {
+      comment = { kind: source[index + 1] === "/" ? "line" : "block", start: index };
+      index += 1;
+    } else if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+    } else if (character === open) {
+      depth += 1;
+    } else if (character === close) {
+      depth -= 1;
+      if (depth === 0) {
+        return { closeIndex: index, comments };
+      }
+    }
+  }
+  // No trailing comment span to record: reaching EOF means the delimiter never
+  // balanced, and both callers throw on that without reading the spans.
+  return { closeIndex: -1, comments };
+}
+
+/** Overwrites `[start, end)` spans with spaces, preserving offsets and newlines. */
+function blankSpans(source, spans) {
+  let out = "";
+  let cursor = 0;
+  for (const [start, end] of spans) {
+    // `[^\n]` without the `u` flag replaces per UTF-16 code unit, so an astral
+    // character in a comment cannot shift the offsets the callers slice by.
+    out += source.slice(cursor, start) + source.slice(start, end).replace(/[^\n]/g, " ");
+    cursor = end;
+  }
+  return out + source.slice(cursor);
+}
+
+/**
+ * Extracts the quoted entries of a `const NAME = new Set([...])` literal,
+ * carrying each entry's 1-based line number.
+ *
+ * Throws when the block is absent. A parser that silently returns `[]` when the
+ * shape it expects has moved is exactly the failure this gate is built to avoid:
+ * the run would report every target resolving, having checked none.
+ */
+export function extractSetEntries(source, setName, file) {
+  const openMarker = `${setName} = new Set([`;
+  const openIndex = source.indexOf(openMarker);
+  if (openIndex === -1) {
+    throw new Error(
+      `${file}: could not find \`${setName} = new Set([\`. The gate reads this ` +
+        `declaration to learn which docs targets the Control UI exposes; if the ` +
+        `declaration was renamed or reshaped, update ${SELF_PATH} to match.`,
+    );
+  }
+  const { closeIndex, comments } = scanDelimitedBlock(
+    source,
+    openIndex + openMarker.length - 1,
+    "[",
+    "]",
+  );
+  if (closeIndex === -1) {
+    throw new Error(`${file}: \`${setName}\` has no matching \`]\`.`);
+  }
+  const lineOffset = source.slice(0, openIndex).split("\n").length;
+  const body = blankSpans(source, comments).slice(openIndex, closeIndex);
+  const entries = [];
+  body.split("\n").forEach((text, index) => {
+    for (const match of text.matchAll(/"([^"]+)"/g)) {
+      entries.push({ value: match[1], file, line: lineOffset + index });
+    }
+  });
+  return entries;
+}
+
+/**
+ * Parses the `redirects` map out of the Astro config.
+ *
+ * Throws when the map is absent, for the same reason `extractSetEntries` does.
+ */
+export function extractRedirects(source, file) {
+  const openIndex = source.indexOf("const redirects = {");
+  if (openIndex === -1) {
+    throw new Error(
+      `${file}: could not find \`const redirects = {\`. The Control UI's ` +
+        `shortlink table resolves through this map; without it every shortlink ` +
+        `would read as dangling.`,
+    );
+  }
+  const { closeIndex, comments } = scanDelimitedBlock(
+    source,
+    openIndex + "const redirects = {".length - 1,
+    "{",
+    "}",
+  );
+  if (closeIndex === -1) {
+    throw new Error(`${file}: \`redirects\` has no matching \`}\`.`);
+  }
+  const body = blankSpans(source, comments).slice(openIndex, closeIndex);
+  return new Map([...body.matchAll(/^\s*"([^"]+)"\s*:\s*"([^"]+)"/gm)].map((m) => [m[1], m[2]]));
+}
+
+function pageExists(repoRoot, docsPath) {
+  const relative = docsPath.replace(/^\//, "").replace(/[#?].*$/, "");
+  if (relative === "") {
+    return false;
+  }
+  const base = path.resolve(repoRoot, DOCS_ROOT, relative);
+  return PAGE_EXTENSIONS.some(
+    (extension) =>
+      fs.existsSync(`${base}.${extension}`) || fs.existsSync(path.join(base, `index.${extension}`)),
+  );
+}
+
+function directoryExists(repoRoot, segment) {
+  const target = path.resolve(repoRoot, DOCS_ROOT, segment);
+  return fs.existsSync(target) && fs.statSync(target).isDirectory();
+}
+
+/**
+ * Resolves one shortlink, following the redirects map.
+ *
+ * Returns `{ resolved: true }`, or `{ resolved: false, reason }` naming whether
+ * the slug had no page and no redirect, or reached a redirect whose target has
+ * no page — the two failure shapes read differently in review.
+ */
+export function resolveShortlink(slug, { repoRoot, redirects }) {
+  if (pageExists(repoRoot, slug)) {
+    return { resolved: true };
+  }
+  const seen = new Set([slug]);
+  let current = slug;
+  while (redirects.has(current)) {
+    const next = redirects.get(current);
+    if (seen.has(next)) {
+      return { resolved: false, reason: `redirect cycle at "${next}"` };
+    }
+    seen.add(next);
+    if (pageExists(repoRoot, next)) {
+      return { resolved: true };
+    }
+    current = next;
+  }
+  if (seen.size > 1) {
+    return {
+      resolved: false,
+      reason: `redirects to "${current}", which has no page under ${DOCS_ROOT}/`,
+    };
+  }
+  return { resolved: false, reason: `no page under ${DOCS_ROOT}/ and no redirect` };
+}
+
+/**
+ * Resolves one root segment. A segment legitimately resolves as a directory, as
+ * a single page, or as the prefix of at least one redirect key — all three are
+ * live shapes in this tree, and checking only the first produces false positives
+ * on `docs/ci.md`-style single-file sections.
+ */
+export function resolveRootSegment(segment, { repoRoot, redirects }) {
+  if (directoryExists(repoRoot, segment) || pageExists(repoRoot, `/${segment}`)) {
+    return { resolved: true };
+  }
+  for (const key of redirects.keys()) {
+    if (key === `/${segment}` || key.startsWith(`/${segment}/`)) {
+      return { resolved: true };
+    }
+  }
+  return {
+    resolved: false,
+    reason: `no directory or page under ${DOCS_ROOT}/, and no redirect below /${segment}`,
+  };
+}
+
+const ledgerKey = (entry) => `${entry.file}:${entry.line}:${entry.value}`;
+
+/** Splits dangling targets into unreviewed ones and stale ledger entries. */
+export function compareToLedger(dangling, ledger = KNOWN_DANGLING_UI_DOCS_TARGETS) {
+  const ledgerKeys = new Set(ledger.map(ledgerKey));
+  const seenKeys = new Set(dangling.map(ledgerKey));
+  return {
+    unreviewed: dangling.filter((entry) => !ledgerKeys.has(ledgerKey(entry))),
+    stale: ledger.filter((entry) => !seenKeys.has(ledgerKey(entry))),
+  };
+}
+
+/**
+ * Runs the gate.
+ *
+ * `mode` is one of:
+ *   - "default"   — ledgered entries pass; unreviewed and stale entries fail.
+ *   - "strict"    — every dangling target fails, ledgered or not. Use before
+ *                   closing a remediation issue, to prove its entries can go.
+ *   - "inventory" — reports every dangling target and fails on none of them.
+ *                   Still fails on a zero-cardinality scan: an inventory
+ *                   compiled by an instrument that read nothing is not a shorter
+ *                   inventory, it is a false one.
+ */
+export function checkControlUiDocsAffordances({
+  repoRoot = REPO_ROOT,
+  ledger = KNOWN_DANGLING_UI_DOCS_TARGETS,
+  mode = "default",
+} = {}) {
+  const markdownSource = fs.readFileSync(path.resolve(repoRoot, MARKDOWN_SOURCE), "utf8");
+  const astroSource = fs.readFileSync(path.resolve(repoRoot, ASTRO_CONFIG_SOURCE), "utf8");
+
+  const shortlinks = extractSetEntries(markdownSource, "DOCS_SHORTLINK_PATHS", MARKDOWN_SOURCE);
+  const rootSegments = extractSetEntries(markdownSource, "DOCS_ROOT_SEGMENTS", MARKDOWN_SOURCE);
+  const redirects = extractRedirects(astroSource, ASTRO_CONFIG_SOURCE);
+
+  const counts = {
+    shortlinks: shortlinks.length,
+    rootSegments: rootSegments.length,
+    redirects: redirects.size,
+  };
+
+  // Cardinality gate. Each of these derivations is a place where a silent
+  // upstream reshape turns this gate into a green no-op: an empty shortlink set
+  // means nothing is checked, and an empty redirects map means everything
+  // resolves through file existence alone. Both would print a healthy-looking
+  // pass. #3138 established the precedent — the throwing-stub gate reports how
+  // many production files it walked and fails when that count is zero, in every
+  // mode — and #3160's own review comment asked for it here specifically,
+  // because a seeded leak catches a broken matcher but not an empty vocabulary.
+  const emptyDerivations = Object.entries({
+    DOCS_SHORTLINK_PATHS: counts.shortlinks,
+    DOCS_ROOT_SEGMENTS: counts.rootSegments,
+    "redirects (docs/astro.config.mjs)": counts.redirects,
+  })
+    .filter(([, size]) => size === 0)
+    .map(([name]) => name);
+
+  if (emptyDerivations.length > 0) {
+    return {
+      ok: false,
+      counts,
+      messages: emptyDerivations.map(
+        (name) =>
+          `${name} yielded 0 entries. The gate has nothing to check and would pass ` +
+          `vacuously, which is indistinguishable from a healthy run. Fix the ` +
+          `derivation before trusting this gate's verdict.`,
+      ),
+    };
+  }
+
+  const dangling = [];
+  for (const entry of shortlinks) {
+    const outcome = resolveShortlink(entry.value, { repoRoot, redirects });
+    if (!outcome.resolved) {
+      dangling.push({ ...entry, kind: "shortlink", reason: outcome.reason });
+    }
+  }
+  for (const entry of rootSegments) {
+    const outcome = resolveRootSegment(entry.value, { repoRoot, redirects });
+    if (!outcome.resolved) {
+      dangling.push({ ...entry, kind: "root segment", reason: outcome.reason });
+    }
+  }
+
+  if (mode === "inventory") {
+    return {
+      ok: true,
+      counts,
+      messages: dangling.map(
+        (entry) => `${entry.file}:${entry.line} ${entry.kind} "${entry.value}" — ${entry.reason}`,
+      ),
+      dangling,
+    };
+  }
+
+  const { unreviewed, stale } =
+    mode === "strict" ? { unreviewed: dangling, stale: [] } : compareToLedger(dangling, ledger);
+
+  const messages = [];
+  for (const entry of unreviewed) {
+    messages.push(
+      `${entry.file}:${entry.line} ${entry.kind} "${entry.value}" — ${entry.reason}. ` +
+        `The Control UI links a user to a docs page that does not exist. Drop the ` +
+        `entry, point it at a real page, or add a reviewed entry (with a tracking ` +
+        `issue) to KNOWN_DANGLING_UI_DOCS_TARGETS in ${SELF_PATH}.`,
+    );
+  }
+  for (const entry of stale) {
+    messages.push(
+      `KNOWN_DANGLING_UI_DOCS_TARGETS entry ${entry.file}:${entry.line} ("${entry.value}") no ` +
+        `longer matches a dangling target. Remove the ledger entry — it is debt that ` +
+        `has been paid, or the target moved and needs re-review.`,
+    );
+  }
+
+  return { ok: messages.length === 0, counts, messages, dangling };
+}
+
+/**
+ * `--repo-root` exists so the CLI itself is testable against a fixture, the way
+ * `check-throwing-stub-callers.mjs --roots=` is. Without it the only reachable
+ * assertion is on the exported function, and the two can disagree: a revision of
+ * this file returned `ok: false` on a zero-cardinality scan while the
+ * `--inventory` branch left `process.exitCode` at 0, and the suite stayed green
+ * because it asserted on the function. CI runs the gate unflagged.
+ *
+ * A `--repo-root` with no usable value is an error, not a fall-back to
+ * `REPO_ROOT`, for the reason `parseRootsFlag` in that sibling gives: scanning
+ * the whole repo when the caller asked for a fixture is indistinguishable from
+ * scanning the fixture, and the real tree is green, so a mistyped flag would
+ * turn every fixture assertion into a green that proves nothing.
+ */
+export function parseArgs(argv) {
+  const mode = argv.includes("--strict")
+    ? "strict"
+    : argv.includes("--inventory")
+      ? "inventory"
+      : "default";
+  const missingValue = {
+    error: "`--repo-root` needs a value: --repo-root <path> or --repo-root=<path>",
+  };
+
+  const flagIndex = argv.indexOf("--repo-root");
+  if (flagIndex !== -1) {
+    const value = argv[flagIndex + 1];
+    // A following flag is a missing value, not a path: `--repo-root --strict`
+    // would otherwise scan a directory literally named `--strict`.
+    return value === undefined || value.startsWith("--") ? missingValue : { mode, repoRoot: value };
+  }
+
+  const inlineRoot = argv.find((argument) => argument.startsWith("--repo-root="));
+  if (inlineRoot !== undefined) {
+    const value = inlineRoot.slice("--repo-root=".length);
+    return value === "" ? missingValue : { mode, repoRoot: value };
+  }
+
+  return { mode, repoRoot: REPO_ROOT };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { mode, repoRoot, error } = parseArgs(process.argv.slice(2));
+  if (error) {
+    console.error(`[control-ui-docs-affordances] ${error}`);
+    process.exit(1);
+  }
+  let result;
+  try {
+    result = checkControlUiDocsAffordances({ mode, repoRoot });
+  } catch (error) {
+    console.error(`[control-ui-docs-affordances] ${error.message}`);
+    process.exit(1);
+  }
+
+  const scanned =
+    `${result.counts.shortlinks} shortlink(s) + ${result.counts.rootSegments} root segment(s) ` +
+    `checked against ${result.counts.redirects} redirect(s)`;
+
+  if (mode === "inventory") {
+    console.log(`[control-ui-docs-affordances] ${scanned}.`);
+    console.log(`[control-ui-docs-affordances] ${result.messages.length} dangling target(s):`);
+    for (const message of result.messages) {
+      console.log(`  - ${message}`);
+    }
+    // Inventory mode does not fail on findings — that is its purpose — but the
+    // cardinality floor still has to bite here, exactly as it does for
+    // `check-throwing-stub-callers.mjs --inventory`. Reading `result.ok` rather
+    // than assuming inventory is always exit 0 is what keeps that promise at the
+    // surface a user actually invokes: `checkControlUiDocsAffordances` already
+    // returns `ok: false` on a zero-cardinality scan in every mode, and an
+    // earlier revision of this branch dropped that on the floor here while the
+    // suite still passed, because the test asserted on the exported function
+    // instead of the exit code.
+    if (!result.ok) {
+      process.exitCode = 1;
+    }
+  } else if (!result.ok) {
+    console.error(`Control UI docs targets that do not resolve (${scanned}):\n`);
+    for (const message of result.messages) {
+      console.error(`  - ${message}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `[control-ui-docs-affordances] ${scanned}; all resolve ` +
+        `(${KNOWN_DANGLING_UI_DOCS_TARGETS.length} reviewed exception(s)).`,
+    );
+  }
+}

--- a/test/fixtures/control-ui-docs-affordances/absent-declaration/docs/astro.config.mjs
+++ b/test/fixtures/control-ui-docs-affordances/absent-declaration/docs/astro.config.mjs
@@ -1,0 +1,7 @@
+// Fixture mirror of docs/astro.config.mjs. Populated on purpose — what is
+// absent in this fixture is the Control UI's shortlink declaration.
+const redirects = {
+  "/control-ui": "/web/control-ui",
+};
+
+export default { redirects };

--- a/test/fixtures/control-ui-docs-affordances/absent-declaration/ui/src/components/markdown.ts
+++ b/test/fixtures/control-ui-docs-affordances/absent-declaration/ui/src/components/markdown.ts
@@ -1,0 +1,10 @@
+// Fixture: the shortlink declaration is gone entirely.
+//
+// This is what a real upstream restructure looks like from the gate's side —
+// the table renamed, inlined, or moved to another module. The gate must throw
+// and name the missing declaration, not fall back to "found nothing, all clear".
+// A parser that returns `[]` on a shape it no longer recognizes is the same
+// vacuous pass as an empty vocabulary, arrived at one step earlier.
+const DOCS_ROOT_SEGMENTS = new Set(["web"]);
+
+export { DOCS_ROOT_SEGMENTS };

--- a/test/fixtures/control-ui-docs-affordances/empty-redirects/docs/astro.config.mjs
+++ b/test/fixtures/control-ui-docs-affordances/empty-redirects/docs/astro.config.mjs
@@ -1,0 +1,4 @@
+// Fixture: the redirects map parses, but declares no redirects.
+const redirects = {};
+
+export default { redirects };

--- a/test/fixtures/control-ui-docs-affordances/empty-redirects/ui/src/components/markdown.ts
+++ b/test/fixtures/control-ui-docs-affordances/empty-redirects/ui/src/components/markdown.ts
@@ -1,0 +1,13 @@
+// Fixture: the Control UI tables are populated, but the redirects map is empty.
+//
+// The other half of the cardinality floor. 105 of this repo's 147 shortlinks
+// resolve only through a redirect, so an empty map does not merely lose a little
+// signal — it inverts the gate's verdict wholesale, and it inverts it toward
+// noise rather than silence. Without the floor the run would report ~105 fresh
+// dangling targets and read as a catastrophic regression in the Control UI,
+// sending a reviewer to fix link tables that never changed.
+const DOCS_ROOT_SEGMENTS = new Set(["web"]);
+
+const DOCS_SHORTLINK_PATHS = new Set(["/control-ui", "/web/dashboard"]);
+
+export { DOCS_ROOT_SEGMENTS, DOCS_SHORTLINK_PATHS };

--- a/test/fixtures/control-ui-docs-affordances/empty-vocabulary/docs/astro.config.mjs
+++ b/test/fixtures/control-ui-docs-affordances/empty-vocabulary/docs/astro.config.mjs
@@ -1,0 +1,7 @@
+// Fixture mirror of docs/astro.config.mjs. Populated on purpose — the emptiness
+// under test in this fixture is the Control UI's shortlink table, not this map.
+const redirects = {
+  "/control-ui": "/web/control-ui",
+};
+
+export default { redirects };

--- a/test/fixtures/control-ui-docs-affordances/empty-vocabulary/ui/src/components/markdown.ts
+++ b/test/fixtures/control-ui-docs-affordances/empty-vocabulary/ui/src/components/markdown.ts
@@ -1,0 +1,14 @@
+// Fixture: the shortlink table parses, but yields zero entries.
+//
+// This is the failure #3160's review comment asked for by name. A seeded leak
+// proves the *matcher* works; it says nothing about the *vocabulary*. If an
+// upstream sync empties or reshapes this table, a gate without a cardinality
+// floor checks nothing and prints a healthy pass — byte-indistinguishable from a
+// real one. The same shape has now bitten this repo three times (#3138's stub
+// walk, the dangling `tooling-config-refs` paths, and a shell-eaten `\b` in a
+// gut-reversion sweep), so the floor is not hypothetical hardening.
+const DOCS_ROOT_SEGMENTS = new Set(["web"]);
+
+const DOCS_SHORTLINK_PATHS = new Set([]);
+
+export { DOCS_ROOT_SEGMENTS, DOCS_SHORTLINK_PATHS };

--- a/test/fixtures/control-ui-docs-affordances/resolves/docs/astro.config.mjs
+++ b/test/fixtures/control-ui-docs-affordances/resolves/docs/astro.config.mjs
@@ -1,0 +1,7 @@
+// Fixture mirror of docs/astro.config.mjs — the map that decides which Control
+// UI shortlinks resolve.
+const redirects = {
+  "/control-ui": "/web/control-ui",
+};
+
+export default { redirects };

--- a/test/fixtures/control-ui-docs-affordances/resolves/docs/web/control-ui.md
+++ b/test/fixtures/control-ui-docs-affordances/resolves/docs/web/control-ui.md
@@ -1,0 +1,4 @@
+# Control UI
+
+Fixture page. `/control-ui` resolves here through the redirects map, and the
+`web` root segment resolves because this directory exists.

--- a/test/fixtures/control-ui-docs-affordances/resolves/docs/web/dashboard.md
+++ b/test/fixtures/control-ui-docs-affordances/resolves/docs/web/dashboard.md
@@ -1,0 +1,3 @@
+# Dashboard
+
+Fixture page. `/web/dashboard` resolves directly, with no redirect hop.

--- a/test/fixtures/control-ui-docs-affordances/resolves/ui/src/components/markdown.ts
+++ b/test/fixtures/control-ui-docs-affordances/resolves/ui/src/components/markdown.ts
@@ -1,0 +1,24 @@
+// Fixture: every Control UI docs target resolves.
+//
+// This file deliberately carries the three homographs #3160 named as
+// must-not-fire: `resolveEmbedSandbox` / `ControlUiEmbedSandboxMode` (an iframe
+// `sandbox` attribute, unrelated to the gutted agent sandbox), the `bg-elevated`
+// CSS token, and live `thinking` / `provider` identifiers. None of them is a
+// docs target, so a clean run against this fixture is positive evidence that the
+// gate reads link targets rather than concept words — the false-positive
+// boundary #3160 was most worried about.
+const DOCS_ROOT_SEGMENTS = new Set(["web"]);
+
+const DOCS_SHORTLINK_PATHS = new Set(["/control-ui", "/web/dashboard"]);
+
+export function resolveEmbedSandbox() {
+  return "allow-scripts allow-same-origin";
+}
+
+export type ControlUiEmbedSandboxMode = "strict" | "relaxed";
+
+export const ELEVATED_SURFACE_CLASS = "bg-elevated";
+
+export const runtimeStatus = { provider: "cli", model: "default", thinking: "off" };
+
+export { DOCS_ROOT_SEGMENTS, DOCS_SHORTLINK_PATHS };

--- a/test/fixtures/control-ui-docs-affordances/seeded-leak/docs/astro.config.mjs
+++ b/test/fixtures/control-ui-docs-affordances/seeded-leak/docs/astro.config.mjs
@@ -1,0 +1,7 @@
+// Fixture mirror of docs/astro.config.mjs — identical to the `resolves`
+// fixture's. The seeded leak is in the Control UI's link tables, not here.
+const redirects = {
+  "/control-ui": "/web/control-ui",
+};
+
+export default { redirects };

--- a/test/fixtures/control-ui-docs-affordances/seeded-leak/docs/web/control-ui.md
+++ b/test/fixtures/control-ui-docs-affordances/seeded-leak/docs/web/control-ui.md
@@ -1,0 +1,4 @@
+# Control UI
+
+Fixture page. `/control-ui` resolves here through the redirects map, and the
+`web` root segment resolves because this directory exists.

--- a/test/fixtures/control-ui-docs-affordances/seeded-leak/docs/web/dashboard.md
+++ b/test/fixtures/control-ui-docs-affordances/seeded-leak/docs/web/dashboard.md
@@ -1,0 +1,3 @@
+# Dashboard
+
+Fixture page. `/web/dashboard` resolves directly, with no redirect hop.

--- a/test/fixtures/control-ui-docs-affordances/seeded-leak/ui/src/components/markdown.ts
+++ b/test/fixtures/control-ui-docs-affordances/seeded-leak/ui/src/components/markdown.ts
@@ -1,0 +1,40 @@
+// Fixture: the known-positive this gate is REQUIRED to fail on.
+//
+// Identical to the `resolves` fixture, except that four gutted-subsystem docs
+// targets are restored. All four are real residue that a real `gut(ui)` wave
+// removed, so this is a re-introduced defect rather than an invented one:
+//
+//   - "/skill-workshop", "/models", "/sandbox" — three of the 13 shortlinks
+//     #3157 dropped, naming the skills marketplace, the model-provider catalog,
+//     and the agent sandbox, all gutted in this fork.
+//   - "clawhub" — the skills-marketplace root segment.
+//
+// "/sandbox" is load-bearing in this fixture: `resolveEmbedSandbox` and
+// `ControlUiEmbedSandboxMode` below are the live iframe-sandbox homographs, and
+// they sit in the same file. A gate that fires on the shortlink while staying
+// silent on the identifiers is reading targets, not words. A gate that fires on
+// both, or on neither, is broken in one of the two directions #3160 named.
+//
+// If this fixture ever stops failing the gate, the gate has stopped working —
+// that is what `check-control-ui-docs-affordances.test.ts` asserts.
+const DOCS_ROOT_SEGMENTS = new Set(["web", "clawhub"]);
+
+const DOCS_SHORTLINK_PATHS = new Set([
+  "/control-ui",
+  "/web/dashboard",
+  "/models",
+  "/sandbox",
+  "/skill-workshop",
+]);
+
+export function resolveEmbedSandbox() {
+  return "allow-scripts allow-same-origin";
+}
+
+export type ControlUiEmbedSandboxMode = "strict" | "relaxed";
+
+export const ELEVATED_SURFACE_CLASS = "bg-elevated";
+
+export const runtimeStatus = { provider: "cli", model: "default", thinking: "off" };
+
+export { DOCS_ROOT_SEGMENTS, DOCS_SHORTLINK_PATHS };

--- a/test/scripts/check-control-ui-docs-affordances.test.ts
+++ b/test/scripts/check-control-ui-docs-affordances.test.ts
@@ -1,0 +1,388 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  checkControlUiDocsAffordances,
+  compareToLedger,
+  extractRedirects,
+  extractSetEntries,
+  KNOWN_DANGLING_UI_DOCS_TARGETS,
+  parseArgs,
+  resolveRootSegment,
+  resolveShortlink,
+} from "../../scripts/check-control-ui-docs-affordances.mjs";
+
+const FIXTURE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/control-ui-docs-affordances",
+);
+
+const fixture = (name: string) => path.join(FIXTURE_ROOT, name);
+
+const GATE_SCRIPT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../scripts/check-control-ui-docs-affordances.mjs",
+);
+
+/** Runs the gate the way CI and a developer do — as a process, reading its exit code. */
+const runCli = (args: string[]) =>
+  spawnSync(process.execPath, [GATE_SCRIPT, ...args], { encoding: "utf8" });
+
+describe("check-control-ui-docs-affordances — canary", () => {
+  // THE DISCRIMINATING TEST. #3160 asks for a gate that can be shown to FAIL, on
+  // the reasoning that a gate which only passes on a clean tree proves nothing.
+  // Everything else in this file is secondary to this assertion.
+  it("FAILS on the seeded leak — gutted-subsystem targets restored", () => {
+    const result = checkControlUiDocsAffordances({
+      repoRoot: fixture("seeded-leak"),
+      ledger: [],
+    });
+
+    expect(result.ok).toBe(false);
+    const flagged = result.dangling.map((entry) => entry.value).toSorted();
+    expect(flagged).toEqual(["/models", "/sandbox", "/skill-workshop", "clawhub"]);
+  });
+
+  it("passes on the equivalent fixture with those targets removed", () => {
+    // Same fixture minus the seed. Pairing the two is what makes the failure
+    // above attributable to the leak rather than to anything else in the tree.
+    const result = checkControlUiDocsAffordances({
+      repoRoot: fixture("resolves"),
+      ledger: [],
+    });
+
+    expect(result.messages).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("does not fire on the homographs #3160 named, which sit in the same file", () => {
+    // `resolveEmbedSandbox`, `ControlUiEmbedSandboxMode`, `bg-elevated` and the
+    // live `provider` / `model` / `thinking` identifiers are all present in the
+    // `resolves` fixture's markdown.ts. The gate reads link targets, so they are
+    // outside what it looks at rather than allowlisted — and the seeded-leak
+    // fixture carries the same identifiers while its "/sandbox" SHORTLINK does
+    // fire, which is the pair that distinguishes "reads targets" from
+    // "reads words".
+    const result = checkControlUiDocsAffordances({ repoRoot: fixture("resolves"), ledger: [] });
+    const reported = result.messages.join("\n");
+
+    for (const homograph of ["EmbedSandbox", "bg-elevated", "thinking", "provider"]) {
+      expect(reported).not.toContain(homograph);
+    }
+  });
+});
+
+describe("check-control-ui-docs-affordances — cardinality floor", () => {
+  // A seeded leak catches a broken matcher. It does not catch an empty
+  // vocabulary: a gate with nothing to check passes, and its output is
+  // byte-identical to a healthy run. #3138 established the counter-measure in
+  // this repo (report what was walked, fail at zero) and #3160's review comment
+  // asked for it here by name.
+  it("fails when the shortlink table yields zero entries", () => {
+    const result = checkControlUiDocsAffordances({
+      repoRoot: fixture("empty-vocabulary"),
+      ledger: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.counts.shortlinks).toBe(0);
+    expect(result.messages.join("\n")).toContain("DOCS_SHORTLINK_PATHS yielded 0 entries");
+  });
+
+  it("fails when the redirects map yields zero entries", () => {
+    const result = checkControlUiDocsAffordances({
+      repoRoot: fixture("empty-redirects"),
+      ledger: [],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.counts.redirects).toBe(0);
+    expect(result.messages.join("\n")).toContain("redirects (docs/astro.config.mjs) yielded 0");
+  });
+
+  it("fails in inventory mode too, where findings are non-fatal", () => {
+    // Inventory mode reports dangling targets without failing on them. The
+    // zero-cardinality floor still has to bite: an inventory compiled by an
+    // instrument that read nothing is not a shorter inventory, it is a false one.
+    const result = checkControlUiDocsAffordances({
+      repoRoot: fixture("empty-vocabulary"),
+      ledger: [],
+      mode: "inventory",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("exits non-zero from the CLI on a zero-cardinality inventory, not just the API", () => {
+    // The assertion above passed while the shipped surface did the opposite: the
+    // `--inventory` branch printed its report and never consulted `result.ok`,
+    // so `process.exitCode` stayed 0. The function was right and the CLI was
+    // wrong, and a test that only reads the function cannot tell them apart —
+    // the #3138 shape one level up. So assert the exit code a caller observes.
+    const empty = runCli(["--inventory", "--repo-root", fixture("empty-vocabulary")]);
+    expect(empty.status).toBe(1);
+    expect(empty.stdout).toContain("DOCS_SHORTLINK_PATHS yielded 0 entries");
+
+    // Paired control: same mode, same flags, a fixture that reads a real
+    // vocabulary. Without this the assertion above is satisfied by a CLI that
+    // exits 1 unconditionally.
+    const healthy = runCli(["--inventory", "--repo-root", fixture("resolves")]);
+    expect(healthy.status).toBe(0);
+  });
+
+  it("exits non-zero from the CLI when a declaration is absent", () => {
+    const result = runCli(["--repo-root", fixture("absent-declaration")]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("DOCS_SHORTLINK_PATHS");
+  });
+
+  it("throws, rather than reporting clean, when the declaration is absent", () => {
+    expect(() =>
+      checkControlUiDocsAffordances({ repoRoot: fixture("absent-declaration"), ledger: [] }),
+    ).toThrow(/DOCS_SHORTLINK_PATHS = new Set\(\[/);
+  });
+});
+
+describe("check-control-ui-docs-affordances — resolution", () => {
+  it("resolves a slug through the redirects map", () => {
+    const redirects = new Map([["/control-ui", "/web/control-ui"]]);
+    expect(
+      resolveShortlink("/control-ui", { repoRoot: fixture("resolves"), redirects }).resolved,
+    ).toBe(true);
+  });
+
+  it("reports a redirect whose target has no page distinctly from an absent one", () => {
+    // Both 404 for the user, but they read differently in review and are owned by
+    // different issues, so the message has to tell them apart.
+    const redirects = new Map([["/mistral", "/providers/mistral"]]);
+    const hop = resolveShortlink("/mistral", { repoRoot: fixture("resolves"), redirects });
+    const bare = resolveShortlink("/mistral", {
+      repoRoot: fixture("resolves"),
+      redirects: new Map(),
+    });
+
+    expect(hop.reason).toContain('redirects to "/providers/mistral"');
+    expect(bare.reason).toContain("no page under docs/ and no redirect");
+  });
+
+  it("does not loop forever on a redirect cycle", () => {
+    const redirects = new Map([
+      ["/a", "/b"],
+      ["/b", "/a"],
+    ]);
+    const outcome = resolveShortlink("/a", { repoRoot: fixture("resolves"), redirects });
+
+    expect(outcome.resolved).toBe(false);
+    expect(outcome.reason).toContain("redirect cycle");
+  });
+
+  it("accepts a root segment that is a single page rather than a directory", () => {
+    // docs/ci.md and docs/date-time.md are real single-file sections. Checking
+    // only for a directory would flag them, which is the false-positive class
+    // that trains people to pad the ledger.
+    const redirects = new Map<string, string>();
+    expect(resolveRootSegment("web", { repoRoot: fixture("resolves"), redirects }).resolved).toBe(
+      true,
+    );
+    expect(
+      resolveRootSegment("clawhub", { repoRoot: fixture("resolves"), redirects }).resolved,
+    ).toBe(false);
+  });
+});
+
+describe("check-control-ui-docs-affordances — parsing", () => {
+  it("carries 1-based line numbers so ledger entries can be pinned", () => {
+    const source = ["// header", "const S = new Set([", '  "/one",', '  "/two",', "]);"].join("\n");
+
+    expect(extractSetEntries(source, "S", "f.ts")).toEqual([
+      { value: "/one", file: "f.ts", line: 3 },
+      { value: "/two", file: "f.ts", line: 4 },
+    ]);
+  });
+
+  it("parses redirect pairs and ignores prose around them", () => {
+    const source = [
+      "// a comment mentioning /control-ui",
+      "const redirects = {",
+      '  "/control-ui": "/web/control-ui",',
+      "};",
+    ].join("\n");
+
+    expect([...extractRedirects(source, "docs/astro.config.mjs")]).toEqual([
+      ["/control-ui", "/web/control-ui"],
+    ]);
+  });
+
+  it("throws when the redirects map is absent", () => {
+    expect(() => extractRedirects("export default {};", "docs/astro.config.mjs")).toThrow(
+      /const redirects = \{/,
+    );
+  });
+
+  it("finds a declaration the formatter has collapsed onto one line", () => {
+    // Not hypothetical: `pnpm format` collapsed `const redirects = {\n};` in the
+    // empty-redirects fixture, and the original literal `\n};` terminator then
+    // threw on a well-formed file. Both declarations are now found by counting
+    // delimiters, so neither depends on a formatting choice nothing guarantees.
+    expect(extractSetEntries('const S = new Set(["/one", "/two"]);', "S", "f.ts")).toEqual([
+      { value: "/one", file: "f.ts", line: 1 },
+      { value: "/two", file: "f.ts", line: 1 },
+    ]);
+    expect([...extractRedirects("const redirects = {};", "c.mjs")]).toEqual([]);
+  });
+
+  it("extracts redirect pairs line by line, so a collapsed map parses as empty", () => {
+    // Stated rather than implied, because it is the one place the collapsed-line
+    // guarantee above stops: finding the map no longer depends on formatting,
+    // but extracting its entries still does — the pair regex is line-anchored.
+    // Safe only because empty is the loudest possible outcome: the cardinality
+    // floor fails the run rather than letting every shortlink read as dangling.
+    expect([...extractRedirects('const redirects = { "/a": "/b" };', "c.mjs")]).toEqual([]);
+  });
+
+  it("does not end a declaration on a delimiter inside a quoted value", () => {
+    const source = ["const S = new Set([", '  "/a]b",', '  "/c",', "]);"].join("\n");
+
+    expect(extractSetEntries(source, "S", "f.ts").map((entry) => entry.value)).toEqual([
+      "/a]b",
+      "/c",
+    ]);
+  });
+
+  it("ignores comments inside a declaration, in all three ways they broke the scan", () => {
+    // A note inside these tables is an edit waiting to happen — #3180 and #3211
+    // drain the ledger by editing this exact table, and upstream sync re-applies
+    // it wholesale. Each line below broke the scanner differently, and only one
+    // of the three broke it loudly.
+    const source = [
+      "const S = new Set([",
+      '  "/keep",',
+      "  // a stray ] used to end the block here, dropping every entry below it",
+      "  // an apostrophe like it's used to open a quote that ate the terminator",
+      '  // and a slug quoted in prose ("/skill-workshop") became a phantom target',
+      '  "/kept-too",',
+      "]);",
+    ].join("\n");
+
+    expect(extractSetEntries(source, "S", "f.ts").map((entry) => entry.value)).toEqual([
+      "/keep",
+      "/kept-too",
+    ]);
+  });
+
+  it("keeps line numbers correct across a multi-line block comment", () => {
+    // Blanking a comment must preserve its newlines, or every ledger entry
+    // pinned below one silently points at the wrong line.
+    const source = [
+      "const S = new Set([",
+      '  "/a",',
+      "  /* note",
+      "     more */",
+      '  "/b",',
+      "]);",
+    ].join("\n");
+
+    expect(extractSetEntries(source, "S", "f.ts")).toEqual([
+      { value: "/a", file: "f.ts", line: 2 },
+      { value: "/b", file: "f.ts", line: 5 },
+    ]);
+  });
+
+  it("does not mistake the // inside a string value for a comment", () => {
+    expect(
+      extractSetEntries('const S = new Set(["https://docs.example/x", "/b"]);', "S", "f.ts").map(
+        (entry) => entry.value,
+      ),
+    ).toEqual(["https://docs.example/x", "/b"]);
+  });
+
+  it("ignores a comment inside the redirects map", () => {
+    const source = [
+      "const redirects = {",
+      '  // was "/gone": "/nowhere", dropped along with the } subsystem',
+      '  "/b": "/x/b",',
+      "};",
+    ].join("\n");
+
+    expect([...extractRedirects(source, "c.mjs")]).toEqual([["/b", "/x/b"]]);
+  });
+});
+
+describe("check-control-ui-docs-affordances — repository state", () => {
+  // The AC's second half: green against the real tree once #3156-#3159 merged.
+  // Asserting it here means a future PR that adds a dangling Control UI docs
+  // target fails `pnpm test` as well as the standalone gate job.
+  it("is green against the real repository", () => {
+    const result = checkControlUiDocsAffordances();
+
+    expect(result.messages).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports a non-zero scan of the real repository", () => {
+    const result = checkControlUiDocsAffordances();
+
+    expect(result.counts.shortlinks).toBeGreaterThan(0);
+    expect(result.counts.rootSegments).toBeGreaterThan(0);
+    expect(result.counts.redirects).toBeGreaterThan(0);
+  });
+
+  it("keeps every ledger entry pinned to a file, line, and tracking issue", () => {
+    for (const entry of KNOWN_DANGLING_UI_DOCS_TARGETS) {
+      expect(entry.file).toBeTruthy();
+      expect(Number.isInteger(entry.line)).toBe(true);
+      expect(entry.issue).toMatch(/^#\d+$/);
+    }
+  });
+
+  it("has no stale ledger entries — every exception still describes a real target", () => {
+    // The drain. A ledger entry whose target now resolves fails here, so the
+    // ledger cannot outlive its debt as #3180 and #3211 pay it down.
+    //
+    // Compared through the gate's own `compareToLedger` rather than a
+    // re-implemented key: a test that builds both sides of the comparison itself
+    // stays green when the real key format changes underneath it.
+    const { dangling } = checkControlUiDocsAffordances({ mode: "inventory" });
+
+    expect(compareToLedger(dangling).stale).toEqual([]);
+  });
+
+  it("fails in --strict mode on the ledgered entries, so a line can be proven removable", () => {
+    // The mode's whole contract, and nothing else asserted it: `--strict` exists
+    // to show that a ledger line is ready to go before its issue is closed, which
+    // is worth nothing if strict quietly honours the ledger like the default does.
+    const strict = checkControlUiDocsAffordances({ mode: "strict" });
+
+    expect(strict.ok).toBe(false);
+    expect(strict.messages).toHaveLength(KNOWN_DANGLING_UI_DOCS_TARGETS.length);
+  });
+});
+
+describe("check-control-ui-docs-affordances — CLI arguments", () => {
+  it("rejects a --repo-root with no usable value rather than scanning the real repo", () => {
+    // The silent-fallback shape `check-throwing-stub-callers.mjs` rejects by name
+    // in `parseRootsFlag`. It bites harder here: the real tree is green, so a
+    // mistyped flag would turn every fixture assertion above into a pass that
+    // proves nothing at all.
+    expect(parseArgs(["--repo-root"]).error).toMatch(/needs a value/);
+    expect(parseArgs(["--repo-root", "--strict"]).error).toMatch(/needs a value/);
+    expect(parseArgs(["--repo-root="]).error).toMatch(/needs a value/);
+
+    const bare = runCli(["--repo-root"]);
+    expect(bare.status).toBe(1);
+    expect(bare.stderr).toContain("needs a value");
+  });
+
+  it("accepts both --repo-root spellings and reads the mode alongside them", () => {
+    expect(parseArgs(["--repo-root", "fixtures/x"])).toEqual({
+      mode: "default",
+      repoRoot: "fixtures/x",
+    });
+    expect(parseArgs(["--inventory", "--repo-root=fixtures/x"])).toEqual({
+      mode: "inventory",
+      repoRoot: "fixtures/x",
+    });
+  });
+});


### PR DESCRIPTION
Closes #3160.

## Outcome up front

**The gate #3160 sketched is not buildable. This ships the strongest thing that is** — a
resolution gate covering the *links* third of the defect class — plus the measurements that
establish the broader shape has no signal to derive. #3160 pre-authorized this outcome in its
Risk section; the narrowing is evidence-backed, not a shortcut.

## Why the proposed shape does not work

#3160 suggested deriving a gutted-concept vocabulary from the fork's own gut markers and
flagging `ui/` affordances built on one. Measured against this tree:

| Mechanism | Measurement | Verdict |
|---|---|---|
| Symbol vocabulary from gut markers | 2 hits in `ui/`, **both false positives** (`AgentContext`, a type declared in `ui/` itself). Recall on all four siblings: **0** | not viable |
| Word vocabulary from marker prose | 39 words → **944 hits**, led by `export` (218), `state` (104), `index` (87), `test` (80), then the homographs #3160 predicted: `model` (51), `provider` (33) | not viable |
| Orphan UI module detection | **69 / 220** production files flagged, dominated by dynamically-registered Lit elements | not viable — the same mis-tuning that keeps knip out of CI |
| Orphan i18n key detection | **33 / 33** strict orphans are dynamic-composition false positives (`t(\`tabs.${id}\`)`) | not viable; #3208's surface anyway |

**Root cause — structural, not tuning.** `ui/` has no static edge to the gutted `src/`
subsystems. Its 48 `ui/ → src/` imports reach 34 distinct modules and **not one carries a
`Gutted in RemoteClaw fork` marker** — the Control UI talks to the gateway over RPC. A gut in
`src/` leaves nothing in `ui/` to derive from, which is precisely *why* five `gut(ui)` waves
each removed 0 lines of the Model Selection UI. Reproduction commands are in the script header.

An independent fresh-context validation re-measured this from scratch and came out *more*
damning (0 symbol hits, 0 recall), confirming the conclusion is not sensitive to extraction.

## What does hold

Resolution, not classification. Every docs target the Control UI hands a user is a concrete
path, and whether it resolves is a fact about the repo rather than a judgement about a word.

`control-ui-docs-affordance-gate` checks that the **147** `DOCS_SHORTLINK_PATHS` entries and
**37** `DOCS_ROOT_SEGMENTS` entries in `ui/src/components/markdown.ts` resolve to a real page
under `docs/`, directly or through the `redirects` map in `docs/astro.config.mjs` — the source
`markdown.ts` already names as authoritative. That is #3157's exact instance.

**The false-positive AC is satisfied by construction, not by tuning.** The gate reads link
targets and never concept words, so `resolveEmbedSandbox`, `ControlUiEmbedSandboxMode`,
`bg-elevated`, and the live `thinking` / `provider` identifiers are *outside its read set*
rather than allowlisted. The seeded-leak fixture makes this falsifiable: it carries those same
identifiers while its `/sandbox` **shortlink** fires.

## Both halves of the non-negotiable constraint

**(a) Canary fixture.** `test/fixtures/.../seeded-leak/` restores `/models`, `/sandbox`,
`/skill-workshop` — three shortlinks **#3157 actually removed** — plus the `clawhub` root
segment. A committed test requires the gate to fail on it, paired with a leak-free control
fixture so the failure is attributable to the seed. It runs in the `test` lane (verified by
vitest collection, not by force-run), which is in the `CI` rollup.

**(b) Cardinality report.** The gate prints how many shortlinks, root segments and redirects it
read, and fails when any is zero — **in every mode**, per #3138. This is the strengthening
#3160's review comment asked for by name: a seeded leak catches a broken *matcher* but never an
empty *vocabulary*. A missing declaration throws rather than reporting clean.

**Mutation-verified** (a green canary that cannot go red is not a canary):

| Mutation | Result |
|---|---|
| Resolver stubbed to always resolve | 5 canary tests **red** |
| Derivation emptied | gate **exit 1**, naming both empty tables |
| Cardinality floor removed from `--inventory` | its CLI test **red** |
| Comment-tracking removed from the parser | 2 tests **red** |

## Ledger

47 targets do not resolve today, each pinned to `file:line` with a justification and tracking
issue, draining via STALE: **38 → #3180**, **9 → #3211** (filed here for the residue #3180 does
not name — 3 shortlinks that 404 one redirect hop later, and 6 root segments including
`clawhub` and `openclaw-agent-runtime`, the latter an `openclaw` leak `rebrand-gate`
structurally cannot see because it is changed-files-only).

~62% of the ledger is squarely gutted-subsystem (11 model-provider slugs, 6 Pi-era, 3
skills-marketplace, 8 `/templates/*`), which is what makes this a real detector for the class
rather than a generic link linter. The header is explicit that a few (`/cron`, `/mcp`,
`/opencode`) name live subsystems whose page is merely absent.

## Verification

```
node scripts/check-control-ui-docs-affordances.mjs
  → 147 shortlink(s) + 37 root segment(s) checked against 140 redirect(s);
    all resolve (47 reviewed exception(s))                              exit 0
--strict                                                                exit 1  (ledger is real, not padding)
pnpm check                                                              exit 0
test/scripts (16 files)                                             222 passed
all 10 standalone fork-integrity gates                                  exit 0
actionlint 1.7.11 on ci.yml                          clean (canary confirms it detects)
CI rollup needs: ↔ result-check condition                          19 / 19 parity
```

## Scope discipline

Zero changes under `ui/`, `docs/`, locale bundles, or `.css`. No #3180 / #3208 / #3209
remediation absorbed — the dangling targets are *ledgered*, not fixed.

## Ratification-pending judgment calls

Per the batch question policy, recorded rather than blocked on:

1. **Gate is narrower than the issue's title implies.** Covers links only; it does **not**
   detect #3156's rendered affordance or #3158's orphan strings, and both the script header and
   CLAUDE.md say so explicitly. If a broader gate is still wanted, the measurements above are
   the evidence base for what it would have to overcome.
2. **47-entry birth ledger.** #3160 warned against "a large birth-allowlist that reads as
   coverage while gating nothing." Judged to be the ratified `scripts-typecheck-gate` shape
   (baseline + fail-on-new + STALE drain) rather than that anti-pattern: 137 of 184 targets are
   actively enforced, every future addition is gated, and both owning issues are open. Reject
   this reading and the alternative is landing red or absorbing #3180.
3. **Filed #3211** rather than fixing its 9 entries here — #3157 deliberately audited
   `DOCS_ROOT_SEGMENTS` and left it unmodified ("the verb is 'audited'"), and dropping a segment
   changes link-rewriting for every path beneath it.
4. **Standalone job, not inside `pnpm check`** — fork-lifecycle gate, sync-carried input, spans
   `ui/` ↔ `docs/`. Also runnable locally as `pnpm lint:ui:no-dangling-docs-affordances`.
5. **Did NOT wire `control-ui-i18n.ts check`.** The batch evidence called this "largely wiring";
   that premise is false. It fails on a clean tree *before* reaching its key-set assertion —
   `en.ts`'s `languages` block names 5 of the 18 expected locales — so it is blocked behind
   #3208, not wiring-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
